### PR TITLE
fix(watchlist): preserve legacy keys on migration write failure

### DIFF
--- a/src/hooks/__tests__/use-watchlist.test.ts
+++ b/src/hooks/__tests__/use-watchlist.test.ts
@@ -1,14 +1,19 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWatchlist, WATCHLIST_STORAGE_KEY } from "@/hooks/use-watchlist";
 
+const LEGACY_PINNED_STORAGE_KEY = "pharos-pinned-stablecoins";
 const LEGACY_YIELD_STORAGE_KEY = "pharos:yield-watchlist:v1";
 
 describe("useWatchlist", () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("hydrates with an empty list and flips isHydrated", async () => {
@@ -62,6 +67,29 @@ describe("useWatchlist", () => {
 
     await waitFor(() => expect(result.current.isHydrated).toBe(true));
     await waitFor(() => expect([...result.current.idSet].sort()).toEqual(["dai-mkr", "usdc-circle"]));
+  });
+
+  it("keeps legacy watchlist keys when canonical migration storage write fails", async () => {
+    const pinned = ["usdc-circle"];
+    const yieldList = ["dai-mkr"];
+    window.localStorage.setItem(LEGACY_PINNED_STORAGE_KEY, JSON.stringify(pinned));
+    window.localStorage.setItem(LEGACY_YIELD_STORAGE_KEY, JSON.stringify(yieldList));
+
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function setItem(this: Storage, key, value) {
+      if (key === WATCHLIST_STORAGE_KEY) {
+        throw new DOMException("Quota exceeded", "QuotaExceededError");
+      }
+      return Reflect.apply(originalSetItem, this, [key, value]);
+    });
+
+    const { result } = renderHook(() => useWatchlist());
+
+    await waitFor(() => expect(result.current.isHydrated).toBe(true));
+    await waitFor(() => expect([...result.current.idSet].sort()).toEqual(["dai-mkr", "usdc-circle"]));
+    expect(window.localStorage.getItem(WATCHLIST_STORAGE_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(LEGACY_PINNED_STORAGE_KEY) ?? "null")).toEqual(pinned);
+    expect(JSON.parse(window.localStorage.getItem(LEGACY_YIELD_STORAGE_KEY) ?? "null")).toEqual(yieldList);
   });
 
   it("ignores malformed stored values", async () => {

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -51,9 +51,11 @@ function loadFromStorage(): string[] {
   const legacyPinned = readLegacy(storage, LEGACY_PINNED_KEY);
   const legacyYield = readLegacy(storage, LEGACY_YIELD_KEY);
   const merged = normalize([...legacyPinned, ...legacyYield]);
-  writeJsonStorageValue(storage, WATCHLIST_STORAGE_KEY, merged);
-  safeStorageRemoveItem(storage, LEGACY_PINNED_KEY);
-  safeStorageRemoveItem(storage, LEGACY_YIELD_KEY);
+  const migrated = writeJsonStorageValue(storage, WATCHLIST_STORAGE_KEY, merged);
+  if (migrated) {
+    safeStorageRemoveItem(storage, LEGACY_PINNED_KEY);
+    safeStorageRemoveItem(storage, LEGACY_YIELD_KEY);
+  }
   return merged;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent client-side data loss during the one-time watchlist migration when a browser `localStorage` write to the canonical key fails.
- Preserve legacy watchlist keys so a later load or retry can recover the user's persisted list instead of erasing it.

### Description
- Guard legacy-key cleanup in `loadFromStorage()` so the legacy keys are only removed if `writeJsonStorageValue()` returns `true` (i.e., the canonical write succeeded) in `src/hooks/use-watchlist.ts`.
- Add a regression test that simulates `QuotaExceededError` for the canonical key and asserts the legacy keys remain intact while the in-memory merged list hydrates in `src/hooks/__tests__/use-watchlist.test.ts`.
- Add test housekeeping (`vi.restoreAllMocks()`) and a small test constant for the legacy pinned key.

### Testing
- Ran the focused test suite with `npx vitest run src/hooks/__tests__/use-watchlist.test.ts --reporter=verbose` and all tests in that file passed (7 tests).
- Ran a quick `git diff --check` to ensure no whitespace or diff errors were introduced and observed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33df87823483329dbdabe00c6416da)