### PR TITLE
fix(dex-liquidity): ignore stale staged rows in identity counts

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
@@ -334,6 +334,86 @@ describe("mergeStagedPools", () => {
     ]);
   });
 
+  it("does not let stale zero-confidence rows make fresh duplicate fingerprints ambiguous", async () => {
+    const now = 1710000000;
+    const stalePoolAddress = "0x0000000000000000000000000000000000000999";
+    const mockDb = createMockDb([
+      {
+        pool_id: `ethereum:${newPoolAddress}`,
+        stablecoin_id: "usdt-tether",
+        source: "gecko_terminal",
+        chain: "ethereum",
+        protocol: "pancakeswap",
+        dex_id: "pancakeswap-v3",
+        symbol: "USDT/USDC",
+        tvl_usd: 100000,
+        volume_24h: 50000,
+        quality_multiplier: 0.5,
+        pool_type: "gt-concentrated",
+        fee_tier: null,
+        balance_ratio: null,
+        is_stable: 1,
+        base_token: baseToken,
+        quote_token: quoteToken,
+        quote_symbol: "USDC",
+        price_usd: 1,
+        locked_liq_pct: null,
+        discovered_at: now - 100000,
+        refreshed_at: now,
+      },
+      {
+        pool_id: `ethereum:${stalePoolAddress}`,
+        stablecoin_id: "usdt-tether",
+        source: "gecko_terminal",
+        chain: "ethereum",
+        protocol: "pancakeswap",
+        dex_id: "pancakeswap-v3",
+        symbol: "USDT/USDC",
+        tvl_usd: 100000,
+        volume_24h: 50000,
+        quality_multiplier: 0.5,
+        pool_type: "gt-concentrated",
+        fee_tier: null,
+        balance_ratio: null,
+        is_stable: 1,
+        base_token: baseToken,
+        quote_token: quoteToken,
+        quote_symbol: "USDC",
+        price_usd: 1,
+        locked_liq_pct: null,
+        discovered_at: now - 100000,
+        refreshed_at: now - 86400 - 30,
+      },
+    ]);
+    const metrics = new Map();
+    const knownPoolIndex = makeKnownPoolIndex([
+      `derived:ethereum:pancakeswap-v3:${baseToken}:${quoteToken}:gt-concentrated:na:stable`,
+    ]);
+
+    const result = await mergeStagedPools(mockDb, metrics, knownPoolIndex, now);
+
+    expect(result.skippedCount).toBe(2);
+    expect(result.skippedByUniqueDerivedIdentityCount).toBe(1);
+    expect(result.mergedCount).toBe(0);
+    expect(metrics.size).toBe(0);
+    expect(result.skipDimensions).toEqual([
+      {
+        reason: "duplicate_unique_derived_identity",
+        protocol: "pancakeswap",
+        chain: "ethereum",
+        count: 1,
+        conflict: "derived_unique",
+      },
+      {
+        reason: "stale_confidence_zero",
+        protocol: "pancakeswap",
+        chain: "ethereum",
+        count: 1,
+        threshold: 24,
+      },
+    ]);
+  });
+
   it("skips one staged exact-pool-id pool that uniquely matches an identity-poor DL row", async () => {
     const now = 1710000000;
     const uniswapV4PoolAddress = "0x5d0ed52610c76d7bf729130ce7ddc0488b2f4bd0a0db1f12adbe6a32deaff893";

--- a/worker/src/cron/dex-liquidity/staging-merge.ts
+++ b/worker/src/cron/dex-liquidity/staging-merge.ts
@@ -286,6 +286,7 @@ export async function mergeStagedPools(
     qualityMultiplier: number;
     orderbookMetadata: CgTickerOrderbookMetadata | null;
     identity: ReturnType<typeof buildPoolIdentity>;
+    confidence: number;
   }> = [];
 
   for (const row of rows) {
@@ -327,6 +328,8 @@ export async function mergeStagedPools(
       feeTierBps: stagedPool.feeTier,
       isStable: stagedPool.isStable,
     });
+    const ageHours = (nowSec - stagedPool.refreshedAt) / 3600;
+    const confidence = stagedPoolConfidence(ageHours);
     stagedEntries.push({
       stagedPool,
       dexId: profile.dexId,
@@ -334,17 +337,18 @@ export async function mergeStagedPools(
       qualityMultiplier: profile.qualityMultiplier,
       orderbookMetadata,
       identity,
+      confidence,
     });
   }
-  const stagedIdentityCounts = countPoolIdentityKeys(stagedEntries.map((entry) => entry.identity));
+  const stagedIdentityCounts = countPoolIdentityKeys(
+    stagedEntries.filter((entry) => entry.confidence > 0).map((entry) => entry.identity),
+  );
 
   for (const entry of stagedEntries) {
-    const { stagedPool, dexId, poolType, qualityMultiplier, orderbookMetadata, identity } = entry;
+    const { stagedPool, dexId, poolType, qualityMultiplier, orderbookMetadata, identity, confidence } = entry;
     const normalizedProtocol = normalizeProtocol(stagedPool.protocol || dexId);
 
     // Compute confidence and adjusted TVL early — needed for price observation gate
-    const ageHours = (nowSec - stagedPool.refreshedAt) / 3600;
-    const confidence = stagedPoolConfidence(ageHours);
     if (confidence === 0) {
       skippedCount++;
       incrementSkipDimension(skipDimensions, "stale_confidence_zero", stagedPool, { threshold: 24 });


### PR DESCRIPTION
### Motivation
- A widened staging read window allowed zero-confidence (stale) rows into the merge pipeline and those rows were being counted in identity-ambiguity buckets before the stale filter ran, which could disable derived/wildcard deduplication and let fresh duplicates merge.
- The change aims to ensure identity-counts used for deduplication reflect only entries that remain eligible (non-zero confidence) so duplicate suppression remains correct.

### Description
- Compute `confidence` for each staged row while building the `stagedEntries` array and store it as a new `confidence` field on each entry in `worker/src/cron/dex-liquidity/staging-merge.ts`.
- Build `stagedIdentityCounts` by calling `countPoolIdentityKeys` only on the subset `stagedEntries.filter(entry => entry.confidence > 0)` so zero-confidence rows are excluded from dedup buckets.
- Reuse the precomputed `confidence` during the main merge loop to preserve the existing `stale_confidence_zero` skip behavior and price-observation extraction.
- Add a regression test in `worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts` proving a stale zero-confidence row sharing a derived identity does not make a fresh row ambiguous.

### Testing
- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts` and the suite passed (`1` test file, `27` tests passed).
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33df87166c833280506c0713ebe81a)