### PR TITLE
chore: add pharosville api contract

### DIFF
--- a/shared/lib/__tests__/pharosville-api-contract.test.ts
+++ b/shared/lib/__tests__/pharosville-api-contract.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { API_FRESHNESS_MAX_AGE_SEC } from "../api-freshness";
+import { CRON_INTERVALS } from "../cron-jobs";
+import {
+  PHAROSVILLE_API_CONTRACT,
+  PHAROSVILLE_API_ENDPOINTS,
+} from "../pharosville-api-contract";
+import { ChainsResponseSchema } from "../../types/chains";
+import {
+  PegSummaryResponseSchema,
+  StablecoinListResponseSchema,
+  StressSignalsAllResponseSchema,
+} from "../../types/market";
+import { ReportCardsResponseSchema } from "../../types/report-cards";
+import { StabilityIndexResponseSchema } from "../../types/stability";
+
+describe("PHAROSVILLE_API_CONTRACT", () => {
+  it("describes the exact API paths the split app consumes", () => {
+    expect(PHAROSVILLE_API_ENDPOINTS.map((endpoint) => endpoint.key)).toEqual([
+      "stablecoins",
+      "chains",
+      "stability",
+      "pegSummary",
+      "stress",
+      "reportCards",
+    ]);
+
+    expect(Object.fromEntries(
+      PHAROSVILLE_API_ENDPOINTS.map((endpoint) => [endpoint.key, endpoint.path]),
+    )).toEqual({
+      stablecoins: "/api/stablecoins",
+      chains: "/api/chains",
+      stability: "/api/stability-index?detail=true",
+      pegSummary: "/api/peg-summary",
+      stress: "/api/stress-signals",
+      reportCards: "/api/report-cards",
+    });
+  });
+
+  it("uses the shared endpoint schemas", () => {
+    expect(PHAROSVILLE_API_CONTRACT.stablecoins.schema).toBe(StablecoinListResponseSchema);
+    expect(PHAROSVILLE_API_CONTRACT.chains.schema).toBe(ChainsResponseSchema);
+    expect(PHAROSVILLE_API_CONTRACT.stability.schema).toBe(StabilityIndexResponseSchema);
+    expect(PHAROSVILLE_API_CONTRACT.pegSummary.schema).toBe(PegSummaryResponseSchema);
+    expect(PHAROSVILLE_API_CONTRACT.stress.schema).toBe(StressSignalsAllResponseSchema);
+    expect(PHAROSVILLE_API_CONTRACT.reportCards.schema).toBe(ReportCardsResponseSchema);
+  });
+
+  it("pins freshness and producer cadence budgets for the standalone proxy client", () => {
+    expect(PHAROSVILLE_API_CONTRACT.stablecoins.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.stablecoins);
+    expect(PHAROSVILLE_API_CONTRACT.chains.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.chains);
+    expect(PHAROSVILLE_API_CONTRACT.stability.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.stabilityIndex);
+    expect(PHAROSVILLE_API_CONTRACT.pegSummary.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.pegSummary);
+    expect(PHAROSVILLE_API_CONTRACT.stress.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.stressSignals);
+    expect(PHAROSVILLE_API_CONTRACT.reportCards.metaMaxAgeSec).toBe(API_FRESHNESS_MAX_AGE_SEC.reportCards);
+
+    expect(PHAROSVILLE_API_CONTRACT.stablecoins.producerIntervalSec).toBe(CRON_INTERVALS["sync-stablecoins"]);
+    expect(PHAROSVILLE_API_CONTRACT.chains.producerIntervalSec).toBe(CRON_INTERVALS["sync-stablecoins"]);
+    expect(PHAROSVILLE_API_CONTRACT.stability.producerIntervalSec).toBe(CRON_INTERVALS["stability-index"]);
+    expect(PHAROSVILLE_API_CONTRACT.pegSummary.producerIntervalSec).toBe(CRON_INTERVALS["sync-stablecoins"]);
+    expect(PHAROSVILLE_API_CONTRACT.stress.producerIntervalSec).toBe(CRON_INTERVALS["compute-dews"]);
+    expect(PHAROSVILLE_API_CONTRACT.reportCards.producerIntervalSec).toBe(CRON_INTERVALS["publish-report-card-cache"]);
+  });
+});

