### PR TITLE
chore: update runtime repo identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "stablecoin-dashboard",
+  "name": "pharos-watch",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stablecoin-dashboard",
+      "name": "pharos-watch",
       "version": "0.1.0",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stablecoin-dashboard",
+  "name": "pharos-watch",
   "version": "0.1.0",
   "private": true,
   "license": "MIT",

--- a/worker/src/api/__tests__/feedback.test.ts
+++ b/worker/src/api/__tests__/feedback.test.ts
@@ -204,8 +204,7 @@ describe("handleFeedback", () => {
     // Verify GitHub API was called
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(String(url)).toContain("api.github.com");
-    expect(String(url)).toContain("/issues");
+    expect(String(url)).toBe("https://api.github.com/repos/TokenBrice/pharos-watch/issues");
     expect(init?.method).toBe("POST");
     expect(response.bodyUsed).toBe(true);
   });
@@ -352,7 +351,7 @@ describe("handleFeedback", () => {
     expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(String(url)).toContain("/issues");
+    expect(String(url)).toBe("https://api.github.com/repos/TokenBrice/pharos-watch/issues");
     expect(init?.method).toBe("POST");
     const payload = JSON.parse(String(init?.body)) as { labels: string[] };
     expect(payload.labels).toEqual(["feature-request"]);

--- a/worker/src/api/feedback/types.ts
+++ b/worker/src/api/feedback/types.ts
@@ -42,4 +42,4 @@ export interface PreparedFeedbackSubmission {
 }
 
 export const GITHUB_OWNER = "TokenBrice";
-export const GITHUB_REPO = "stablecoin-dashboard";
+export const GITHUB_REPO = "pharos-watch";

--- a/worker/src/lib/__tests__/evaluation-causes-runbook.test.ts
+++ b/worker/src/lib/__tests__/evaluation-causes-runbook.test.ts
@@ -10,7 +10,7 @@ describe("StatusCause.runbookUrl", () => {
       severity: "critical",
       message: "DB unhealthy",
     };
-    expect(withRunbook(cause).runbookUrl).toBe("https://github.com/TokenBrice/stablecoin-dashboard/blob/main/docs/runbooks/db-connectivity.md");
+    expect(withRunbook(cause).runbookUrl).toBe("https://github.com/TokenBrice/pharos-watch/blob/main/docs/runbooks/db-connectivity.md");
   });
 
   it("omits runbookUrl for codes without a documented runbook", () => {
@@ -35,7 +35,7 @@ describe("StatusCause.runbookUrl", () => {
     };
     const withUrl = withRunbook(cause);
     expect(withUrl).toMatchObject(cause);
-    expect(withUrl.runbookUrl).toBe("https://github.com/TokenBrice/stablecoin-dashboard/blob/main/docs/runbooks/stablecoins-cache.md");
+    expect(withUrl.runbookUrl).toBe("https://github.com/TokenBrice/pharos-watch/blob/main/docs/runbooks/stablecoins-cache.md");
   });
 
   it("covers all codes listed in RUNBOOK_BY_CODE with valid documented URLs", () => {

--- a/worker/src/lib/status/evaluation-causes.ts
+++ b/worker/src/lib/status/evaluation-causes.ts
@@ -24,7 +24,7 @@ function formatRatio(value: number): string {
  * would 404 at `https://ops.pharos.watch/...`. The blob URL survives branch
  * renames as long as `main` is the default.
  */
-const RUNBOOK_BASE = "https://github.com/TokenBrice/stablecoin-dashboard/blob/main/docs/runbooks";
+const RUNBOOK_BASE = "https://github.com/TokenBrice/pharos-watch/blob/main/docs/runbooks";
 
 export const RUNBOOK_BY_CODE: Record<string, string> = {
   db_unhealthy: `${RUNBOOK_BASE}/db-connectivity.md`,


### PR DESCRIPTION
## Summary
- Rename root package metadata to pharos-watch
- Point Worker runbook URLs at TokenBrice/pharos-watch
- Route feedback issue creation to TokenBrice/pharos-watch and assert the target URL in tests

## Validation
- npm test -- worker/src/lib/__tests__/evaluation-causes-runbook.test.ts worker/src/api/__tests__/feedback.test.ts shared/lib/__tests__/runtime-origins.test.ts src/lib/__tests__/api-fetch-contracts.test.ts functions/lib/__tests__/site-data-origin.test.ts functions/__tests__/site-data-proxy.test.ts functions/__tests__/site-api-env.test.ts scripts/__tests__/rollback-pages-deployment.test.ts
- npm run lint
- npm run typecheck
- npm run typecheck:worker
- npm test
- npm run test:merge-gate
- pre-push npm run test:merge-gate

Cloudflare Pages project references intentionally remain stablecoin-dashboard.