### PR TITLE
fix: update GHO GitHub URLs and add missing contracts

### DIFF
--- a/src/lib/stablecoins.ts
+++ b/src/lib/stablecoins.ts
@@ -697,6 +697,8 @@ export const TRACKED_STABLECOINS: StablecoinMeta[] = [
       { chain: "gnosis", address: "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73", decimals: 18 },
       { chain: "ink", address: "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73", decimals: 18 },
       { chain: "avalanche", address: "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73", decimals: 18 },
+      { chain: "mantle", address: "0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73", decimals: 18 },
+      { chain: "ink", address: "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73", decimals: 18 },
     ],
     proofOfReserves: { type: "independent-audit", url: "https://github.com/aave-dao/gho-origin/tree/main/audits", provider: "OpenZeppelin, ABDK, Sigma Prime, Certora" },
     reserves: [


### PR DESCRIPTION
## Summary
- Update GHO GitHub links from `aave/gho-core` (deprecated) to `aave-dao/gho-origin`
- Update proof-of-reserves audit URL accordingly
- Add additional GHO contract deployments (Mantle, Ink)