--- a/shared/lib/pharosville-api-contract.ts
+++ b/shared/lib/pharosville-api-contract.ts
@@ -1,0 +1,76 @@
+import type { ZodType } from "zod";
+import { API_PATHS } from "./api-endpoints";
+import { API_FRESHNESS_MAX_AGE_SEC } from "./api-freshness";
+import { CRON_INTERVALS } from "./cron-jobs";
+import {
+  PHAROSVILLE_API_ENDPOINT_KEYS,
+  type PharosVilleApiEndpointKey,
+  type PharosVilleApiPayload,
+} from "../types/pharosville";
+import { ChainsResponseSchema } from "../types/chains";
+import {
+  PegSummaryResponseSchema,
+  StablecoinListResponseSchema,
+  StressSignalsAllResponseSchema,
+} from "../types/market";
+import { ReportCardsResponseSchema } from "../types/report-cards";
+import { StabilityIndexResponseSchema } from "../types/stability";
+
+export interface PharosVilleApiEndpoint<K extends PharosVilleApiEndpointKey = PharosVilleApiEndpointKey> {
+  key: K;
+  path: string;
+  schema: ZodType<PharosVilleApiPayload<K>>;
+  metaMaxAgeSec: number;
+  producerIntervalSec: number;
+}
+
+export const PHAROSVILLE_API_CONTRACT = {
+  stablecoins: {
+    key: "stablecoins",
+    path: API_PATHS.stablecoins(),
+    schema: StablecoinListResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.stablecoins,
+    producerIntervalSec: CRON_INTERVALS["sync-stablecoins"],
+  },
+  chains: {
+    key: "chains",
+    path: API_PATHS.chains(),
+    schema: ChainsResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.chains,
+    producerIntervalSec: CRON_INTERVALS["sync-stablecoins"],
+  },
+  stability: {
+    key: "stability",
+    path: API_PATHS.stabilityIndex(true),
+    schema: StabilityIndexResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.stabilityIndex,
+    producerIntervalSec: CRON_INTERVALS["stability-index"],
+  },
+  pegSummary: {
+    key: "pegSummary",
+    path: API_PATHS.pegSummary(),
+    schema: PegSummaryResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.pegSummary,
+    producerIntervalSec: CRON_INTERVALS["sync-stablecoins"],
+  },
+  stress: {
+    key: "stress",
+    path: API_PATHS.stressSignals(),
+    schema: StressSignalsAllResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.stressSignals,
+    producerIntervalSec: CRON_INTERVALS["compute-dews"],
+  },
+  reportCards: {
+    key: "reportCards",
+    path: API_PATHS.reportCards(),
+    schema: ReportCardsResponseSchema,
+    metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.reportCards,
+    producerIntervalSec: CRON_INTERVALS["publish-report-card-cache"],
+  },
+} satisfies {
+  [K in PharosVilleApiEndpointKey]: PharosVilleApiEndpoint<K>;
+};
+
+export const PHAROSVILLE_API_ENDPOINTS = PHAROSVILLE_API_ENDPOINT_KEYS.map(
+  (key) => PHAROSVILLE_API_CONTRACT[key],
+);

--- a/shared/types/__tests__/api-meta.test.ts
+++ b/shared/types/__tests__/api-meta.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ApiMetaSchema } from "../api-meta";
+
+describe("ApiMetaSchema", () => {
+  it("parses freshness metadata with dependency status details", () => {
+    const parsed = ApiMetaSchema.parse({
+      updatedAt: 1777555000,
+      ageSeconds: 300,
+      status: "degraded",
+      warning: "110 - \"Response is degraded\"",
+      dependencies: {
+        reportCards: {
+          updatedAt: 1777554800,
+          ageSeconds: 500,
+          status: "fresh",
+          reason: null,
+        },
+      },
+    });
+
+    expect(parsed.dependencies?.reportCards.status).toBe("fresh");
+  });
+
+  it("rejects unknown top-level freshness statuses", () => {
+    expect(ApiMetaSchema.safeParse({
+      updatedAt: 1777555000,
+      ageSeconds: 300,
+      status: "unavailable",
+    }).success).toBe(false);
+  });
+});

