### PR TITLE
chore(deps): sync lockfile with worker viem/workers-types bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260430.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260430.1.tgz",
-      "integrity": "sha512-Rguf/SdQNm1HG2yZi8m57K4qvVh2fic+Xny4UidY1pCgHagOAq7Cy0WIp1JKQx54T8lgOgOWFzIaCK4iwLpxlg==",
+      "version": "4.20260502.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260502.1.tgz",
+      "integrity": "sha512-gttFwGL0pYBF5nA2GIazKTVjDqXLnqWa/Mstd5aGTZyzkhmPy0ej3L2sIn2h8kAbF6I+XGK0P4UXvlmnuxefYg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -14062,9 +14062,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
-      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
+      "version": "2.48.8",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.8.tgz",
+      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
       "funding": [
         {
           "type": "github",
@@ -14689,10 +14689,10 @@
       "dependencies": {
         "@cf-wasm/resvg": "^0.3.3",
         "satori": "^0.26.0",
-        "viem": "2.48.4"
+        "viem": "2.48.8"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260430.1",
+        "@cloudflare/workers-types": "4.20260502.1",
         "typescript": "~5.9.0",
         "wrangler": "4.87.0"
       },


### PR DESCRIPTION
## Summary
- PR #104 merged the worker/package.json bumps (`viem` 2.48.4→2.48.8, `@cloudflare/workers-types` 4.20260430.1→4.20260502.1) but didn't update `package-lock.json`, so `npm ci` now fails on main.
- This PR syncs the lockfile to match.

## Test plan
- [x] `npm ci` succeeds locally
- [x] `cd worker && npx tsc --noEmit` passes
- [x] Pre-push merge-gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)