### PR TITLE
fix(worker): preserve fetch retry timeout through body reads

### DIFF
--- a/worker/src/lib/__tests__/fetch-retry.test.ts
+++ b/worker/src/lib/__tests__/fetch-retry.test.ts
@@ -22,6 +22,7 @@ describe("fetchWithRetry", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -118,4 +119,31 @@ describe("fetchWithRetry", () => {
     expect(sleepWithSignalMock).toHaveBeenNthCalledWith(1, 5000, undefined);
     expect(sleepWithSignalMock).toHaveBeenNthCalledWith(2, 10000, undefined);
   });
+
+  it("keeps the per-request timeout active while callers consume the response body", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      return new Response(new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+          controller.close();
+        },
+      }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.test/slow-body", undefined, 0, { timeoutMs: 200 });
+    expect(res).not.toBeNull();
+
+    const bodyRead = res!.text();
+    const assertion = expect(bodyRead).rejects.toMatchObject({ name: "TimeoutError" });
+    await vi.advanceTimersByTimeAsync(201);
+
+    await assertion;
+  });
+
 });

--- a/worker/src/lib/fetch-retry.ts
+++ b/worker/src/lib/fetch-retry.ts
@@ -7,6 +7,44 @@ interface FetchWithRetryOptions {
   returnFinalResponse?: boolean;
   timeoutMs?: number;
 }
+
+function responseWithTimeoutLifetime(response: Response, dispose: () => void): Response {
+  if (!response.body) {
+    dispose();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let disposed = false;
+  const disposeOnce = () => {
+    if (disposed) return;
+    disposed = true;
+    dispose();
+  };
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          disposeOnce();
+          controller.close();
+          return;
+        }
+        controller.enqueue(result.value);
+      } catch (err) {
+        disposeOnce();
+        controller.error(err);
+      }
+    },
+    async cancel(reason) {
+      disposeOnce();
+      await reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, response);
+}
+
 function getRetryDelayMs(response: Response, attempt: number): number | null {
   if (response.status === 429) {
     const retryAfter = response.headers.get("Retry-After");
@@ -46,15 +84,11 @@ export async function fetchWithRetry(
         timeoutReason: new DOMException(`fetch timed out after ${timeoutMs}ms`, "TimeoutError"),
         parentSignal: signal,
       });
-      let res: Response;
-      try {
-        res = await fetch(url, {
-          ...opts,
-          signal: perRequestTimeout.signal,
-        });
-      } finally {
-        perRequestTimeout.dispose();
-      }
+      const fetched = await fetch(url, {
+        ...opts,
+        signal: perRequestTimeout.signal,
+      });
+      const res = responseWithTimeoutLifetime(fetched, perRequestTimeout.dispose);
       if (res.ok) return res;
       if (passthroughStatuses.has(res.status)) {
         const passthroughDelayMs = res.status === 429 ? getRetryDelayMs(res, i) : null;


### PR DESCRIPTION
### Motivation
- The per-attempt timeout created by `fetchWithRetry` was being disposed as soon as `fetch()` returned headers, which allowed malicious or broken upstreams to stall the response body and bypass the configured per-request timeout, hurting availability.
- The change aims to preserve the existing retry/timeout semantics while ensuring the configured timeout also protects downstream body consumption such as `res.text()`/`res.json()`.

### Description
- Add `responseWithTimeoutLifetime(response, dispose)` which wraps the returned `Response` body with a `ReadableStream` that calls `dispose()` on EOF, read error, or cancel so the per-attempt timer remains active while the body is consumed.
- Replace the immediate `perRequestTimeout.dispose()` after `fetch()` with wrapping the fetched response via `responseWithTimeoutLifetime(...)` so cleanup happens only after the body lifetime ends.
- Implement the wrapper using the response `body.getReader()` and a `ReadableStream` that forwards chunks and guarantees `dispose()` runs exactly once on completion, error, or cancellation.
- Add a regression unit test that simulates a slow/dripping body and verifies that a caller-side `res.text()` rejects with the configured `TimeoutError` when the per-request timeout elapses.

### Testing
- Ran the focused unit test `npx vitest run worker/src/lib/__tests__/fetch-retry.test.ts` and it passed (including the new regression test). 
- Ran `npm run typecheck:worker` and the Worker TypeScript checks passed. 
- Ran `npm run check:provider-resilience` and the provider resilience registry validation passed. 
- Verified `git diff --check` (no whitespace/errors) and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33dcdb6a54833292eb146ff6102ccf)