### PR TITLE
fix(tape): guard cause-of-death metadata lookup

### DIFF
--- a/src/components/tape/event-card.test.tsx
+++ b/src/components/tape/event-card.test.tsx
@@ -293,6 +293,28 @@ describe("EventCard enrichment", () => {
     expect(screen.getByText("abandoned")).toBeTruthy();
   });
 
+  it("cemetery falls back to malformed prototype-key cause strings", () => {
+    const event = makeEvent({
+      type: "cemetery.entry.added",
+      severity: "notice",
+      title: "USDH entered cemetery (peak $14.0M)",
+      summary: "First Solana CDP, last one standing.",
+      coinId: "usdh-hubble-2026-05",
+      payload: {
+        symbol: "USDH",
+        name: "Hubble USDH",
+        causeOfDeath: "constructor",
+        deathDate: "2026-05",
+        peakMcap: 14_000_000,
+        sourceUrl: "https://www.coingecko.com/en/coins/usdh",
+        sourceLabel: "CoinGecko",
+      },
+      sourceUrl: "/cemetery/",
+    });
+    render(<EventCard event={event} />);
+    expect(screen.getByText("constructor")).toBeTruthy();
+  });
+
   it("lifecycle renders the cause pill and the frozen date in absolute form", () => {
     const event = makeEvent({
       type: "lifecycle.tracked.frozen",

--- a/src/components/tape/event-card.tsx
+++ b/src/components/tape/event-card.tsx
@@ -344,7 +344,10 @@ function MethodologyEnrichment({ event }: { event: TapeEvent }) {
 }
 
 function CauseOfDeathPill({ cause }: { cause: string }) {
-  const label = CAUSE_META[cause as keyof typeof CAUSE_META]?.label.toLowerCase() ?? cause;
+  const meta = Object.prototype.hasOwnProperty.call(CAUSE_META, cause)
+    ? CAUSE_META[cause as keyof typeof CAUSE_META]
+    : null;
+  const label = meta?.label.toLowerCase() ?? cause;
   return (
     <span className="inline-flex items-center rounded border border-border/60 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
       {label}


### PR DESCRIPTION
### Motivation
- Prevent a client-side rendering crash where indexing `CAUSE_META` with arbitrary `cause` strings (including inherited prototype keys) could result in a missing `label` and cause `.label.toLowerCase()` to throw.

### Description
- Update `CauseOfDeathPill` in `src/components/tape/event-card.tsx` to check `Object.prototype.hasOwnProperty.call(CAUSE_META, cause)` before reading `label`, and fall back to the raw `cause` when no owned metadata exists.
- Add a regression test in `src/components/tape/event-card.test.tsx` that verifies a prototype-key cause (e.g. `"constructor"`) renders the raw text instead of crashing.

### Testing
- Ran `npm run typecheck` which succeeded (`tsc --noEmit` passed).
- Attempted `npm run test` for `src/components/tape/event-card.test.tsx` but the test run was blocked by a local `react`/`react-dom` version mismatch (19.2.7 vs 19.2.6), so unit tests could not be executed in this environment; the new regression test is included and should pass once the dependency mismatch is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33df8731f8833286f9441243841d2c)