### PR TITLE
fix(worker-scripts): redact RPC URLs in reconciliation logs

### DIFF
--- a/worker/scripts/__tests__/reconcile-blacklist-events-from-kyc-rip.test.ts
+++ b/worker/scripts/__tests__/reconcile-blacklist-events-from-kyc-rip.test.ts
@@ -75,6 +75,34 @@ describe("event kyc.rip reconciliation", () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining("receipt fetch failed"));
   });
 
+  it("redacts secret-bearing RPC URLs from receipt fetch errors", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okPayload(eventRows));
+    const d1 = createRemoteD1Mock([]);
+    const client = {
+      getTransactionReceipt: vi.fn().mockRejectedValue(
+        new Error(
+          "HTTP request failed. URL: https://eth-mainnet.g.alchemy.com/v2/LEAKED_ALCHEMY_KEY?token=LEAKED_QUERY_SECRET Status: 429",
+        ),
+      ),
+      getBlock: vi.fn(),
+    } as never;
+    const log = vi.fn();
+
+    await runEventReconciliation(
+      { apply: true, remote: true, database: "stablecoin-db", timeoutMs: 1000, minRows: 1 },
+      { fetchImpl, d1, client, log },
+    );
+
+    const receiptFailureLog = log.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes("receipt fetch failed"));
+
+    expect(receiptFailureLog).toContain("https://eth-mainnet.g.alchemy.com/[redacted]");
+    expect(receiptFailureLog).toContain("Status: 429");
+    expect(receiptFailureLog).not.toContain("LEAKED_ALCHEMY_KEY");
+    expect(receiptFailureLog).not.toContain("LEAKED_QUERY_SECRET");
+  });
+
   it("queries D1 in apply mode and skips inserts for already-known addresses", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(okPayload(eventRows));
     const d1 = createRemoteD1Mock([

--- a/worker/scripts/reconcile-blacklist-events-from-kyc-rip.ts
+++ b/worker/scripts/reconcile-blacklist-events-from-kyc-rip.ts
@@ -174,6 +174,24 @@ function parseReceiptLogs(config: ContractEventConfig, logs: ParsedReceiptLog[])
   return rows;
 }
 
+function redactUrlSecrets(message: string): string {
+  return message.replace(/https?:\/\/[^\s)'",]+/g, (rawUrl) => {
+    try {
+      const url = new URL(rawUrl);
+      return `${url.origin}/[redacted]`;
+    } catch {
+      return "[redacted-url]";
+    }
+  });
+}
+
+function formatRpcErrorForLog(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${redactUrlSecrets(error.message)}`;
+  }
+  return redactUrlSecrets(String(error));
+}
+
 function buildInsertStatement(row: BlacklistRow): string {
   return `INSERT OR IGNORE INTO blacklist_events
     (id, stablecoin, chain_id, chain_name, event_type, address, amount, amount_native, amount_usd_at_event, amount_source, amount_status, tx_hash, block_number, timestamp, methodology_version, contract_address, config_key, event_signature, event_topic0, amount_attempt_count, amount_last_attempted_at, amount_last_error_class, amount_last_provider, explorer_tx_url, explorer_address_url)
@@ -248,7 +266,7 @@ export async function runEventReconciliation(
       }
     } catch (error) {
       dependencies.log?.(
-        `Skipping ${candidate.asset} ${candidate.tx_hash}: receipt fetch failed (${error instanceof Error ? error.message : String(error)})`,
+        `Skipping ${candidate.asset} ${candidate.tx_hash}: receipt fetch failed (${formatRpcErrorForLog(error)})`,
       );
     }
   }


### PR DESCRIPTION
### Motivation

- Prevent secret-bearing RPC provider URLs supplied via `ETHEREUM_RPC_URL` from being written to operator/CI logs when viem HTTP errors include the full request URL.

### Description

- Add `redactUrlSecrets()` to remove path/query parts of HTTP(S) URLs and return the origin plus `/[redacted]` when formatting messages.
- Add `formatRpcErrorForLog()` to preserve the error class while sanitizing any embedded URLs before logging.
- Replace the raw `error.message` usage in the receipt-fetch `catch` with `formatRpcErrorForLog(error)` so provider API keys are not emitted.
- Add a regression unit test that simulates an Alchemy-style secret-bearing RPC URL in a fetch error and asserts the logged message is redacted but retains status context.

### Testing

- Ran `npx vitest run worker/scripts/__tests__/reconcile-blacklist-events-from-kyc-rip.test.ts` and all tests passed.
- Ran type checking with `cd worker && npx tsc --noEmit` and the build check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33df877f6883328ff22f1346dce69e)