### PR TITLE
fix(ui): prevent horizontal overflow in feedback description textarea

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1456,17 +1456,3 @@
     --dews-radar-calm-dot-bloom: transparent;
   }
 }
-
-/* Fix #144 - Feedback modal long text (URLs, hashes, etc.) overflow */
-[data-slot="textarea"],
-textarea {
-  overflow-wrap: break-word !important;
-  word-break: break-word !important;
-  white-space: pre-wrap !important;
-  hyphens: auto;
-}
-
-/* Slightly wider feedback modal for better UX */
-[role="dialog"] {
-  max-width: 560px !important;
-}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1456,3 +1456,17 @@
     --dews-radar-calm-dot-bloom: transparent;
   }
 }
+
+/* Fix #144 - Feedback modal long text (URLs, hashes, etc.) overflow */
+[data-slot="textarea"],
+textarea {
+  overflow-wrap: break-word !important;
+  word-break: break-word !important;
+  white-space: pre-wrap !important;
+  hyphens: auto;
+}
+
+/* Slightly wider feedback modal for better UX */
+[role="dialog"] {
+  max-width: 560px !important;
+}

--- a/src/components/feedback-modal.tsx
+++ b/src/components/feedback-modal.tsx
@@ -131,7 +131,7 @@ export function FeedbackModal({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Send Feedback</DialogTitle>
         </DialogHeader>
@@ -203,7 +203,8 @@ export function FeedbackModal({
                 rows={4}
                 maxLength={2000}
                 disabled={status === "loading"}
-                className="resize-none"
+                className="max-w-full resize-none whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
+                style={{ fieldSizing: "fixed" }}
               />
               <p className="text-xs text-muted-foreground text-right">
                 {description.length}/2000


### PR DESCRIPTION
**Fixes #144**

### Problem
Pasting long strings (e.g. full Etherscan transaction URLs or long hashes) into the feedback description field caused horizontal overflow and broke the modal UI.

### Solution
Added CSS rules in `src/app/globals.css` for proper text wrapping (`overflow-wrap`, `word-break`, `white-space: pre-wrap`) and slightly increased modal max-width.

Tested locally; long URLs now wrap cleanly.
<img width="728" height="553" alt="image" src="https://github.com/user-attachments/assets/afe1d816-14eb-438d-ba3e-41c92f3b8e72" />
