### PR TITLE
Harden retained-pool volume guard

### DIFF
--- a/docs/dex-liquidity.md
+++ b/docs/dex-liquidity.md
@@ -2,7 +2,7 @@
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v5.81`
+- **Current methodology version:** `v5.82`
 - **Runtime/version source:** `shared/lib/liquidity-score-version.ts`
 - **Public changelog route:** `/methodology/liquidity-score-changelog/`
 - **Version timeline:** [liquidity-score-timeline.md](./liquidity-score-timeline.md)
@@ -64,7 +64,7 @@ During the scoring cron, UniV3/Aerodrome subgraph enrichment completes before th
 
 Balancer, Raydium, Orca, and resolver-backed Fluid pools now preserve richer metadata through `top_pools_json`: measured `balanceRatio`, per-token `balanceDetails`, and normalized `feeTier` badges in basis points. Balancer weighted pools compare actual USD composition versus target token weights before deriving balance health; Raydium and Orca derive inventory balance from token balances plus per-token USD prices; Fluid derives inventory from the official DexReservesResolver by summing collateral and debt real reserves per token. Fluid pools on chains without that resolver deployment, or on any chain where token decimals cannot be resolved safely, fall back to neutral balance.
 
-After pool filtering and protocol-level TVL caps are applied, the scorer rebuilds every aggregate (`total_tvl_usd`, `total_volume_24h_usd`, `total_volume_7d_usd`, `effective_tvl_usd`, balance/organic/stress weights, protocol/chain breakdowns, and source-family mix) from the retained pool set before computing the final score. Filtered or capped pools cannot continue influencing the score through stale pre-filter aggregates. The strict cap now targets the inflation-prone secondary discovery families (`cg_onchain`, `gecko_terminal`, `dexscreener`, `cg_tickers`) rather than clipping `direct_api` pools by default, so legitimate protocol-native liquidity is less likely to be suppressed by stale DefiLlama protocol ceilings.
+Large retained pools must pass the minimum 24-hour volume floor even when a source marks volume as unmeasured; the unmeasured flag is retained for diagnostics but does not bypass the large-pool anti-poisoning guard. After pool filtering and protocol-level TVL caps are applied, the scorer rebuilds every aggregate (`total_tvl_usd`, `total_volume_24h_usd`, `total_volume_7d_usd`, `effective_tvl_usd`, balance/organic/stress weights, protocol/chain breakdowns, and source-family mix) from the retained pool set before computing the final score. Filtered or capped pools cannot continue influencing the score through stale pre-filter aggregates. The strict cap now targets the inflation-prone secondary discovery families (`cg_onchain`, `gecko_terminal`, `dexscreener`, `cg_tickers`) rather than clipping `direct_api` pools by default, so legitimate protocol-native liquidity is less likely to be suppressed by stale DefiLlama protocol ceilings.
 
 `dex_pool_staging` is the handoff point for discovery-refresh rows (CoinGecko Onchain, GeckoTerminal, DexScreener, CoinGecko Tickers). The scoring cron consumes staged rows refreshed within the last 24 hours and gracefully falls back to primary-only scoring when the staging table is absent or empty. It also retains bounded direct fallback probes after the primary/staged merge: DexScreener can still repair zero-pool, no-price, or materially weak partial on-chain coverage, while CoinGecko ticker/orderbook fallback is limited to assets with absent, no-price, or tiny DEX coverage so centralized synthetic books do not churn already-covered DEX assets.
 

--- a/docs/liquidity-score-timeline.md
+++ b/docs/liquidity-score-timeline.md
@@ -1,6 +1,14 @@
 # Liquidity Score Methodology - Version Timeline
 
-Internal changelog reconstructed from git history. Covers Liquidity Score `v1.0` through `v5.81` (2026-02-19 -> 2026-06-14).
+Internal changelog reconstructed from git history. Covers Liquidity Score `v1.0` through `v5.82` (2026-02-19 -> 2026-06-18).
+
+---
+
+## v5.82 - Large zero-volume pool retention hardening (June 18, 2026)
+
+- Large retained pools once again need minimum 24-hour volume even when the source marks volume as unmeasured
+- Pool-state-only direct sources such as Slipstream can still expand coverage with smaller eligible pools, but large zero-volume rows no longer bypass the retained-pool anti-poisoning guard
+- The existing volume-to-TVL outlier and blocked-DEX filters continue to run before aggregate liquidity metrics are rebuilt
 
 ---
 

--- a/shared/data/methodology-changelogs/liquidity-score/v5.ts
+++ b/shared/data/methodology-changelogs/liquidity-score/v5.ts
@@ -11,6 +11,21 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 // counter over. Entries below are newest-first by version.
 export const LIQUIDITY_SCORE_V5: readonly MethodologyChangelogEntry[] = [
   {
+    version: "5.82",
+    title: "Large zero-volume pool retention hardening",
+    date: "2026-06-18",
+    effectiveAt: 1781740800,
+    summary:
+      "Large retained pools once again need minimum 24-hour volume even when the source marks volume as unmeasured, closing a zero-volume TVL inflation path for protocol-native and DeFiLlama pools.",
+    impact: [
+      "Pools above the large-pool TVL threshold are dropped when 24-hour volume is below the minimum-volume floor regardless of the volumeMeasured flag",
+      "Pool-state-only direct sources such as Slipstream can still expand coverage with smaller eligible pools, but large zero-volume rows no longer bypass the retained-pool anti-poisoning guard",
+      "Measured high volume-to-TVL outliers and blocked DEX ids continue to be filtered before aggregate liquidity metrics are rebuilt",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
+  {
     version: "5.81",
     title: "Unsupported-chain Curve fallback coverage",
     date: "2026-06-14",

--- a/shared/lib/methodology-versions/liquidity-score.ts
+++ b/shared/lib/methodology-versions/liquidity-score.ts
@@ -6,7 +6,7 @@ import { LIQUIDITY_SCORE_V5 } from "../../data/methodology-changelogs/liquidity-
 import { createMethodologyVersion } from "./base";
 
 const liquidity = createMethodologyVersion({
-  currentVersion: "5.81",
+  currentVersion: "5.82",
   changelogPath: "/methodology/liquidity-score-changelog/",
   changelog: [
     ...LIQUIDITY_SCORE_V5,

--- a/src/app/methodology/sections/core/liquidity-section.tsx
+++ b/src/app/methodology/sections/core/liquidity-section.tsx
@@ -90,9 +90,11 @@ export function LiquidityMethodologySection() {
             toward zero between UTC day rollovers.
           </p>
           <p>
-            After bad pools are filtered and secondary-source TVL caps are applied, every exported aggregate and score input
-            is rebuilt from the retained pool set. That keeps filtered or downscaled pools from lingering in the final score
-            through stale pre-filter totals.
+            Large pools must also clear the minimum 24h volume floor even when a source marks volume as unmeasured, so
+            pool-state-only rows cannot bypass the retained-pool anti-poisoning guard. After bad pools are filtered and
+            secondary-source TVL caps are applied, every exported aggregate and score input is rebuilt from the retained
+            pool set. That keeps filtered or downscaled pools from lingering in the final score through stale pre-filter
+            totals.
           </p>
           <p>
             Curve balance, registry, token-price, and metapool TVL enrichment is applied only to Curve DeFiLlama rows.

--- a/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
@@ -246,7 +246,7 @@ describe("collapseDuplicateObservations", () => {
 });
 
 describe("filterRetainedPools", () => {
-  it("retains large direct pools when zero volume is explicitly unmeasured", () => {
+  it("drops large direct pools when zero volume is explicitly unmeasured", () => {
     const retained = filterRetainedPools([
       makePool({
         poolId: "base:0xslipstream",
@@ -264,7 +264,7 @@ describe("filterRetainedPools", () => {
       }),
     ]);
 
-    expect(retained).toHaveLength(1);
+    expect(retained).toHaveLength(0);
   });
 
   it("still drops large pools with measured low volume", () => {

--- a/worker/src/cron/dex-liquidity/scoring-helpers.ts
+++ b/worker/src/cron/dex-liquidity/scoring-helpers.ts
@@ -154,9 +154,8 @@ export function filterRetainedPools(pools: LiquidityMetrics["topPools"]): Liquid
   return pools.filter((pool) => {
     if (isBlockedDexId(pool.project)) return false;
     const vol = pool.volumeUsd1d || 0;
-    const volumeMeasured = pool.extra?.measurement?.volumeMeasured !== false;
     if (pool.tvlUsd > 0 && vol / pool.tvlUsd > POOL_VOL_TO_TVL_RATIO_MAX) return false;
-    if (volumeMeasured && pool.tvlUsd > LARGE_POOL_TVL_MIN_USD && vol < LARGE_POOL_MIN_VOLUME_USD) return false;
+    if (pool.tvlUsd > LARGE_POOL_TVL_MIN_USD && vol < LARGE_POOL_MIN_VOLUME_USD) return false;
     return true;
   });
 }


### PR DESCRIPTION
### Motivation
- Fix a logic/integrity vulnerability where pools marked `volumeMeasured: false` could bypass the large-pool minimum-volume sanity check, allowing large zero-volume pools (e.g. Slipstream/direct_api and some DeFiLlama rows) to inflate TVL and downstream scores.
- Reinstate the previous anti-poisoning guard so large pools with near-zero 24h volume cannot be retained regardless of the `volumeMeasured` diagnostic flag.

### Description
- Restore the unconditional large-pool minimum-volume filter in `filterRetainedPools` so the `LARGE_POOL_MIN_VOLUME_USD` check runs for all pools (file: `worker/src/cron/dex-liquidity/scoring-helpers.ts`).
- Update the focused regression test to assert a $150M zero-volume `direct_api` Slipstream-like pool is dropped (file: `worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts`).
- Bump the Liquidity Score methodology version to `v5.82` and add a machine-readable changelog entry documenting the hardening (files: `shared/lib/methodology-versions/liquidity-score.ts`, `shared/data/methodology-changelogs/liquidity-score/v5.ts`).
- Update docs and methodology copy to describe the stricter retained-pool behavior and version bump (files: `docs/dex-liquidity.md`, `docs/liquidity-score-timeline.md`, `src/app/methodology/sections/core/liquidity-section.tsx`).

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts` and observed all tests pass (`22 passed`).
- Verified TypeScript worker build: `cd worker && npx tsc --noEmit` succeeded.
- Ran repository checks: `npm run check:doc-sync` passed; `npm run check:worker-boundary` and `npm run check:shared-cycles` passed; `npm run check:verified-doc-links` and `npm run check:doc-source-paths` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34160b4d8c8332b698ddb27408c7d7)