--- a/shared/types/__tests__/chains.test.ts
+++ b/shared/types/__tests__/chains.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { ChainsResponseSchema } from "../chains";
+
+const validChainsPayload = {
+  chains: [
+    {
+      id: "ethereum",
+      name: "Ethereum",
+      logoPath: "/chains/ethereum.png",
+      type: "evm",
+      totalUsd: 1000,
+      change24h: 10,
+      change24hPct: 0.01,
+      change7d: 20,
+      change7dPct: 0.02,
+      change30d: 30,
+      change30dPct: 0.03,
+      stablecoinCount: 2,
+      dominantStablecoin: {
+        id: "usdc-circle",
+        symbol: "USDC",
+        share: 0.6,
+      },
+      topStablecoins: [
+        {
+          id: "usdc-circle",
+          symbol: "USDC",
+          share: 0.6,
+          supplyUsd: 600,
+        },
+      ],
+      dominanceShare: 0.8,
+      healthScore: 82,
+      healthBand: "robust",
+      healthFactors: {
+        concentration: 80,
+        quality: null,
+        pegStability: 90,
+        backingDiversity: 70,
+        chainEnvironment: 85,
+      },
+    },
+  ],
+  globalTotalUsd: 1250,
+  chainAttributedTotalUsd: 1000,
+  unattributedTotalUsd: 250,
+  globalChange24hPct: 0.01,
+  globalChange7dPct: 0.02,
+  globalChange30dPct: 0.03,
+  updatedAt: 1777555000,
+  healthMethodologyVersion: "v1.0",
+};
+
+describe("ChainsResponseSchema", () => {
+  it("parses the public chains endpoint payload", () => {
+    const parsed = ChainsResponseSchema.parse(validChainsPayload);
+
+    expect(parsed.chains[0].id).toBe("ethereum");
+    expect(parsed.chains[0].healthFactors.quality).toBeNull();
+  });
+
+  it("rejects unknown chain runtime types", () => {
+    expect(ChainsResponseSchema.safeParse({
+      ...validChainsPayload,
+      chains: [{ ...validChainsPayload.chains[0], type: "solana" }],
+    }).success).toBe(false);
+  });
+
+  it("rejects unknown health bands", () => {
+    expect(ChainsResponseSchema.safeParse({
+      ...validChainsPayload,
+      chains: [{ ...validChainsPayload.chains[0], healthBand: "excellent" }],
+    }).success).toBe(false);
+  });
+});

--- a/shared/types/__tests__/pharosville.test.ts
+++ b/shared/types/__tests__/pharosville.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { ChainsResponseSchema } from "../chains";
+import {
+  PegSummaryResponseSchema,
+  StablecoinListResponseSchema,
+  StressSignalsAllResponseSchema,
+} from "../market";
+import { PHAROSVILLE_API_CONTRACT_VERSION, PHAROSVILLE_API_ENDPOINT_KEYS, PharosVilleApiPayloadsSchema } from "../pharosville";
+import { ReportCardsResponseSchema } from "../report-cards";
+import { StabilityIndexResponseSchema } from "../stability";
+
+describe("PharosVille shared payload contract", () => {
+  it("pins the endpoint key set and version", () => {
+    expect(PHAROSVILLE_API_CONTRACT_VERSION).toBe(1);
+    expect(PHAROSVILLE_API_ENDPOINT_KEYS).toEqual([
+      "stablecoins",
+      "chains",
+      "stability",
+      "pegSummary",
+      "stress",
+      "reportCards",
+    ]);
+  });
+
+  it("bundles the six existing endpoint schemas without creating a new API shape", () => {
+    expect(PharosVilleApiPayloadsSchema.shape.stablecoins).toBe(StablecoinListResponseSchema);
+    expect(PharosVilleApiPayloadsSchema.shape.chains).toBe(ChainsResponseSchema);
+    expect(PharosVilleApiPayloadsSchema.shape.stability).toBe(StabilityIndexResponseSchema);
+    expect(PharosVilleApiPayloadsSchema.shape.pegSummary).toBe(PegSummaryResponseSchema);
+    expect(PharosVilleApiPayloadsSchema.shape.stress).toBe(StressSignalsAllResponseSchema);
+    expect(PharosVilleApiPayloadsSchema.shape.reportCards).toBe(ReportCardsResponseSchema);
+  });
+});

--- a/shared/types/api-meta.ts
+++ b/shared/types/api-meta.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const ApiDependencyMetaSchema = z.object({
+  updatedAt: z.number().nullable().optional(),
+  ageSeconds: z.number().nullable().optional(),
+  status: z.enum(["fresh", "degraded", "stale", "unavailable"]),
+  reason: z.string().nullish(),
+});
+
+export type ApiDependencyMeta = z.infer<typeof ApiDependencyMetaSchema>;
+
+export const ApiMetaSchema = z.object({
+  updatedAt: z.number(),
+  ageSeconds: z.number(),
+  status: z.enum(["fresh", "degraded", "stale"]),
+  warning: z.string().nullish(),
+  dependencies: z.record(z.string(), ApiDependencyMetaSchema).nullish(),
+});
+
+export type ApiMeta = z.infer<typeof ApiMetaSchema>;

