### PR TITLE
chore: update repo links to pharos-watch

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -11,7 +11,7 @@
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/TokenBrice/stablecoin-dashboard/blob/main/LICENSE"
+      "url": "https://github.com/TokenBrice/pharos-watch/blob/main/LICENSE"
     }
   },
   "externalDocs": {

--- a/scripts/generate-openapi-spec.ts
+++ b/scripts/generate-openapi-spec.ts
@@ -77,7 +77,7 @@ function render() {
       },
       license: {
         name: "MIT",
-        url: "https://github.com/TokenBrice/stablecoin-dashboard/blob/main/LICENSE",
+        url: "https://github.com/TokenBrice/pharos-watch/blob/main/LICENSE",
       },
     },
     externalDocs: {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -490,7 +490,7 @@ export default function AboutPage() {
           </p>
           <div className="flex flex-wrap gap-2">
             <Button asChild variant="outline" className={CTA_BUTTON_CLASS}>
-              <a href="https://github.com/TokenBrice/stablecoin-dashboard" target="_blank" rel="noopener noreferrer">
+              <a href="https://github.com/TokenBrice/pharos-watch" target="_blank" rel="noopener noreferrer">
                 <GitBranch className="h-4 w-4" />
                 View on GitHub
                 <ExternalLink className="h-4 w-4" />

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -64,7 +64,7 @@ export default function ChangelogPage() {
           </Link>{" "}
           for real-time alerts, or browse the{" "}
           <a
-            href="https://github.com/TokenBrice/stablecoin-dashboard/commits/main/"
+            href="https://github.com/TokenBrice/pharos-watch/commits/main/"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-4 hover:text-foreground"

--- a/src/components/changelog-entry-card.tsx
+++ b/src/components/changelog-entry-card.tsx
@@ -162,7 +162,7 @@ export function ChangelogEntryCard({
           {commits.slice(0, COMMIT_PREVIEW_COUNT).map((c) => (
             <li key={c.hash}>
               <a
-                href={`https://github.com/TokenBrice/stablecoin-dashboard/commit/${c.hash}`}
+                href={`https://github.com/TokenBrice/pharos-watch/commit/${c.hash}`}
                 className="text-foreground/60 hover:text-foreground transition-colors"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -41,7 +41,7 @@ export function Footer() {
               </svg>
             </a>
             <a
-              href="https://github.com/TokenBrice/stablecoin-dashboard"
+              href="https://github.com/TokenBrice/pharos-watch"
               target="_blank"
               rel="noopener noreferrer"
               className="pharos-focus-ring rounded-full border border-transparent p-1.5 hover:border-border/60 hover:bg-muted/40 hover:text-foreground"

--- a/src/components/funding/funding-page-sections.tsx
+++ b/src/components/funding/funding-page-sections.tsx
@@ -15,7 +15,7 @@ import { groupCostsByCategory } from "@shared/lib/funding/helpers";
 const PHAROS_FUNDING_WALLET_DISPLAY = "0x5d698362EDb8AEa1C2b2483096BDeE3265D860DB";
 const PHAROS_FUNDING_ENS = "pharos-watch.eth";
 const GIVETH_URL = "https://giveth.io/project/pharos-watch:-transparent-stablecoins-analytics";
-const GITHUB_URL = "https://github.com/TokenBrice/stablecoin-dashboard";
+const GITHUB_URL = "https://github.com/TokenBrice/pharos-watch";
 const TWITTER_URL = "https://x.com/PharosWatch";
 const TELEGRAM_GROUP_URL = "https://t.me/pharoswatchers";
 const SUPPORTED_CHAINS: FundingChain[] = ["ethereum", "base", "optimism", "arbitrum", "polygon", "gnosis"];

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -35,7 +35,7 @@ export const PHAROS_ORG_NODE = {
   description: PHAROS_SITE_DESCRIPTION,
   sameAs: [
     "https://x.com/PharosWatch",
-    "https://github.com/TokenBrice/stablecoin-dashboard",
+    "https://github.com/TokenBrice/pharos-watch",
     "https://t.me/pharoswatch",
     "https://t.me/PharosWatchBot",
     "https://t.me/pharoswatchers",


### PR DESCRIPTION
## Summary
- Updates user-facing GitHub links from `TokenBrice/stablecoin-dashboard` to `TokenBrice/pharos-watch`
- Updates JSON-LD `sameAs` and OpenAPI license URL
- Regenerates `public/openapi.json`

Cloudflare Pages project references to `stablecoin-dashboard` are intentionally unchanged because that is the current Pages project name.

## Validation
- `npm run check:openapi`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run seo:check`
- pre-push `npm run test:merge-gate`
