### PR TITLE
[codex] Renumber methodology versions

### DIFF
--- a/docs/depeg-dews-timeline.md
+++ b/docs/depeg-dews-timeline.md
@@ -1,10 +1,10 @@
 # Depeg Tracker + DEWS Methodology — Version Timeline
 
-Internal changelog reconstructed from git history. Covers `v1.0` through `v4.10` (2026-02-18 -> 2026-03-28).
+Internal changelog reconstructed from git history. Covers `v1.0` through `v5.0` (2026-02-18 -> 2026-03-28).
 
 ---
 
-## v4.10 — DEWS blacklist coverage parity and thin-peg FX fallback parity (Mar 28, 2026)
+## v5.0 — DEWS blacklist coverage parity and thin-peg FX fallback parity (Mar 28, 2026)
 
 **Commit:** `unreleased`
 

--- a/docs/dews.md
+++ b/docs/dews.md
@@ -6,7 +6,7 @@ Per-coin, forward-looking stress score (0-100) estimating depeg probability. Com
 
 DEWS shares its methodology versioning with the Depeg Tracker pipeline. Both are tracked together in `shared/lib/depeg-dews-version.ts`.
 
-- **Current methodology version:** `v4.10`
+- **Current methodology version:** `v5.0`
 - **Public changelog page:** `/methodology/depeg-changelog/`
 - **Canonical source:** `shared/lib/depeg-dews-version.ts`
 
@@ -184,12 +184,12 @@ When a coin has insufficient data in a cycle (`computeDEWS() === null`), that ru
 ```json
 {
   "signals": {
-    "usdt-tether": { "score": 5, "band": "CALM", "signals": { ... }, "computedAt": 1740000000, "methodologyVersion": "4.10" },
+    "usdt-tether": { "score": 5, "band": "CALM", "signals": { ... }, "computedAt": 1740000000, "methodologyVersion": "5.0" },
     ...
   },
   "updatedAt": 1740000000,
   "malformedRows": 0,
-  "methodology": { "version": "4.10", "versionLabel": "...", "currentVersion": "4.10", "currentVersionLabel": "...", "changelogPath": "/methodology/depeg-changelog/", "asOf": 1740000000 }
+  "methodology": { "version": "5.0", "versionLabel": "...", "currentVersion": "5.0", "currentVersionLabel": "...", "changelogPath": "/methodology/depeg-changelog/", "asOf": 1740000000 }
 }
 ```
 