--- a/shared/types/chains.ts
+++ b/shared/types/chains.ts
@@ -1,3 +1,13 @@
+import { z } from "zod";
+
+export const ChainHealthFactorsSchema = z.object({
+  concentration: z.number(),
+  quality: z.number().nullable(),
+  pegStability: z.number(),
+  backingDiversity: z.number(),
+  chainEnvironment: z.number(),
+});
+
 export interface ChainHealthFactors {
   concentration: number;
   quality: number | null;
@@ -6,7 +16,14 @@ export interface ChainHealthFactors {
   chainEnvironment: number;
 }
 
-export type HealthBand = "robust" | "healthy" | "mixed" | "fragile" | "concentrated";
+export const HealthBandSchema = z.enum(["robust", "healthy", "mixed", "fragile", "concentrated"]);
+export type HealthBand = z.infer<typeof HealthBandSchema>;
+
+export const ChainDominantStablecoinSchema = z.object({
+  id: z.string(),
+  symbol: z.string(),
+  share: z.number(),
+});
 
 export interface ChainDominantStablecoin {
   id: string;
@@ -14,12 +31,40 @@ export interface ChainDominantStablecoin {
   share: number;
 }
 
+export const ChainTopStablecoinSchema = z.object({
+  id: z.string(),
+  symbol: z.string(),
+  share: z.number(),
+  supplyUsd: z.number(),
+});
+
 export interface ChainTopStablecoin {
   id: string;
   symbol: string;
   share: number;
   supplyUsd: number;
 }
+
+export const ChainSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  logoPath: z.string(),
+  type: z.enum(["evm", "tron", "other"]),
+  totalUsd: z.number(),
+  change24h: z.number(),
+  change24hPct: z.number(),
+  change7d: z.number(),
+  change7dPct: z.number(),
+  change30d: z.number(),
+  change30dPct: z.number(),
+  stablecoinCount: z.number(),
+  dominantStablecoin: ChainDominantStablecoinSchema,
+  topStablecoins: z.array(ChainTopStablecoinSchema).optional(),
+  dominanceShare: z.number(),
+  healthScore: z.number().nullable(),
+  healthBand: HealthBandSchema.nullable(),
+  healthFactors: ChainHealthFactorsSchema,
+});
 
 export interface ChainSummary {
   id: string;
@@ -41,6 +86,18 @@ export interface ChainSummary {
   healthBand: HealthBand | null;
   healthFactors: ChainHealthFactors;
 }
+
+export const ChainsResponseSchema = z.object({
+  chains: z.array(ChainSummarySchema),
+  globalTotalUsd: z.number(),
+  chainAttributedTotalUsd: z.number(),
+  unattributedTotalUsd: z.number(),
+  globalChange24hPct: z.number(),
+  globalChange7dPct: z.number(),
+  globalChange30dPct: z.number(),
+  updatedAt: z.number(),
+  healthMethodologyVersion: z.string(),
+});
 
 export interface ChainsResponse {
   chains: ChainSummary[];

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./api-meta";
 export * from "./live-reserves";
 export * from "./core";
 export * from "./digest";
@@ -12,3 +13,4 @@ export * from "./chains";
 export * from "./request-source";
 export * from "./api-keys";
 export * from "./editorial";
+export * from "./pharosville";

--- a/shared/types/market.ts
+++ b/shared/types/market.ts
@@ -48,7 +48,7 @@ const StablecoinDataRawSchema = z.object({
   frozenAt: z.string().optional(),
 });
 
-const StablecoinDataSchema = StablecoinDataRawSchema.transform((asset) => ({
+export const StablecoinDataSchema = StablecoinDataRawSchema.transform((asset) => ({
   id: asset.id,
   name: asset.name,
   symbol: asset.symbol,
@@ -360,7 +360,7 @@ export type DepegEventsResponse = z.infer<typeof DepegEventsResponseSchema>;
 
 export type DepegDewsMethodology = MethodologyEnvelope;
 
-const PegSummaryCoinSchema = z.object({
+export const PegSummaryCoinSchema = z.object({
   id: z.string(),
   symbol: z.string(),
   name: z.string(),
@@ -401,7 +401,7 @@ const PegSummaryCoinSchema = z.object({
 });
 export type PegSummaryCoin = z.infer<typeof PegSummaryCoinSchema>;
 
-const PegSummaryStatsSchema = z.object({
+export const PegSummaryStatsSchema = z.object({
   activeDepegCount: z.number(),
   medianDeviationBps: z.number(),
   worstCurrent: z.object({ id: z.string(), symbol: z.string(), bps: z.number() }).nullable(),
@@ -597,7 +597,7 @@ const AmplifiersSchema = z.object({
   contagion: z.number(),
 });
 
-const StressSignalEntrySchema = z.object({
+export const StressSignalEntrySchema = z.object({
   score: z.number(),
   band: z.string(),
   signals: z.record(z.string(), SignalDetailSchema),

--- a/shared/types/pharosville.ts
+++ b/shared/types/pharosville.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { ChainsResponseSchema } from "./chains";
+import {
+  PegSummaryResponseSchema,
+  StablecoinListResponseSchema,
+  StressSignalsAllResponseSchema,
+} from "./market";
+import { ReportCardsResponseSchema } from "./report-cards";
+import { StabilityIndexResponseSchema } from "./stability";
+
+export const PHAROSVILLE_API_CONTRACT_VERSION = 1;
+
+export const PHAROSVILLE_API_ENDPOINT_KEYS = [
+  "stablecoins",
+  "chains",
+  "stability",
+  "pegSummary",
+  "stress",
+  "reportCards",
+] as const;
+
+export type PharosVilleApiEndpointKey = (typeof PHAROSVILLE_API_ENDPOINT_KEYS)[number];
+
+export const PharosVilleApiPayloadsSchema = z.object({
+  stablecoins: StablecoinListResponseSchema,
+  chains: ChainsResponseSchema,
+  stability: StabilityIndexResponseSchema,
+  pegSummary: PegSummaryResponseSchema,
+  stress: StressSignalsAllResponseSchema,
+  reportCards: ReportCardsResponseSchema,
+});
+
+export type PharosVilleApiPayloads = z.infer<typeof PharosVilleApiPayloadsSchema>;
+export type PharosVilleApiPayload<K extends PharosVilleApiEndpointKey> = PharosVilleApiPayloads[K];

--- a/shared/types/stability.ts
+++ b/shared/types/stability.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 import { MethodologyEnvelopeSchema } from "./core";
 
-const StabilityIndexComponentsSchema = z.object({
+export const StabilityIndexComponentsSchema = z.object({
   severity: z.number(),
   breadth: z.number(),
   stressBreadth: z.number().optional(),
   trend: z.number(),
 });
 
-const StabilityContributorSchema = z.object({
+export const StabilityContributorSchema = z.object({
   id: z.string(),
   symbol: z.string(),
   bps: z.number(),
@@ -17,14 +17,14 @@ const StabilityContributorSchema = z.object({
   factor: z.number(),
 });
 
-const StabilityIndexInputDegradationSchema = z.object({
+export const StabilityIndexInputDegradationSchema = z.object({
   dewsUnavailable: z.boolean(),
   dewsFailureReason: z.string().nullable(),
   depegEventsUnavailable: z.boolean(),
   depegEventsFailureReason: z.string().nullable(),
 });
 
-const StabilityIndexCurrentSchema = z.object({
+export const StabilityIndexCurrentSchema = z.object({
   score: z.number(),
   band: z.string(),
   avg24h: z.number().optional(),
@@ -37,7 +37,7 @@ const StabilityIndexCurrentSchema = z.object({
   methodologyVersion: z.string(),
 });
 
-const StabilityIndexHistoryPointSchema = z.object({
+export const StabilityIndexHistoryPointSchema = z.object({
   date: z.number(),
   score: z.number(),
   band: z.string(),

--- a/src/hooks/__tests__/use-chains.test.tsx
+++ b/src/hooks/__tests__/use-chains.test.tsx
@@ -15,6 +15,7 @@ vi.mock("../use-stablecoins", () => ({
   useStablecoins: useStablecoinsMock,
 }));
 
+import { ChainsResponseSchema } from "@shared/types/chains";
 import { useChainStablecoins, useChains } from "../use-chains";
 
 describe("useChains", () => {
@@ -33,6 +34,7 @@ describe("useChains", () => {
       "/api/chains",
       15 * 60 * 1000,
       expect.objectContaining({
+        schema: ChainsResponseSchema,
         metaMaxAgeSec: 1800,
       }),
     );

--- a/src/hooks/use-chains.ts
+++ b/src/hooks/use-chains.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { API_PATHS } from "@shared/lib/api-endpoints";
 import { API_FRESHNESS_MAX_AGE_SEC } from "@shared/lib/api-freshness";
 import { findCanonicalChainData, type RawChainCirculating } from "@shared/lib/chain-circulating";
-import type { ChainsResponse } from "@shared/types/chains";
+import { ChainsResponseSchema, type ChainsResponse } from "@shared/types/chains";
 import { useApiQueryWithMeta } from "./use-api-query";
 import { useStablecoins } from "./use-stablecoins";
 import { CRON_15MIN } from "@/lib/cron-intervals";
@@ -16,7 +16,10 @@ export function useChains() {
     ["chains"],
     API_PATHS.chains(),
     CRON_15MIN,
-    { metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.chains },
+    {
+      schema: ChainsResponseSchema,
+      metaMaxAgeSec: API_FRESHNESS_MAX_AGE_SEC.chains,
+    },
   );
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,14 +1,17 @@
-import { z, type ZodType } from "zod";
+import type { ZodType } from "zod";
 import { API_PATHS } from "@shared/lib/api-endpoints";
 import { PHAROS_WEB_ACCEPT_MARKER } from "@shared/lib/request-source-marker";
 import { toSiteDataPath } from "@shared/lib/site-data-routes";
 import { classifyFreshnessRatio } from "@shared/lib/status-thresholds";
 import { createTimeoutSignal } from "@shared/lib/timeout-signal";
 import { isSiteDataUiHostname, resolvePublicApiBase } from "@shared/lib/runtime-origins";
+import { ApiMetaSchema, type ApiMeta } from "@shared/types/api-meta";
 import {
   StablecoinReservesResponseSchema,
   type StablecoinReservesResponse,
 } from "@shared/types";
+
+export type { ApiMeta } from "@shared/types/api-meta";
 
 export type ApiContractMode = "strict" | "warn";
 export const DEFAULT_API_REQUEST_TIMEOUT_MS = 10_000;
@@ -178,36 +181,6 @@ async function buildFetchError(path: string, res: Response): Promise<ApiFetchErr
   }
   return new ApiFetchError(path, res.status, bodyText);
 }
-
-// --- Data freshness metadata ---
-
-export interface ApiMeta {
-  updatedAt: number;
-  ageSeconds: number;
-  status: "fresh" | "degraded" | "stale";
-  warning?: string | null;
-  dependencies?: Record<string, {
-    updatedAt?: number | null;
-    ageSeconds?: number | null;
-    status: "fresh" | "degraded" | "stale" | "unavailable";
-    reason?: string | null;
-  }> | null;
-}
-
-const ApiDependencyMetaSchema = z.object({
-  updatedAt: z.number().nullable().optional(),
-  ageSeconds: z.number().nullable().optional(),
-  status: z.enum(["fresh", "degraded", "stale", "unavailable"]),
-  reason: z.string().nullish(),
-});
-
-const ApiMetaSchema = z.object({
-  updatedAt: z.number(),
-  ageSeconds: z.number(),
-  status: z.enum(["fresh", "degraded", "stale"]),
-  warning: z.string().nullish(),
-  dependencies: z.record(z.string(), ApiDependencyMetaSchema).nullish(),
-});
 
 function resolveContractMode(
   schema: ZodType<unknown> | undefined,


### PR DESCRIPTION
## Summary
- add shared API meta schemas and exported endpoint response schemas for PharosVille consumers
- add a runtime-neutral PharosVille API contract descriptor for the six existing host API endpoints
- reuse the shared chains response schema in the existing frontend hook without changing routing or Worker behavior

## Risk
- No new endpoint, route, CORS policy, Worker handler, D1 migration, or Cloudflare config change.
- This is contract/schema prep only for the future standalone PharosVille repo.

## Validation
- npm test -- shared/types/__tests__/api-meta.test.ts shared/types/__tests__/chains.test.ts shared/types/__tests__/pharosville.test.ts shared/lib/__tests__/pharosville-api-contract.test.ts src/hooks/__tests__/use-chains.test.tsx src/lib/__tests__/api-fetch-contracts.test.ts
- npm run typecheck
- npm run lint
- npm run check:shared-cycles
- npm run check:unused-code
- npm run typecheck:worker
- npm run check:worker-boundary
- npm test
- npm run test:critical-contracts
- npm run test:merge-gate