### PR TITLE
Improve reserve sync coverage rescues

### DIFF
--- a/scripts/__tests__/check-redemption-backstops.test.ts
+++ b/scripts/__tests__/check-redemption-backstops.test.ts
@@ -15,8 +15,8 @@ describe("check-redemption-backstops CLI", () => {
     });
 
     const report = JSON.parse(readFileSync(reportPath, "utf8"));
-    expect(report.summary.configuredCount).toBe(287);
-    expect(report.auditRows).toHaveLength(287);
+    expect(report.summary.configuredCount).toBe(304);
+    expect(report.auditRows).toHaveLength(304);
     expect(report.auditRows[0]).toMatchObject({
       stablecoinId: expect.any(String),
       routeFamily: expect.any(String),

--- a/shared/data/stablecoins/coins.frozen.generated.ts
+++ b/shared/data/stablecoins/coins.frozen.generated.ts
@@ -12,7 +12,7 @@ import type { StablecoinMeta } from "../../types";
 import coinsGenerated from "./coins.generated.json";
 
 /** FNV-1a 32-bit fingerprint of `coins.generated.json` at generation time. */
-export const STABLECOIN_META_ASSETS_FROZEN_HASH = "3d836b83";
+export const STABLECOIN_META_ASSETS_FROZEN_HASH = "d1cf602f";
 
 /**
  * Pre-validated stablecoin metas, exposed in source order. The generator

--- a/shared/data/stablecoins/coins.generated.json
+++ b/shared/data/stablecoins/coins.generated.json
@@ -24557,7 +24557,7 @@
     "liveReservesConfig": {
       "version": 1,
       "semantics": "protocol-reserve",
-      "breakerScope": "srusd-reservoir",
+      "breakerScope": "reservoir",
       "display": {
         "url": "https://app.reservoir.xyz/reserves",
         "label": "Proof of Reserves"
@@ -34505,7 +34505,7 @@
         "tokenAddress": "0x96F6eF951840721AdBF46Ac996b59E0235CB985C",
         "assetLabel": "Short-term U.S. Treasuries and bank deposits",
         "assetRisk": "very-low",
-        "oracleMethod": "getPrice"
+        "oracleMethod": "getPriceData"
       }
     },
     "yieldConfig": {
@@ -38250,7 +38250,7 @@
     "liveReservesConfig": {
       "version": 1,
       "semantics": "protocol-reserve",
-      "breakerScope": "wsrusd-reservoir",
+      "breakerScope": "reservoir",
       "display": {
         "url": "https://app.reservoir.xyz/reserves",
         "label": "Proof of Reserves"
@@ -40563,8 +40563,10 @@
           "[Fluid]_fUSDT0": "low",
           "Liquidity_Buffer": "low",
           "[Aave]_USDT": "medium",
+          "[Aave]_GHO": "medium",
           "[Aave]_Gho_Savings": "low",
           "[Cap]_stcUSD": "medium",
+          "[Fluid]_Gho": "medium",
           "[Fluent]_fUSDnr": "medium",
           "[GlobalDollar]_USDG": "low",
           "[Ripple]_Sentora_RLUSD": "medium",
@@ -40585,14 +40587,17 @@
           "[Paypal]_PYUSD_Loop": "high",
           "[MegaEth]_USDm": "low",
           "[Paxos]_USDG": "low",
-          "[Ethena]_sUSDe_Loop": "high"
+          "[Ethena]_sUSDe_Loop": "high",
+          "[Yuzu]_yzPRIME": "medium"
         },
         "renameMap": {
           "[Fluid]_fUSDT0": "Fluid fUSDT0",
           "Liquidity_Buffer": "Liquidity buffer",
           "[Aave]_USDT": "Aave USDT",
+          "[Aave]_GHO": "Aave GHO",
           "[Aave]_Gho_Savings": "Aave GHO Savings",
           "[Cap]_stcUSD": "Cap stcUSD",
+          "[Fluid]_Gho": "Fluid GHO",
           "[Fluent]_fUSDnr": "Fluent fUSDnr",
           "[GlobalDollar]_USDG": "Global Dollar USDG",
           "[Ripple]_Sentora_RLUSD": "Ripple RLUSD Sentora",
@@ -40613,7 +40618,8 @@
           "[Paypal]_PYUSD_Loop": "PayPal PYUSD loop",
           "[MegaEth]_USDm": "MegaETH USDm",
           "[Paxos]_USDG": "Paxos USDG",
-          "[Ethena]_sUSDe_Loop": "Ethena sUSDe loop"
+          "[Ethena]_sUSDe_Loop": "Ethena sUSDe loop",
+          "[Yuzu]_yzPRIME": "Yuzu yzPRIME"
         }
       }
     },

--- a/shared/data/stablecoins/coins/srusd-reservoir.json
+++ b/shared/data/stablecoins/coins/srusd-reservoir.json
@@ -93,7 +93,7 @@
         "source-total-gap"
       ]
     },
-    "breakerScope": "srusd-reservoir",
+    "breakerScope": "reservoir",
     "display": {
       "url": "https://app.reservoir.xyz/reserves",
       "label": "Proof of Reserves"

--- a/shared/data/stablecoins/coins/usdy-ondo-finance.json
+++ b/shared/data/stablecoins/coins/usdy-ondo-finance.json
@@ -155,7 +155,7 @@
       "tokenAddress": "0x96F6eF951840721AdBF46Ac996b59E0235CB985C",
       "assetLabel": "Short-term U.S. Treasuries and bank deposits",
       "assetRisk": "very-low",
-      "oracleMethod": "getPrice"
+      "oracleMethod": "getPriceData"
     }
   },
   "yieldConfig": {

--- a/shared/data/stablecoins/coins/wsrusd-reservoir.json
+++ b/shared/data/stablecoins/coins/wsrusd-reservoir.json
@@ -181,7 +181,7 @@
         "source-total-gap"
       ]
     },
-    "breakerScope": "wsrusd-reservoir",
+    "breakerScope": "reservoir",
     "display": {
       "url": "https://app.reservoir.xyz/reserves",
       "label": "Proof of Reserves"

--- a/shared/data/stablecoins/coins/yzusd-yuzu.json
+++ b/shared/data/stablecoins/coins/yzusd-yuzu.json
@@ -102,8 +102,10 @@
         "[Fluid]_fUSDT0": "low",
         "Liquidity_Buffer": "low",
         "[Aave]_USDT": "medium",
+        "[Aave]_GHO": "medium",
         "[Aave]_Gho_Savings": "low",
         "[Cap]_stcUSD": "medium",
+        "[Fluid]_Gho": "medium",
         "[Fluent]_fUSDnr": "medium",
         "[GlobalDollar]_USDG": "low",
         "[Ripple]_Sentora_RLUSD": "medium",
@@ -124,14 +126,17 @@
         "[Paypal]_PYUSD_Loop": "high",
         "[MegaEth]_USDm": "low",
         "[Paxos]_USDG": "low",
-        "[Ethena]_sUSDe_Loop": "high"
+        "[Ethena]_sUSDe_Loop": "high",
+        "[Yuzu]_yzPRIME": "medium"
       },
       "renameMap": {
         "[Fluid]_fUSDT0": "Fluid fUSDT0",
         "Liquidity_Buffer": "Liquidity buffer",
         "[Aave]_USDT": "Aave USDT",
+        "[Aave]_GHO": "Aave GHO",
         "[Aave]_Gho_Savings": "Aave GHO Savings",
         "[Cap]_stcUSD": "Cap stcUSD",
+        "[Fluid]_Gho": "Fluid GHO",
         "[Fluent]_fUSDnr": "Fluent fUSDnr",
         "[GlobalDollar]_USDG": "Global Dollar USDG",
         "[Ripple]_Sentora_RLUSD": "Ripple RLUSD Sentora",
@@ -152,7 +157,8 @@
         "[Paypal]_PYUSD_Loop": "PayPal PYUSD loop",
         "[MegaEth]_USDm": "MegaETH USDm",
         "[Paxos]_USDG": "Paxos USDG",
-        "[Ethena]_sUSDe_Loop": "Ethena sUSDe loop"
+        "[Ethena]_sUSDe_Loop": "Ethena sUSDe loop",
+        "[Yuzu]_yzPRIME": "Yuzu yzPRIME"
       }
     }
   },

--- a/shared/lib/live-reserve-adapters-schemas.ts
+++ b/shared/lib/live-reserve-adapters-schemas.ts
@@ -202,7 +202,7 @@ const chainlinkNavParamsSchema = z
     tokenAddress: z.string(),
     assetLabel: z.string(),
     assetRisk: LiveReserveRiskSchema,
-    oracleMethod: z.enum(["latestRoundData", "getPrice", "getAssetPrice"]).optional(),
+    oracleMethod: z.enum(["latestRoundData", "getPrice", "getPriceData", "getAssetPrice"]).optional(),
     rpcUrl: AbsoluteUrlSchema.optional(),
     fallbackRpcUrl: AbsoluteUrlSchema.optional(),
     maxOracleAgeSec: z.number().positive().optional(),

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -48,7 +48,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {
-    "dateModified": "2026-05-14T02:50:20+02:00",
+    "dateModified": "2026-05-17T16:13:17+02:00",
     "dateCreated": "2026-03-12T23:06:41+01:00"
   },
   "chain-health": {

--- a/worker/src/cron/reserve-adapters/__tests__/chainlink-nav.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/chainlink-nav.test.ts
@@ -138,9 +138,62 @@ describe("parseOndoPriceData", () => {
   });
 });
 
-describe("fetchChainlinkNavReserves getAssetPrice wrapper-oracle parse", () => {
+describe("fetchChainlinkNavReserves Ondo methods", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("reads getPriceData directly and marks freshness verified", async () => {
+    const helpers = await import("../helpers");
+    const { fetchChainlinkNavReserves } = await import("../chainlink-nav");
+    const updatedAt = 1_775_684_339;
+    const rawPriceData = "0x"
+      + "00000000000000000000000000000000000000000000000639e961576659e000"
+      + "0000000000000000000000000000000000000000000000000000000069d6caf3";
+
+    vi.mocked(helpers.fetchOnchainUint256).mockImplementation(async (opts) => {
+      if (opts.data === "0x313ce567") return 18n; // decimals()
+      if (opts.data === "0x18160ddd") return 500_000_000_000_000_000_000n; // totalSupply()
+      return null;
+    });
+    vi.mocked(helpers.fetchOnchainRawCall).mockImplementation(async (opts) => {
+      if (opts.data === "0xa4a28168" && opts.contract === ORACLE_ADDRESS) {
+        return rawPriceData;
+      }
+      return null;
+    });
+
+    const config = {
+      adapter: "chainlink-nav" as const,
+      version: 1,
+      semantics: "single-asset" as const,
+      inputs: {
+        primary: { kind: "onchain-evm" as const, chain: "ethereum", rpcMode: "public-rpc" as const },
+      },
+      params: {
+        oracleAddress: ORACLE_ADDRESS,
+        tokenAddress: TOKEN_ADDRESS,
+        assetLabel: "Ondo T-Bills",
+        assetRisk: "very-low" as const,
+        oracleMethod: "getPriceData" as const,
+      },
+    };
+
+    const result = await fetchChainlinkNavReserves(
+      {} as never,
+      config as never,
+      new AbortController().signal,
+      { nowSec: updatedAt + 60 },
+    );
+
+    expect(result.warnings).toBeUndefined();
+    expect(result.metadata).toMatchObject({
+      freshnessMode: "verified",
+      oracleTimestampSource: "ondo-price-data",
+      oracleUpdatedAt: updatedAt,
+      sourceTimestamp: updatedAt,
+    });
+    expect(result.metadata?.navPerToken).toBe("114.853438");
   });
 
   it("emits chainlink-nav-wrapper-oracle-malformed when the wrapper oracle returns garbage", async () => {

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/mento-reserve-composition.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/mento-reserve-composition.html
@@ -1,6 +1,6 @@
-<!-- captured-at: 2026-03-30T21:12:07Z -->
+<!-- minimized from Mento dashboard Next.js Flight payload; captured-at: 2026-05-17T13:48:00Z -->
 <html><body>
 <script>
-self.__next_f.push([1,"...\"reserveComposition\":[{\"symbol\":\"sUSDS\",\"percent\":54.8},{\"symbol\":\"EURC\",\"percent\":19.9},{\"symbol\":\"CELO\",\"percent\":13.5},{\"symbol\":\"USDGLO\",\"percent\":5.0},{\"symbol\":\"stETH\",\"percent\":2.6},{\"symbol\":\"USDT\",\"percent\":2.1},{\"symbol\":\"USDC\",\"percent\":1.2},{\"symbol\":\"ETH\",\"percent\":0.9}],\"reserveHoldings\":{}..."]);
+self.__next_f.push([1,"...\\\"cdp_backings\\\":[{\\\"stablecoin\\\":\\\"GBPm\\\",\\\"collateral_token\\\":\\\"USDm\\\"}],\\\"timestamp\\\":\\\"2026-05-17T13:46:16.506Z\\\"},\\\"dataUpdateCount\\\":1,\\\"dataUpdatedAt\\\":1779025576506,..."]);
 </script>
 </body></html>

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/mento-reserve-composition.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/mento-reserve-composition.html
@@ -1,4 +1,5 @@
-<!-- minimized from Mento dashboard Next.js Flight payload; captured-at: 2026-05-17T13:48:00Z -->
+<!-- captured-at: 2026-05-17T13:48:00Z -->
+<!-- minimized from Mento dashboard Next.js Flight payload -->
 <html><body>
 <script>
 self.__next_f.push([1,"...\\\"cdp_backings\\\":[{\\\"stablecoin\\\":\\\"GBPm\\\",\\\"collateral_token\\\":\\\"USDm\\\"}],\\\"timestamp\\\":\\\"2026-05-17T13:46:16.506Z\\\"},\\\"dataUpdateCount\\\":1,\\\"dataUpdatedAt\\\":1779025576506,..."]);

--- a/worker/src/cron/reserve-adapters/__tests__/helpers.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/helpers.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../../lib/fetch-retry", () => ({
 
 import { fetchWithRetry } from "../../../lib/fetch-retry";
 import {
+  ADAPTER_USER_AGENT,
   accumulateBucketedExposure,
   buildRedemptionSnapshotMetadata,
   buildBucketSlices,
@@ -452,7 +453,7 @@ describe("fetchJsonWithRetry", () => {
         signal,
         headers: {
           Accept: "application/json",
-          "User-Agent": "Mozilla/5.0",
+          "User-Agent": ADAPTER_USER_AGENT,
         },
       },
       2,
@@ -503,7 +504,7 @@ describe("fetchJsonWithRetry", () => {
         signal,
         headers: {
           Accept: "application/json",
-          "User-Agent": "Mozilla/5.0",
+          "User-Agent": ADAPTER_USER_AGENT,
           Referer: "https://example.com/app",
         },
       },

--- a/worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts
@@ -105,6 +105,27 @@ describe("adaptInfiniFi", () => {
     ]);
   });
 
+  it("recognizes current Liquid Cap and CoW Swap fxSave positions", () => {
+    const response: InfiniFiProtocolData = {
+      ...SAMPLE_RESPONSE,
+      data: {
+        ...SAMPLE_RESPONSE.data,
+        farms: [
+          { name: "liquid-cap", label: "Liquid Cap", assetsNormalized: 60, type: "ILLIQUID", underlyingAssetSymbol: "stcUSD" },
+          { name: "cowswap-fxSave", label: "CoW Swap fxSave", assetsNormalized: 40, type: "ILLIQUID", underlyingAssetSymbol: "fxUSD" },
+        ],
+        stats: { asset: { totalTVLAssetNormalized: 100 } },
+      },
+    };
+
+    const result = adaptInfiniFi(response);
+    expect(result.unknownFarms).toEqual([]);
+    expect(result.slices).toEqual([
+      { name: "Liquid Cap", pct: 60, risk: "medium" },
+      { name: "CoW Swap fxSave", pct: 40, risk: "medium" },
+    ]);
+  });
+
   it("flags dust unknown farms and preserves them in final slices when they remain material at one-decimal precision", () => {
     const response: InfiniFiProtocolData = {
       ...SAMPLE_RESPONSE,

--- a/worker/src/cron/reserve-adapters/__tests__/mento.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/mento.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   adaptMentoCdpComposition,
@@ -9,6 +12,9 @@ import {
 } from "../mento";
 import { getReserveAdapter } from "../index";
 import { validateAdapterOutput } from "../validate";
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const CURRENT_DASHBOARD_HTML = readFileSync(join(FIXTURES_DIR, "mento-reserve-composition.html"), "utf8");
 
 const SAMPLE_PAYLOAD = {
   collateral: {
@@ -128,17 +134,31 @@ describe("mento adapter", () => {
     });
   });
 
-  it("extracts the dashboard reserve payload timestamp", () => {
+  it("extracts the historical dashboard reserve payload timestamp", () => {
     expect(extractMentoDashboardTimestamp(
-      'troves\\":[{}],\\"timestamp\\":\\"2026-05-11T23:21:16.007Z\\"},\\"dataUpdateCount\\":1',
+      String.raw`troves\":[{}],\"timestamp\":\"2026-05-11T23:21:16.007Z\"},\"dataUpdateCount\":1`,
     )).toBe(Math.floor(Date.parse("2026-05-11T23:21:16.007Z") / 1000));
+  });
+
+  it("extracts the current cdp_backings dashboard timestamp with deeper escaped quotes", () => {
+    expect(extractMentoDashboardTimestamp(CURRENT_DASHBOARD_HTML)).toBe(
+      Math.floor(Date.parse("2026-05-17T13:46:16.506Z") / 1000),
+    );
+  });
+
+  it("falls back to numeric dashboard dataUpdatedAt milliseconds", () => {
+    const html = String.raw`...\\"cdp_backings\\":[{\\"stablecoin\\":\\"GBPm\\"}],\\"dataUpdateCount\\":1,\\"dataUpdatedAt\\":1779025576506`;
+
+    expect(extractMentoDashboardTimestamp(html)).toBe(
+      Math.floor(Date.parse("2026-05-17T13:46:16.506Z") / 1000),
+    );
   });
 
   it("ignores unrelated timestamps that appear outside the troves/dataUpdateCount anchor window", () => {
     const buildManifest =
-      'buildManifest\\":{\\"timestamp\\":\\"2099-01-01T00:00:00.000Z\\"},\\"polyfillFiles\\":[]';
+      String.raw`buildManifest\":{\"timestamp\":\"2099-01-01T00:00:00.000Z\"},\"polyfillFiles\":[]`;
     const anchoredPayload =
-      'troves\\":[{}],\\"timestamp\\":\\"2026-05-11T23:21:16.007Z\\"},\\"dataUpdateCount\\":1';
+      String.raw`troves\":[{}],\"timestamp\":\"2026-05-11T23:21:16.007Z\"},\"dataUpdateCount\":1`;
     const html = `${buildManifest}${"x".repeat(1024)}${anchoredPayload}`;
 
     expect(extractMentoDashboardTimestamp(html)).toBe(
@@ -264,7 +284,7 @@ describe("mento adapter", () => {
           [
             "text-get:https://reserve.mento.org/:12000",
             Promise.resolve(
-              'troves\\":[{}],\\"timestamp\\":\\"2026-05-11T23:21:16.007Z\\"},\\"dataUpdateCount\\":1',
+              String.raw`troves\":[{}],\"timestamp\":\"2026-05-11T23:21:16.007Z\"},\"dataUpdateCount\":1`,
             ),
           ],
         ]),

--- a/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
@@ -141,7 +141,7 @@ describe("adaptReservoirReserves", () => {
       new AbortController().signal,
       {
         requestCache: new Map([
-          ["json-get:https://example.com/reservoir:12000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve(SAMPLE_RESPONSE)],
+          ["json-get:https://example.com/reservoir:20000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve(SAMPLE_RESPONSE)],
         ]),
       } as never,
     );
@@ -171,7 +171,7 @@ describe("adaptReservoirReserves", () => {
       new AbortController().signal,
       {
         requestCache: new Map([
-          ["json-get:https://example.com/reservoir:12000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
+          ["json-get:https://example.com/reservoir:20000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
             ...SAMPLE_RESPONSE,
             assets: [
               ...SAMPLE_RESPONSE.assets,
@@ -207,7 +207,7 @@ describe("adaptReservoirReserves", () => {
       new AbortController().signal,
       {
         requestCache: new Map([
-          ["json-get:https://example.com/reservoir:12000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
+          ["json-get:https://example.com/reservoir:20000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
             ...SAMPLE_RESPONSE,
             totalAssets: "125",
           })],
@@ -235,7 +235,7 @@ describe("adaptReservoirReserves", () => {
       new AbortController().signal,
       {
         requestCache: new Map([
-          ["json-get:https://example.com/reservoir:12000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
+          ["json-get:https://example.com/reservoir:20000:{\"Origin\":\"https://app.reservoir.xyz\",\"Referer\":\"https://app.reservoir.xyz/reserves\",\"Accept-Language\":\"en-US,en;q=0.9\"}", Promise.resolve({
             ...SAMPLE_RESPONSE,
             totalAssets: "100",
             totalLiabilities: "120",

--- a/worker/src/cron/reserve-adapters/chainlink-nav-core.ts
+++ b/worker/src/cron/reserve-adapters/chainlink-nav-core.ts
@@ -42,8 +42,9 @@ export interface ChainlinkNavParams {
   assetRisk: ReserveSlice["risk"];
   /** "latestRoundData" (default) = standard AggregatorV3Interface;
    *  "getPrice" = Ondo-style oracle returning a single uint256 with 18 decimals.
+   *  "getPriceData" = Ondo-style oracle returning uint256 price + uint256 timestamp.
    *  "getAssetPrice" = Ondo oracle router returning a token-scoped uint256 with 18 decimals. */
-  oracleMethod?: "latestRoundData" | "getPrice" | "getAssetPrice";
+  oracleMethod?: "latestRoundData" | "getPrice" | "getPriceData" | "getAssetPrice";
   rpcUrl?: string;
   fallbackRpcUrl?: string;
   maxOracleAgeSec?: number;
@@ -195,6 +196,21 @@ export async function fetchChainlinkNavCore(
       "oracle-freshness-unverified",
       "chainlink-nav getPrice() mode does not expose an oracle update timestamp",
     ));
+  } else if (method === "getPriceData") {
+    const rawPriceData = await fetchOnchainRawCall({
+      ...oracleCallBase,
+      data: GET_PRICE_DATA_SELECTOR,
+    });
+    if (rawPriceData == null) {
+      throw new Error("chainlink-nav: getPriceData() call failed");
+    }
+
+    const parsed = parseOndoPriceData(rawPriceData);
+    navPerToken = parsed.price;
+    navDecimals = 18;
+    roundId = 0n;
+    updatedAt = parsed.updatedAt;
+    oracleTimestampSource = "ondo-price-data";
   } else if (method === "getAssetPrice") {
     const rawPrice = await fetchOnchainUint256({
       ...oracleCallBase,

--- a/worker/src/cron/reserve-adapters/helpers.ts
+++ b/worker/src/cron/reserve-adapters/helpers.ts
@@ -41,7 +41,13 @@ export {
   readHtmlAttribute,
   stripTags,
 } from "./html";
-export { fetchJsonPostWithRetry, fetchJsonWithRetry, fetchPrimaryHtmlInput, fetchTextWithRetry } from "./request";
+export {
+  ADAPTER_USER_AGENT,
+  fetchJsonPostWithRetry,
+  fetchJsonWithRetry,
+  fetchPrimaryHtmlInput,
+  fetchTextWithRetry,
+} from "./request";
 export { fetchDefiLlamaPrices } from "./defillama";
 export {
   fetchErc20Balance,

--- a/worker/src/cron/reserve-adapters/infinifi.ts
+++ b/worker/src/cron/reserve-adapters/infinifi.ts
@@ -65,6 +65,8 @@ const FARM_RISK_MAP: Record<string, FarmRiskConfig> = {
   "gauntlet-alpha-farm":     { risk: "medium" },
   "reservoir-wsrUSD":        { risk: "medium" },
   "sGHO":                    { risk: "medium", ...wrapperAssetMeta("gho") },
+  "liquid-cap":              { risk: "medium" },
+  "cowswap-fxSave":          { risk: "medium" },
 };
 
 const SOURCE_TOTAL_RECONCILIATION_THRESHOLD_PCT = 0.5;

--- a/worker/src/cron/reserve-adapters/mento.ts
+++ b/worker/src/cron/reserve-adapters/mento.ts
@@ -55,13 +55,55 @@ interface MentoReserveApiResponse {
 }
 
 // The Mento dashboard ships its reserve payload as a React Query cache entry
-// embedded in the Next.js Flight payload. The reserve-scoped timestamp always
-// appears between the `troves` array and the `dataUpdateCount` cache marker
-// (i.e. it is the React Query entry's payload-update timestamp, not some
-// unrelated build-manifest or news timestamp). Anchoring on those neighbours
-// rules out the many unrelated `"timestamp":"..."` occurrences in the bundle.
-const MENTO_DASHBOARD_TIMESTAMP_PATTERN =
-  /troves\\?"\s*:\s*\[[\s\S]*?\]\s*,\s*\\?"timestamp\\?"\s*:\s*\\?"([^"\\]+)\\?"[\s\S]{0,128}?\\?"dataUpdateCount\\?"/;
+// embedded in the Next.js Flight payload. The reserve-scoped timestamp appears
+// near the historical `troves` array or the current `cdp_backings` array and the
+// `dataUpdateCount` cache marker. Anchoring on those neighbours rules out the
+// many unrelated `"timestamp":"..."` occurrences in the bundle.
+const MENTO_DASHBOARD_PAYLOAD_KEYS = ["cdp_backings", "troves"] as const;
+const MENTO_DASHBOARD_MAX_ESCAPE_DEPTH = 5;
+const MENTO_DASHBOARD_PAYLOAD_WINDOW_CHARS = 64_000;
+const MENTO_DASHBOARD_TIMESTAMP_IN_WINDOW_PATTERN =
+  /\\{1,5}"timestamp\\{1,5}"\s*:\s*\\{1,5}"([^"\\]+)\\{1,5}"/;
+const MENTO_DASHBOARD_DATA_UPDATE_COUNT_IN_WINDOW_PATTERN = /\\{1,5}"dataUpdateCount\\{1,5}"/;
+const MENTO_DASHBOARD_DATA_UPDATED_AT_IN_WINDOW_PATTERN = /\\{1,5}"dataUpdatedAt\\{1,5}"\s*:\s*(\d{13,})/;
+
+function hasEscapedQuoteAt(value: string, index: number): boolean {
+  let slashCount = 0;
+  while (
+    slashCount < MENTO_DASHBOARD_MAX_ESCAPE_DEPTH &&
+    value[index + slashCount] === "\\"
+  ) {
+    slashCount += 1;
+  }
+
+  return slashCount > 0 && value[index + slashCount] === "\"";
+}
+
+function findDashboardPayloadKeyIndex(html: string, key: string): number | null {
+  let keyIndex = html.indexOf(key);
+  while (keyIndex >= 0) {
+    if (hasEscapedQuoteAt(html, keyIndex + key.length)) {
+      return keyIndex;
+    }
+    keyIndex = html.indexOf(key, keyIndex + key.length);
+  }
+
+  return null;
+}
+
+function extractMentoDashboardPayloadWindow(html: string): string | null {
+  for (const key of MENTO_DASHBOARD_PAYLOAD_KEYS) {
+    const keyIndex = findDashboardPayloadKeyIndex(html, key);
+    if (keyIndex != null) {
+      return html.slice(
+        keyIndex,
+        Math.min(html.length, keyIndex + MENTO_DASHBOARD_PAYLOAD_WINDOW_CHARS),
+      );
+    }
+  }
+
+  return null;
+}
 
 interface TokenConfig {
   key: string;
@@ -248,8 +290,17 @@ export function parseMentoCdpComposition(payload: unknown, cdpStablecoin: MentoC
 }
 
 export function extractMentoDashboardTimestamp(html: string): number | null {
-  const timestamp = html.match(MENTO_DASHBOARD_TIMESTAMP_PATTERN)?.[1];
-  return parseTimestampLikeToUnixSeconds(timestamp);
+  const payloadWindow = extractMentoDashboardPayloadWindow(html);
+  if (!payloadWindow) return null;
+
+  const timestamp = payloadWindow.match(MENTO_DASHBOARD_TIMESTAMP_IN_WINDOW_PATTERN)?.[1];
+  const parsedTimestamp = parseTimestampLikeToUnixSeconds(timestamp);
+  if (parsedTimestamp != null && MENTO_DASHBOARD_DATA_UPDATE_COUNT_IN_WINDOW_PATTERN.test(payloadWindow)) {
+    return parsedTimestamp;
+  }
+
+  const dataUpdatedAt = payloadWindow.match(MENTO_DASHBOARD_DATA_UPDATED_AT_IN_WINDOW_PATTERN)?.[1];
+  return parseTimestampLikeToUnixSeconds(dataUpdatedAt);
 }
 
 export function adaptMentoReserveComposition(payload: unknown, sourceTimestamp: number | null = null): AdapterResult {

--- a/worker/src/cron/reserve-adapters/request.ts
+++ b/worker/src/cron/reserve-adapters/request.ts
@@ -5,7 +5,7 @@ import { requireHtmlInput } from "./input-guards";
 import type { AdapterContext } from "./types";
 import { runAdapterIo } from "./concurrency";
 
-const ADAPTER_USER_AGENT = "Mozilla/5.0";
+const ADAPTER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
 
 /**
  * Some issuer dashboards gate their JSON/HTML endpoints with CORS-style

--- a/worker/src/cron/reserve-adapters/request.ts
+++ b/worker/src/cron/reserve-adapters/request.ts
@@ -5,7 +5,7 @@ import { requireHtmlInput } from "./input-guards";
 import type { AdapterContext } from "./types";
 import { runAdapterIo } from "./concurrency";
 
-const ADAPTER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+export const ADAPTER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
 
 /**
  * Some issuer dashboards gate their JSON/HTML endpoints with CORS-style

--- a/worker/src/cron/reserve-adapters/reservoir.ts
+++ b/worker/src/cron/reserve-adapters/reservoir.ts
@@ -198,7 +198,7 @@ export async function fetchReservoirReserves(
   const payload = await fetchJsonWithRetry<ReservoirReservesResponse>(
     primaryInput.url,
     signal,
-    12_000,
+    20_000,
     ctx,
     { headers: RESERVOIR_BROWSER_HEADERS },
   );


### PR DESCRIPTION
## Summary
- harden Mento reserve timestamp parsing for the current cdp_backings payload shape
- switch USDY Chainlink NAV to getPriceData and extend schema/test coverage
- add verified Yuzu/InfiniFi/reservoir operational rescues and regenerate derived stablecoin artifacts

## Validation
- npm test -- worker/src/cron/reserve-adapters/__tests__/mento.test.ts worker/src/cron/reserve-adapters/__tests__/chainlink-nav.test.ts worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts worker/src/cron/reserve-adapters/__tests__/request.test.ts shared/lib/__tests__/stablecoins.test.ts shared/lib/__tests__/live-reserve-adapters-schemas.test.ts
- npm run check:stablecoin-data
- npm run check:doc-counts
- npm run check:generated-artifacts
- npm run typecheck
- npm run typecheck:worker
- npm run lint
- git diff --check

## Deferred
- methodology unlocks for live-aggregator JSON APIs
- stale-source maxSourceAgeSec relaxations for AZND/UTY/FDUSD
- XOFm/asUSDF/NECT reassignments and broader new adapter work pending exact source/feed verification