@@ -199,13 +199,13 @@ Unknown IDs and tracked-but-non-active IDs both return `404` (`Stablecoin not tr
 
 ```json
 {
-  "current": { "score": 5, "band": "CALM", "signals": { ... }, "computedAt": 1740000000, "methodologyVersion": "4.10" },
+  "current": { "score": 5, "band": "CALM", "signals": { ... }, "computedAt": 1740000000, "methodologyVersion": "5.0" },
   "history": [
-    { "date": 1739900000, "score": 3, "band": "CALM", "signals": { ... }, "methodologyVersion": "4.10" },
+    { "date": 1739900000, "score": 3, "band": "CALM", "signals": { ... }, "methodologyVersion": "5.0" },
     ...
   ],
   "malformedRows": 0,
-  "methodology": { "version": "4.10", "versionLabel": "...", "currentVersion": "4.10", "currentVersionLabel": "...", "changelogPath": "/methodology/depeg-changelog/", "asOf": 1740000000 }
+  "methodology": { "version": "5.0", "versionLabel": "...", "currentVersion": "5.0", "currentVersionLabel": "...", "changelogPath": "/methodology/depeg-changelog/", "asOf": 1740000000 }
 }
 ```
 

--- a/docs/pricing-pipeline-timeline.md
+++ b/docs/pricing-pipeline-timeline.md
@@ -1,10 +1,10 @@
 # Pricing Pipeline Methodology - Version Timeline
 
-Internal changelog reconstructed from the machine-readable methodology version source. Covers Pricing Pipeline `v1.0` through `v2.19` (2026-02-01 -> 2026-03-30).
+Internal changelog reconstructed from the machine-readable methodology version source. Covers Pricing Pipeline `v1.0` through `v3.9` (2026-02-01 -> 2026-03-30).
 
 ---
 
-## v2.19 - Explicit source semantics, cluster-median publication, and fallback identity hardening (Mar 30, 2026)
+## v3.9 - Explicit source semantics, cluster-median publication, and fallback identity hardening (Mar 30, 2026)
 
 **Commit:** `unreleased`
 
@@ -19,7 +19,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.18 - Validated DefiLlama fallback admission and exact-target DexScreener gating (Mar 30, 2026)
+## v3.8 - Validated DefiLlama fallback admission and exact-target DexScreener gating (Mar 30, 2026)
 
 **Commit:** `unreleased`
 
@@ -30,7 +30,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.17 - Protocol-aware DEX hardening estimators and provider-config cleanup (Mar 24, 2026)
+## v3.7 - Protocol-aware DEX hardening estimators and provider-config cleanup (Mar 24, 2026)
 
 **Commit:** `unreleased`
 
@@ -42,7 +42,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.16 - Explicit source freshness provenance for live prices (Mar 24, 2026)
+## v3.6 - Explicit source freshness provenance for live prices (Mar 24, 2026)
 
 **Commit:** `unreleased`
 
@@ -54,7 +54,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.15 - Independent FX recovery during cached fallback (Mar 23, 2026)
+## v3.5 - Independent FX recovery during cached fallback (Mar 23, 2026)
 
 **Commit:** `unreleased`
 
@@ -65,7 +65,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.14 - Replay-safe trusted-price continuity for confirmed depegs (Mar 23, 2026)
+## v3.4 - Replay-safe trusted-price continuity for confirmed depegs (Mar 23, 2026)
 
 **Commit:** `unreleased`
 
@@ -76,7 +76,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.13 - Source-aware trust, observed-time freshness, and weak-price jump quarantine (Mar 22, 2026)
+## v3.3 - Source-aware trust, observed-time freshness, and weak-price jump quarantine (Mar 22, 2026)
 
 **Commit:** `unreleased`
 
@@ -92,7 +92,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.12 - Identity-safe enrichment, severe-downside publication guards, and replay-safe DEX quote derivation (Mar 22, 2026)
+## v3.2 - Identity-safe enrichment, severe-downside publication guards, and replay-safe DEX quote derivation (Mar 22, 2026)
 
 **Commit:** `unreleased`
 
@@ -108,7 +108,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.11 - Canonical DEX token identity and non-overlapping DEX consensus (Mar 22, 2026)
+## v3.1 - Canonical DEX token identity and non-overlapping DEX consensus (Mar 22, 2026)
 
 **Commit:** `unreleased`
 
@@ -120,7 +120,7 @@ Internal changelog reconstructed from the machine-readable methodology version s
 
 ---
 
-## v2.10 - Cadence-valid FX carry-forward semantics (Mar 20, 2026)
+## v3.0 - Cadence-valid FX carry-forward semantics (Mar 20, 2026)
 
 **Commit:** `unreleased`
 

--- a/docs/pricing-pipeline.md
+++ b/docs/pricing-pipeline.md
@@ -21,7 +21,7 @@ When an asset still has no usable current price after validation and fallback re
 
 ## Versioning
 
-- **Current methodology version:** `v2.19`
+- **Current methodology version:** `v3.9`
 - **Canonical version module:** `shared/lib/pricing-pipeline-version.ts`
 - **Public changelog route:** `/methodology/pricing-pipeline-changelog/`
 - **Longform methodology section:** `/methodology/#pricing-pipeline-methodology`

--- a/docs/redemption-backstops.md
+++ b/docs/redemption-backstops.md
@@ -6,7 +6,7 @@ Modeled redemption-route coverage for tracked stablecoins. This subsystem estima
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v1.21`
+- **Current methodology version:** `v3.1`
 - **Public methodology anchor:** `/methodology/#safety-scores-methodology`
 - **Canonical source files:** `shared/lib/redemption-backstops.ts`, `shared/lib/redemption-backstop-configs/*`, `shared/lib/redemption-backstop-scoring.ts`, `shared/lib/redemption-backstop-version.ts`
 

--- a/docs/report-cards-timeline.md
+++ b/docs/report-cards-timeline.md
@@ -1,6 +1,6 @@
 # Report Cards Scoring — Version Timeline
 
-Internal changelog reconstructed from git history plus the live version metadata source. Covers v1.0 through v7.0 (2026-02-25 → 2026-03-30).
+Internal changelog reconstructed from git history plus the live version metadata source. Covers v1.0 through v6.91 (2026-02-25 → 2026-03-30).
 
 ---
 
@@ -303,7 +303,7 @@ Weights and grade thresholds are unchanged from v5.8.
 - Wrapper governance exempted from chain infrastructure penalty
 - Deployment multipliers: canonical-bridge 0.85→0.90, native-multichain 0.40→0.75
 
-## v7.0 — Reserve-side blacklist exposure heuristics (2026-03-30)
+## v6.91 — Reserve-side blacklist exposure heuristics (2026-03-30)
 
 Safety Score structure is unchanged, but blacklistability attribution now scans curated and live reserve labels plus reserve-rail text for stablecoin, wrapper, and CEX custody clues:
 
@@ -418,7 +418,7 @@ Weights and grade thresholds are unchanged from v6.0.
 | v4.0        | multiplier | 25%            | —       | 25%        | 10%              | 30%      |
 | v4.1        | multiplier | 30%            | —       | 20%        | 15%              | 25%      |
 | v5.0–5.8    | multiplier | 30%            | —       | 20%        | 15%              | 25%      |
-| **v6.0–7.0** | **multiplier** | **30%**  | **—**   | **20%**    | **15%**          | **25%**  |
+| **v6.0–6.91** | **multiplier** | **30%**  | **—**   | **20%**    | **15%**          | **25%**  |
 
 ## Quick Reference: Grade Thresholds
 

--- a/docs/report-cards.md
+++ b/docs/report-cards.md
@@ -2,7 +2,7 @@
 
 Multi-dimensional risk grades (A+ through F) for every tracked stablecoin. Computed on-demand by the API from live data.
 
-## Overall Grade (v7.0)
+## Overall Grade (v6.91)
 
 Three-step computation:
 
@@ -12,7 +12,7 @@ Three-step computation:
 
 Cemetery coins get a permanent F.
 
-Current-version note: v7.0 keeps the v6.4 structure. LUSD and BOLD still use documented-bound eventual redemption capacity, and when fresh live reserve telemetry exists their current on-chain redemption fee bps is used for cost scoring instead of a flat formula placeholder. Collateral-quality passthrough now only accepts fresh authoritative independent live reserve snapshots whose latest sync state is `ok` and whose freshness evidence is scoring-eligible; `validated-static`, `weak-live-probe`, and `unverified` reserve feeds remain visible on reserve detail surfaces but no longer override curated collateral scoring. Blacklist attribution now distinguishes mutable-contract risk (`Possible`) from majority upstream freeze exposure (`Inherited`), treats reserve-side stablecoin and custody/CEX clues as `Possible` instead of `No`, and no longer treats `centralized-dependent` governance as sufficient evidence on its own.
+Current-version note: v6.91 keeps the v6.4 structure. LUSD and BOLD still use documented-bound eventual redemption capacity, and when fresh live reserve telemetry exists their current on-chain redemption fee bps is used for cost scoring instead of a flat formula placeholder. Collateral-quality passthrough now only accepts fresh authoritative independent live reserve snapshots whose latest sync state is `ok` and whose freshness evidence is scoring-eligible; `validated-static`, `weak-live-probe`, and `unverified` reserve feeds remain visible on reserve detail surfaces but no longer override curated collateral scoring. Blacklist attribution now distinguishes mutable-contract risk (`Possible`) from majority upstream freeze exposure (`Inherited`), treats reserve-side stablecoin and custody/CEX clues as `Possible` instead of `No`, and no longer treats `centralized-dependent` governance as sufficient evidence on its own.
 
 ## Dimensions
 

--- a/docs/yield-intelligence-timeline.md
+++ b/docs/yield-intelligence-timeline.md
@@ -1,17 +1,17 @@
 # Yield Intelligence Methodology - Version Timeline
 
-Internal changelog reconstructed from git history. Covers Yield Intelligence `v1.0` through `v5.17` (2026-03-01 -> 2026-03-28).
+Internal changelog reconstructed from git history. Covers Yield Intelligence `v1.0` through `v6.9` (2026-03-01 -> 2026-03-28).
 
 ---
 
-## v5.17 - K3 sBOLD added as a distinct native BOLD yield source (Mar 28, 2026)
+## v6.9 - K3 sBOLD added as a distinct native BOLD yield source (Mar 28, 2026)
 
 - The supplemental Yearn/Kong feed now recognizes Ethereum `Staked yBOLD` and pins it directly to `bold-liquity`
 - The source publishes as `K3: sBOLD`, giving BOLD a second native wrapper path alongside the base `yBOLD` route
 - `sBOLD` is classified as native `lending-vault` yield because it is another wrapper around the Liquity Stability Pool stack, not a governance-set rate or generic lending opportunity
 - Yield-source links now deep-link this row to Liquity's dedicated `https://liquity.app/earn/sbold` route
 
-## v5.16 - Blocked USR-linked lending suggestions (Mar 28, 2026)
+## v6.8 - Blocked USR-linked lending suggestions (Mar 28, 2026)
 
 - Published `lending-opportunity` suggestions now exclude venues explicitly tied to Resolv / `USR`, `stUSR`, or `wstUSR`
 - Supplemental protocol-API sources such as `Morpho: Resolv USDC` are dropped before ranking publication instead of competing for the best-source slot
@@ -19,81 +19,81 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 - Wrapper-over-native venues such as BOLD / `yBOLD` are treated as native yield rather than governance-set when the wrapper only packages the protocol's own Stability Pool return
 - The filter is scoped to lending suggestions for base assets; native tracked yield assets keep their existing methodology coverage
 
-## v5.15 - Benchmark-aware PYS for cross-currency yield context (Mar 27, 2026)
+## v6.7 - Benchmark-aware PYS for cross-currency yield context (Mar 27, 2026)
 
 - PYS now forms an `effectiveYield` term equal to raw `apy30d` plus 25% of the row's benchmark spread before the safety penalty and consistency multiplier are applied
 - This keeps raw nominal APY as the anchor while giving above-benchmark EUR, CHF, and other non-USD rows explicit credit for clearing their local cash hurdle
 - Read-time `/api/yield-rankings` hydration, leaderboard/detail breakdowns, and methodology docs now use the same benchmark-aware scorer so shipped scores and explanations stay aligned
 - Strong local-rate rows such as EURCV and ZCHF no longer look artificially flat versus same-APY USD rows that clear a much easier benchmark
 
-## v5.14 - Supplemental freshness windows align with the 4-hour cache lane (Mar 27, 2026)
+## v6.6 - Supplemental freshness windows align with the 4-hour cache lane (Mar 27, 2026)
 
 - Read-time `data-stale` warnings now treat supplemental protocol-API rows and optional Aave/Compound rows as 4-hour-family data instead of hourly-family data
 - Supplemental-backed rows now wait 6 hours before going stale, which avoids false warnings during the normal final hour of the supplemental refresh cycle
 - Deterministic hourly on-chain rows keep the 3-hour hourly threshold, so only the slower supplemental families move
 - The methodology and operations docs now spell out the distinct stale windows for hourly, supplemental, and daily yield families
 
-## v5.13 - Optional RPC hardening and explicit wrapper venue pins (Mar 27, 2026)
+## v6.5 - Optional RPC hardening and explicit wrapper venue pins (Mar 27, 2026)
 
 - Compound V3 now probes both configured RPC endpoints instead of only the fallback URL, and Aave V3 plus Compound V3 rotate endpoint order across targets with a slightly deeper retry budget on the supplemental lane
 - `sync-yield-supplemental` metadata now records optional RPC family target counts, attempted counts, resolved target counts, emitted row counts, missing target counts, miss reasons, and per-chain miss breakdowns
 - Layer 2 wrapper matching can now pin a preferred DeFiLlama project in addition to chain and address, keeping shared wrapper tokens fail-closed without attaching to the wrong venue
 - Under-specified wrapper configs now carry explicit live chain/address/project pins for native venues such as `sUSDai`, `sNUSD`, `savUSD`, `sUSDu`, `syzUSD`, `sAID`, `stCUSD`, and `sGHO`
 
-## v5.12 - Protocol-native lending readers no longer outrank stronger native wrapper yields (Mar 27, 2026)
+## v6.4 - Protocol-native lending readers no longer outrank stronger native wrapper yields (Mar 27, 2026)
 
 - Supplemental lending-market readers such as Aave V3 are now classified as curated protocol-native sources instead of Tier 1 deterministic wrapper sources
 - Native wrapper yields such as sDAI no longer lose the primary row to a lower-yield supplemental lending market purely because the supplemental reader queried on-chain state directly
 - Source keys and alternative-source history stay unchanged, so the fix changes arbitration precedence without breaking source continuity
 
-## v5.11 - Restored mixed-view scatter benchmark frame (Mar 27, 2026)
+## v6.3 - Restored mixed-view scatter benchmark frame (Mar 27, 2026)
 
 - The `/yield` scatter plot now restores its horizontal benchmark line and four shaded quadrants on mixed-benchmark scopes instead of dropping them entirely
 - Mixed scopes use the default USD benchmark as the shared visual frame, so the chart stays readable even when rows carry local EUR or CHF hurdles
 - Mixed-view copy now makes the distinction explicit: the background frame is for orientation, while each row's benchmark tag still controls excess-yield interpretation
 
-## v5.10 - Source-cadence-aware freshness warnings (Mar 26, 2026)
+## v6.2 - Source-cadence-aware freshness warnings (Mar 26, 2026)
 
 - Read-time `data-stale` warnings now respect source cadence instead of forcing daily price-derived rows through the hourly publish threshold
 - `price-derived` rows now wait 36 hours before going stale because they are backed by daily `supply_history` snapshots
 - Hourly publication families still mark stale after three missed `sync-yield-data` intervals
 - Healthy daily snapshot rows such as USTB, USDA, and CETES no longer surface false stale warnings after roughly one day of normal operation
 
-## v5.9 - 3M risk-free benchmarks for EUR and CHF (Mar 26, 2026)
+## v6.1 - 3M risk-free benchmarks for EUR and CHF (Mar 26, 2026)
 
 - EUR pegs now benchmark against the ECB's official 3-month compounded €STR series rather than the overnight €STR feed
 - CHF pegs now benchmark against delayed public `SAR3MC` from SIX rather than an SNB policy-rate proxy
 - CHF benchmark rows are no longer marked as proxies, and mixed-benchmark UI copy now names the 3-month compounded EUR/CHF cash hurdles directly
 - The worker now fetches delayed SARON compound-rate files through SIX's guest OAuth plus report-download flow, and the docs/about-page source inventory reflect that pipeline
 
-## v5.8 - Asset-scoped supplemental identity and actionable coverage audits (Mar 26, 2026)
+## v6.0 - Asset-scoped supplemental identity and actionable coverage audits (Mar 26, 2026)
 
 - Aave V3 supplemental rows now use asset-scoped source keys instead of collapsing all same-chain markets into one cached row
 - `sync-yield-supplemental` metadata now reports raw candidate count, deduped candidate count, and dropped-row count so silent row loss is visible in cron history
 - The monthly yield coverage audit now counts explicit auto-discovery overrides and curated exact-pool overrides as covered DL surfaces
 - High-TVL gap reporting now focuses on unsupported protocol families instead of flooding the audit with already-allowlisted markets
 
-## v5.7 - Cadence-aligned data-stale warnings (Mar 26, 2026)
+## v5.9 - Cadence-aligned data-stale warnings (Mar 26, 2026)
 
 - The read-time `data-stale` warning now keys off three `sync-yield-data` intervals instead of a leftover fixed `90 min` threshold from the old half-hourly lane
 - At the current hourly publisher cadence, that means detail-surface stale warnings wait about 3 hours before firing
 - The hourly-source threshold is derived from shared cron metadata, so future schedule changes stay aligned without another manual constant update
 
-## v5.6 - First-party EUR benchmarks and resilient CHF parsing (Mar 26, 2026)
+## v5.8 - First-party EUR benchmarks and resilient CHF parsing (Mar 26, 2026)
 
 - EUR benchmark refreshes now query the ECB's official €STR feed first and only fall back to the FRED mirror when the first-party source is unavailable
 - CHF benchmark parsing now normalizes the SNB current-rates page to text before extracting the policy-rate sentence, so harmless markup changes no longer null out the proxy rate
 - Benchmark degradation metadata now reports explicit EUR and CHF failure modes instead of collapsing first-run outages into a generic `unavailable` bucket
 - The methodology docs, API examples, and about-page source inventory now reflect the ECB Data API and the hardened SNB parser
 
-## v5.5 - Safety-reweighted PYS curve and shared scoring hydration (Mar 26, 2026)
+## v5.7 - Safety-reweighted PYS curve and shared scoring hydration (Mar 26, 2026)
 
 - PYS now divides APY by `riskPenalty ^ 1.75` instead of a linear safety divisor, making weak safety grades earn their place with much larger yield spreads
 - The global PYS scaling factor was retuned from `5` to `8` so score distribution stays readable after the steeper safety curve
 - Live `/api/yield-rankings` hydration now reuses the shared PYS scorer instead of maintaining a duplicated read-time formula
 - Leaderboard and detail breakdown copy now references the adjusted risk penalty explicitly, and the methodology docs / changelog reflect the new formula
 
-## v5.4 - Currency-aware benchmarks for excess yield (Mar 26, 2026)
+## v5.6 - Currency-aware benchmarks for excess yield (Mar 26, 2026)
 
 - Benchmark selection is now row-level: USD pegs use the USD 3M Treasury benchmark, EUR pegs use €STR when available, and CHF pegs use an SNB policy-rate proxy
 - `/api/yield-rankings` now carries row-level benchmark labels, rates, and fallback-selection metadata so `excessYield` stays interpretable on mixed-currency views
@@ -101,13 +101,13 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 - The `/yield` scatter plot now suppresses the single benchmark line on mixed-benchmark scopes and restores it only when the visible filter shares one benchmark
 - CHF support intentionally uses the public SNB policy rate proxy rather than the SNB-published SARON display, whose use is restricted
 
-## v5.3 - Non-USD yield scoping and exact-pool commodity overrides (Mar 26, 2026)
+## v5.5 - Non-USD yield scoping and exact-pool commodity overrides (Mar 26, 2026)
 
 - `/yield` now exposes a shareable peg scope with a `non-usd` preset so the live EUR, CHF, SGD, MXN, and commodity rows can be reviewed as one universe
 - Tier-2 DeFiLlama ingestion now preserves exact curated non-stablecoin pool UUIDs alongside native pool IDs and wrapper-symbol matches
 - Added an exact-pool override lane for assets like `xaut-tether`, while keeping the generic gold/silver auto-discovery exclusion in place so mixed baskets such as Multipli `RWAUSDI` do not get misclassified as single-asset commodity yield sources
 
-## v5.2 - Address-First Identity and Explicit Coverage Truth (Mar 26, 2026)
+## v5.4 - Address-First Identity and Explicit Coverage Truth (Mar 26, 2026)
 
 - DeFiLlama discovery, variant matching, and protocol-native adapters now resolve by chain and address before symbol fallback and drop ambiguous candidates instead of guessing
 - Protocol-native source keys now use full chain-aware identifiers, and source-link resolution understands prefixed labels such as `Morpho: ...`, `Pendle: ...`, `Yearn: ...`, `Kong: ...`, `Beefy: ...`, and chain-qualified labels such as `Aave v3 (base)`
@@ -115,7 +115,7 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 - Warning divergence checks and published `medianApy` now share the same TVL-weighted 30d median benchmark
 - `/api/yield-history` is now bounded to the latest published `/api/yield-rankings` snapshot so history cannot advance past an unpublished cache state
 
-## v5.1 - Yield Infrastructure Automation (Mar 26, 2026)
+## v5.3 - Yield Infrastructure Automation (Mar 26, 2026)
 
 - Chain-scoped Layer 3 symbol matching prevents cross-chain false positives in auto-lending discovery
 - Variant symbol auto-scanner detects new wrapper tokens (sXXX/stXXX/wXXX prefix and SAVE/VAULT/EARN/STAKE suffix patterns) in advisory mode
@@ -124,7 +124,7 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 
 ---
 
-## v5.0 - Yield Coverage Expansion — Protocol-Native API Wave (Mar 25, 2026)
+## v5.2 - Yield Coverage Expansion — Protocol-Native API Wave (Mar 25, 2026)
 
 - 10 protocol-native adapters added: Hashnote USYC, Ondo oracle, Morpho GraphQL, Pendle REST, Yearn Kong GraphQL, Beefy REST, Aave V3 on-chain, Compound V3 on-chain, BIMA Earn
 - USTB + thBILL promoted to on-chain ERC-4626 exchange rate reads (previously T-bill proxy only)
@@ -135,7 +135,7 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 
 ---
 
-## v4.11 - Protocol-native BIMA savings fallback for USBD (Mar 24, 2026)
+## v5.1 - Protocol-native BIMA savings fallback for USBD (Mar 24, 2026)
 
 **Commit:** `unreleased`
 
@@ -143,7 +143,7 @@ Internal changelog reconstructed from git history. Covers Yield Intelligence `v1
 - Protocol-owned earn APIs are now treated as curated yield sources in the arbitration layer
 - The source-link registry and public about-page data-source copy now include BIMA's earn surface
 
-## v4.10 - Richer freshness provenance and curated lending source links (Mar 24, 2026)
+## v5.0 - Richer freshness provenance and curated lending source links (Mar 24, 2026)
 
 **Commit:** `unreleased`
 

--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -6,7 +6,7 @@ Risk-adjusted yield tracking and ranking for yield-bearing stablecoins and curat
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v5.17`
+- **Current methodology version:** `v6.9`
 - **Public changelog page:** `/methodology/yield-changelog/`
 - **Canonical source:** `shared/lib/yield-methodology-version.ts`
 

--- a/shared/lib/depeg-dews-version.ts
+++ b/shared/lib/depeg-dews-version.ts
@@ -1,11 +1,11 @@
 import { createMethodologyVersion } from "./methodology-version";
 
 const depegDews = createMethodologyVersion({
-  currentVersion: "4.10",
+  currentVersion: "5.0",
   changelogPath: "/methodology/depeg-changelog/",
   changelog: [
   {
-    version: "4.10",
+    version: "5.0",
     title: "DEWS blacklist coverage parity and thin-peg FX fallback parity",
     date: "2026-03-28",
     effectiveAt: 1774656000,

--- a/shared/lib/pricing-pipeline-version.ts
+++ b/shared/lib/pricing-pipeline-version.ts
@@ -3,11 +3,11 @@ import {
 } from "./methodology-version";
 
 const pricing = createMethodologyVersion({
-  currentVersion: "2.19",
+  currentVersion: "3.9",
   changelogPath: "/methodology/pricing-pipeline-changelog/",
   changelog: [
     {
-      version: "2.19",
+      version: "3.9",
       title: "Explicit source semantics, cluster-median publication, and fallback identity hardening",
       date: "2026-03-30",
       effectiveAt: 1774832400,
@@ -28,7 +28,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.18",
+      version: "3.8",
       title: "Validated DefiLlama fallback admission and exact-target DexScreener gating",
       date: "2026-03-30",
       effectiveAt: 1774828800,
@@ -45,7 +45,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.17",
+      version: "3.7",
       title: "Protocol-aware DEX hardening estimators and provider-config cleanup",
       date: "2026-03-24",
       effectiveAt: 1774353600,
@@ -62,7 +62,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.16",
+      version: "3.6",
       title: "Explicit source freshness provenance for live prices",
       date: "2026-03-24",
       effectiveAt: 1774350000,
@@ -79,7 +79,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.15",
+      version: "3.5",
       title: "Independent FX recovery during cached fallback",
       date: "2026-03-23",
       effectiveAt: 1774279800,
@@ -96,7 +96,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.14",
+      version: "3.4",
       title: "Replay-safe trusted-price continuity for confirmed depegs",
       date: "2026-03-23",
       effectiveAt: 1774267200,
@@ -113,7 +113,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.13",
+      version: "3.3",
       title: "Source-aware trust, observed-time freshness, and weak-price jump quarantine",
       date: "2026-03-22",
       effectiveAt: 1774230000,
@@ -135,7 +135,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.12",
+      version: "3.2",
       title: "Identity-safe enrichment, severe-downside publication guards, and replay-safe DEX quote derivation",
       date: "2026-03-22",
       effectiveAt: 1774195200,
@@ -158,7 +158,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.11",
+      version: "3.1",
       title: "Canonical DEX token identity and non-overlapping DEX consensus",
       date: "2026-03-22",
       effectiveAt: 1774180800,
@@ -176,7 +176,7 @@ const pricing = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "2.10",
+      version: "3.0",
       title: "Cadence-valid FX carry-forward semantics",
       date: "2026-03-20",
       effectiveAt: 1774014900,

--- a/shared/lib/redemption-backstop-version.ts
+++ b/shared/lib/redemption-backstop-version.ts
@@ -1,11 +1,11 @@
-import { createMethodologyVersion } from "./methodology-version";
+import { createMethodologyVersion, toMethodologyVersionLabel } from "./methodology-version";
 
 const redemptionBackstop = createMethodologyVersion({
-  currentVersion: "1.21",
+  currentVersion: "3.1",
   changelogPath: "/methodology/#safety-scores-methodology",
   changelog: [
     {
-      version: "1.21",
+      version: "3.1",
       title: "Live-capacity truth-boundary hardening and registry cleanup",
       date: "2026-03-30",
       effectiveAt: 1774821600,
@@ -20,7 +20,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.20",
+      version: "3.0",
       title: "Issuer and route-review medium-confidence tranche",
       date: "2026-03-24",
       effectiveAt: 1774368000,
@@ -35,7 +35,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.19",
+      version: "2.9",
       title: "Semantics correction for non-deterministic HOLLAR exit",
       date: "2026-03-24",
       effectiveAt: 1774364400,
@@ -50,7 +50,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.18",
+      version: "2.8",
       title: "Second medium-confidence redemption cleanup tranche",
       date: "2026-03-24",
       effectiveAt: 1774360800,
@@ -65,7 +65,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.17",
+      version: "2.7",
       title: "Buffer-backed medium-confidence redemption tranche",
       date: "2026-03-24",
       effectiveAt: 1774353600,
@@ -80,7 +80,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.16",
+      version: "2.6",
       title: "Moderate-effort redemption confidence tranche",
       date: "2026-03-23",
       effectiveAt: 1774314000,
@@ -95,7 +95,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.15",
+      version: "2.5",
       title: "Reviewed docs-backed quick-win redemption tranche",
       date: "2026-03-23",
       effectiveAt: 1774306800,
@@ -110,7 +110,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.14",
+      version: "2.4",
       title: "Maple syrup withdrawal route correction",
       date: "2026-03-23",
       effectiveAt: 1774303200,
@@ -125,7 +125,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.13",
+      version: "2.3",
       title: "Reviewed lower-cap redemption cleanup tranche",
       date: "2026-03-23",
       effectiveAt: 1774296000,
@@ -140,7 +140,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.12",
+      version: "2.2",
       title: "Live-buffer routes for Ethena and Falcon synthetics",
       date: "2026-03-23",
       effectiveAt: 1774292400,
@@ -155,7 +155,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.11",
+      version: "2.1",
       title: "Mid-cap route correction and review tranche",
       date: "2026-03-23",
       effectiveAt: 1774288800,
@@ -170,7 +170,7 @@ const redemptionBackstop = createMethodologyVersion({
       reconstructed: false,
     },
     {
-      version: "1.10",
+      version: "2.0",
       title: "Third lower-cap redemption review tranche",
       date: "2026-03-23",
       effectiveAt: 1774285200,
@@ -348,3 +348,6 @@ export const REDEMPTION_BACKSTOP_METHODOLOGY_PATH = redemptionBackstop.changelog
 
 /** Resolve Redemption Backstop methodology version active at a given Unix timestamp (seconds). */
 export const getRedemptionBackstopVersionAt = redemptionBackstop.getVersionAt;
+
+/** Display-ready label for a historical Redemption Backstop methodology version. */
+export const toRedemptionBackstopVersionLabel = toMethodologyVersionLabel;

--- a/shared/lib/safety-score-version-data.ts
+++ b/shared/lib/safety-score-version-data.ts
@@ -1,11 +1,11 @@
 import type { MethodologyVersionConfig } from "./methodology-version";
 
 export const SAFETY_SCORE_VERSION_CONFIG: MethodologyVersionConfig = {
-  currentVersion: "7.0",
+  currentVersion: "6.91",
   changelogPath: "/methodology/scoring-changelog/",
   changelog: [
     {
-      version: "7.0",
+      version: "6.91",
       title: "Reserve-side blacklist exposure heuristics",
       date: "2026-03-30",
       effectiveAt: 1774832400,

--- a/shared/lib/yield-methodology-version.ts
+++ b/shared/lib/yield-methodology-version.ts
@@ -3,11 +3,11 @@ import {
 } from "./methodology-version";
 
 const yieldMethodology = createMethodologyVersion({
-  currentVersion: "5.17",
+  currentVersion: "6.9",
   changelogPath: "/methodology/yield-changelog/",
   changelog: [
   {
-    version: "5.17",
+    version: "6.9",
     title: "K3 sBOLD Added As A Distinct Native BOLD Yield Source",
     date: "2026-03-28",
     effectiveAt: 1774692000,
@@ -23,7 +23,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.16",
+    version: "6.8",
     title: "Blocked USR-Linked Lending Suggestions",
     date: "2026-03-28",
     effectiveAt: 1774688400,
@@ -40,7 +40,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.15",
+    version: "6.7",
     title: "Benchmark-Aware PYS For Cross-Currency Yield Context",
     date: "2026-03-27",
     effectiveAt: 1774609200,
@@ -56,7 +56,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.14",
+    version: "6.6",
     title: "Supplemental Freshness Windows Match The 4-Hour Cache Lane",
     date: "2026-03-27",
     effectiveAt: 1774602000,
@@ -72,7 +72,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.13",
+    version: "6.5",
     title: "Optional RPC Hardening And Explicit Wrapper Venue Pins",
     date: "2026-03-27",
     effectiveAt: 1774600200,
@@ -88,7 +88,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.12",
+    version: "6.4",
     title: "Protocol-Native Lending Readers No Longer Outrank Stronger Native Wrapper Yields",
     date: "2026-03-27",
     effectiveAt: 1774587600,
@@ -104,7 +104,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.11",
+    version: "6.3",
     title: "Restored Mixed-View Scatter Benchmark Frame",
     date: "2026-03-27",
     effectiveAt: 1774576800,
@@ -120,7 +120,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.10",
+    version: "6.2",
     title: "Source-Cadence-Aware Freshness Warnings",
     date: "2026-03-26",
     effectiveAt: 1774818000,
@@ -136,7 +136,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.9",
+    version: "6.1",
     title: "3M Risk-Free Benchmarks For EUR And CHF",
     date: "2026-03-26",
     effectiveAt: 1774814400,
@@ -152,7 +152,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.8",
+    version: "6.0",
     title: "Asset-Scoped Supplemental Identity and Actionable Coverage Audits",
     date: "2026-03-26",
     effectiveAt: 1774810800,
@@ -168,7 +168,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.7",
+    version: "5.9",
     title: "Cadence-Aligned Data-Stale Warnings",
     date: "2026-03-26",
     effectiveAt: 1774807200,
@@ -184,7 +184,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.6",
+    version: "5.8",
     title: "First-Party EUR Benchmarks and Resilient CHF Parsing",
     date: "2026-03-26",
     effectiveAt: 1774803600,
@@ -200,7 +200,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.5",
+    version: "5.7",
     title: "Safety-Reweighted PYS Curve and Shared Scoring Hydration",
     date: "2026-03-26",
     effectiveAt: 1774800000,
@@ -216,7 +216,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.4",
+    version: "5.6",
     title: "Currency-Aware Benchmarks For Excess Yield",
     date: "2026-03-26",
     effectiveAt: 1774792800,
@@ -233,7 +233,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.3",
+    version: "5.5",
     title: "Non-USD Yield Scoping and Exact-Pool Commodity Overrides",
     date: "2026-03-26",
     effectiveAt: 1774785600,
@@ -249,7 +249,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.2",
+    version: "5.4",
     title: "Address-First Identity, Explicit Coverage, and Publish-Consistent History",
     date: "2026-03-26",
     effectiveAt: 1774778400,
@@ -266,7 +266,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.1",
+    version: "5.3",
     title: "Yield Infrastructure Automation",
     date: "2026-03-26",
     effectiveAt: 1774771200,
@@ -282,7 +282,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "5.0",
+    version: "5.2",
     title: "Yield Coverage Expansion — Protocol-Native API Wave",
     date: "2026-03-25",
     effectiveAt: 1774684800,
@@ -302,7 +302,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "4.11",
+    version: "5.1",
     title: "Protocol-native BIMA savings fallback for USBD",
     date: "2026-03-24",
     effectiveAt: 1774418400,
@@ -317,7 +317,7 @@ const yieldMethodology = createMethodologyVersion({
     reconstructed: false,
   },
   {
-    version: "4.10",
+    version: "5.0",
     title: "Richer freshness provenance and curated lending source links",
     date: "2026-03-24",
     effectiveAt: 1774407600,

--- a/src/app/methodology/scoring-changelog/content-v6.tsx
+++ b/src/app/methodology/scoring-changelog/content-v6.tsx
@@ -1,11 +1,13 @@
 import { VersionCard, getScoringEntry } from "./content-shared";
-import { ScoringChangelogV70Entry } from "./content-v7-0";
+import { ScoringChangelogV691Entry } from "./content-v7-0";
 import { ScoringChangelogV69Entry } from "./content-v6-9";
 
 export function ScoringChangelogV6Entries() {
   return (
     <>
-            <ScoringChangelogV70Entry />
+            <ScoringChangelogV691Entry />
+
+            <ScoringChangelogV69Entry />
 
             <VersionCard
               entry={getScoringEntry("6.8")}
@@ -28,6 +30,32 @@ export function ScoringChangelogV6Entries() {
                 <li>
                   This aligns implementation with the existing v6.6 freshness gate rather than introducing a new
                   collateral-scoring rule family.
+                </li>
+              </ul>
+            </VersionCard>
+
+            <VersionCard
+              entry={getScoringEntry("6.7")}
+              accent="border-l-amber-500"
+            >
+              <p>
+                Blacklistability attribution now treats{" "}
+                <span className="text-foreground font-medium">centralized-dependent</span> stablecoins as{" "}
+                <span className="text-foreground font-medium">possible</span> by default unless a more specific signal
+                applies.
+              </p>
+              <ul className="list-disc list-inside space-y-1">
+                <li>
+                  Shared blacklistability resolution now falls back to <code className="text-xs bg-muted px-1 py-0.5 rounded">possible</code>{" "}
+                  for centralized-dependent governance instead of <code className="text-xs bg-muted px-1 py-0.5 rounded">false</code>.
+                </li>
+                <li>
+                  Reserve-heavy dependency cases still surface as <code className="text-xs bg-muted px-1 py-0.5 rounded">possible-inherited</code>{" "}
+                  when inherited exposure is the more specific explanation.
+                </li>
+                <li>
+                  Explicit overrides remain authoritative, including curated <code className="text-xs bg-muted px-1 py-0.5 rounded">false</code>{" "}
+                  exceptions.
                 </li>
               </ul>
             </VersionCard>
@@ -239,33 +267,6 @@ export function ScoringChangelogV6Entries() {
               </ul>
             </VersionCard>
 
-            <ScoringChangelogV69Entry />
-
-            <VersionCard
-              entry={getScoringEntry("6.7")}
-              accent="border-l-amber-500"
-            >
-              <p>
-                Blacklistability attribution now treats{" "}
-                <span className="text-foreground font-medium">centralized-dependent</span> stablecoins as{" "}
-                <span className="text-foreground font-medium">possible</span> by default unless a more specific signal
-                applies.
-              </p>
-              <ul className="list-disc list-inside space-y-1">
-                <li>
-                  Shared blacklistability resolution now falls back to <code className="text-xs bg-muted px-1 py-0.5 rounded">possible</code>{" "}
-                  for centralized-dependent governance instead of <code className="text-xs bg-muted px-1 py-0.5 rounded">false</code>.
-                </li>
-                <li>
-                  Reserve-heavy dependency cases still surface as <code className="text-xs bg-muted px-1 py-0.5 rounded">possible-inherited</code>{" "}
-                  when inherited exposure is the more specific explanation.
-                </li>
-                <li>
-                  Explicit overrides remain authoritative, including curated <code className="text-xs bg-muted px-1 py-0.5 rounded">false</code>{" "}
-                  exceptions.
-                </li>
-              </ul>
-            </VersionCard>
     </>
   );
 }

--- a/src/app/methodology/scoring-changelog/content-v7-0.tsx
+++ b/src/app/methodology/scoring-changelog/content-v7-0.tsx
@@ -1,9 +1,9 @@
 import { VersionCard, getScoringEntry } from "./content-shared";
 
-export function ScoringChangelogV70Entry() {
+export function ScoringChangelogV691Entry() {
   return (
     <VersionCard
-      entry={getScoringEntry("7.0")}
+      entry={getScoringEntry("6.91")}
       accent="border-l-amber-500"
     >
       <p>

--- a/src/app/methodology/scoring-changelog/content.test.tsx
+++ b/src/app/methodology/scoring-changelog/content.test.tsx
@@ -4,14 +4,14 @@ import { ScoringChangelogContent, scoringAnchorId } from "./content";
 
 describe("ScoringChangelogContent", () => {
   it("preserves the version anchor and quick-reference rendering contracts", () => {
-    expect(scoringAnchorId("v7.0")).toBe("scoring-v7-0");
+    expect(scoringAnchorId("v6.91")).toBe("scoring-v6-91");
     expect(scoringAnchorId("v6.8")).toBe("scoring-v6-8");
     expect(scoringAnchorId("6.8")).toBe("scoring-6-8");
 
     const html = renderToStaticMarkup(<ScoringChangelogContent />);
 
-    expect(html).toContain('id="scoring-v7-0"');
-    expect(html).toContain("v7.0");
+    expect(html).toContain('id="scoring-v6-91"');
+    expect(html).toContain("v6.91");
     expect(html).toContain('id="scoring-v6-8"');
     expect(html).toContain("v6.8");
     expect(html).toContain("Quick Reference");

--- a/worker/src/lib/redemption-backstops-store.ts
+++ b/worker/src/lib/redemption-backstops-store.ts
@@ -21,6 +21,7 @@ import {
   REDEMPTION_BACKSTOP_VERSION,
   REDEMPTION_BACKSTOP_VERSION_LABEL,
   getRedemptionBackstopVersionAt,
+  toRedemptionBackstopVersionLabel,
 } from "@shared/lib/redemption-backstop-version";
 import {
   EFFECTIVE_EXIT_WEIGHTS,
@@ -218,7 +219,7 @@ function resolveSnapshotMethodologyVersion(
     if (latestEntry?.methodologyVersion) {
       return {
         version: latestEntry.methodologyVersion,
-        versionLabel: `v${latestEntry.methodologyVersion}`,
+        versionLabel: toRedemptionBackstopVersionLabel(latestEntry.methodologyVersion),
       };
     }
   }
@@ -226,7 +227,7 @@ function resolveSnapshotMethodologyVersion(
   const version = getRedemptionBackstopVersionAt(updatedAt);
   return {
     version,
-    versionLabel: `v${version}`,
+    versionLabel: toRedemptionBackstopVersionLabel(version),
   };
 }
 


### PR DESCRIPTION
## What changed
Renumbered methodology version histories so newer versions are always strictly higher numerical values, avoiding cases like `2.10` appearing conceptually newer than `2.9` while still sorting awkwardly in the UI.

This also fixes the custom Safety Score changelog ordering issue by renaming the latest entry from `v7.0` to `v6.91` and rendering the newest cards in true descending order.

## Why
Methodology version labels are user-facing and people will assume larger numbers are newer. The old numbering violated that expectation once patch counts crossed `.9`, and the Safety Score changelog had a separate hardcoded ordering bug.

## Impact
Methodology surfaces now present versions in a monotonic way across Pricing, DEWS, Yield, Redemption Backstops, and Safety Score. The matching docs and timelines were updated to stay in sync with the canonical version metadata.

## Validation
- `npm run test:merge-gate`
- `npm run check:doc-sync`
- `npm run lint`
- `npm run build`
- `npm test`
- `cd worker && npx tsc --noEmit`
