### PR TITLE
fix(reserves): keep Reservoir timestamp-less payload unverified

### DIFF
--- a/shared/lib/live-reserve-adapters-definitions.ts
+++ b/shared/lib/live-reserve-adapters-definitions.ts
@@ -531,7 +531,7 @@ const LIVE_RESERVE_ADAPTER_SOURCE_DEFINITIONS = {
     validation: {
       maxSourceAgeSec: DASHBOARD_SOURCE_MAX_AGE_SEC,
       maxUnknownExposurePct: MATERIAL_UNKNOWN_EXPOSURE_PCT,
-      allowedFreshnessModes: NOT_APPLICABLE_ONLY_FRESHNESS,
+      allowedFreshnessModes: VERIFIED_OR_UNVERIFIED_FRESHNESS,
     },
   },
   "ripple-transparency": {

--- a/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
@@ -25,10 +25,8 @@ const RESERVOIR_BROWSER_CACHE_KEY = `json-get:${RESERVOIR_TEST_URL}:20000:${JSON
 const RESERVOIR_NEUTRAL_CACHE_KEY = `json-get:${RESERVOIR_TEST_URL}:20000:${JSON.stringify(NEUTRAL_ADAPTER_HEADERS)}`;
 
 describe("adaptReservoirReserves", () => {
-  it("declares the reviewed latest-state balance-sheet API as not-applicable-only freshness", () => {
-    expect(LIVE_RESERVE_ADAPTER_DEFINITIONS.reservoir.validation.allowedFreshnessModes).toEqual([
-      "not-applicable",
-    ]);
+  it("declares the timestamp-less balance-sheet API as unverified freshness", () => {
+    expect(LIVE_RESERVE_ADAPTER_DEFINITIONS.reservoir.validation.allowedFreshnessModes).toContain("unverified");
   });
 
   it("groups live balance-sheet assets into reserve slices", () => {
@@ -174,7 +172,7 @@ describe("adaptReservoirReserves", () => {
     expect(slices).toHaveLength(3);
   });
 
-  it("emits reviewed not-applicable freshness with same-run-api redemption telemetry", async () => {
+  it("emits unverified freshness for timestamp-less protocol API telemetry", async () => {
     const result = await fetchReservoirReserves(
       { id: "r" } as never,
       {
@@ -192,10 +190,10 @@ describe("adaptReservoirReserves", () => {
     );
 
     expect(result.metadata).toMatchObject({
-      freshnessMode: "not-applicable",
+      freshnessMode: "unverified",
       details: {
         freshnessSource: "protocol-balance-sheet-api",
-        freshnessReason: expect.stringContaining("live contract state"),
+        freshnessReason: expect.stringContaining("not independently freshness-verified"),
       },
       totalAssetsUsd: 100,
       totalLiabilitiesUsd: 95,
@@ -203,10 +201,10 @@ describe("adaptReservoirReserves", () => {
       collateralizationRatio: 100 / 95,
       redemption: { routeStatus: "unknown", routeStatusSource: "protocol-api" },
     });
-    // No timestamped disclosure exists; the latest-state read must not invent one.
+    // No timestamped disclosure exists; the adapter must not invent score-grade freshness.
     expect(result.metadata?.sourceTimestamp).toBeUndefined();
     expect(result.metadata?.redemption).toMatchObject({
-      freshnessKind: "same-run-api",
+      freshnessKind: "unverified",
     });
   });
 

--- a/worker/src/cron/reserve-adapters/__tests__/validate.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/validate.test.ts
@@ -376,8 +376,7 @@ describe("validateAdapterOutput redemption telemetry", () => {
   });
 
   it("suppresses redemption-capacity-unverified when the adapter policy is unverified-only", () => {
-    // No registry adapter is unverified-only anymore (infinifi gained a verified
-    // probe, reservoir is reviewed not-applicable), so cover the suppression
+    // No registry adapter is unverified-only anymore, so cover the suppression
     // branch with a synthetic unverified-only policy.
     const baseAdapter = getReserveAdapter("infinifi");
     expect(baseAdapter).not.toBeNull();
@@ -403,17 +402,17 @@ describe("validateAdapterOutput redemption telemetry", () => {
     expect(result.warnings.some((w) => w.code === "redemption-capacity-unverified")).toBe(false);
   });
 
-  it("does not flag same-run-api redemption freshness under reservoir's not-applicable policy", () => {
+  it("flags unverified redemption freshness under reservoir's timestamp-less API policy", () => {
     const adapter = getReserveAdapter("reservoir");
     const result = validateAdapterOutput(
       {
         slices,
         metadata: {
           immediateRedeemableUsd: 1_000_000,
-          freshnessMode: "not-applicable",
+          freshnessMode: "unverified",
           redemption: {
             capacityUsd: 1_000_000,
-            freshnessKind: "same-run-api",
+            freshnessKind: "unverified",
           },
         },
       },
@@ -421,7 +420,7 @@ describe("validateAdapterOutput redemption telemetry", () => {
     );
 
     expect(result.valid).toBe(true);
-    expect(result.warnings.some((w) => w.code === "redemption-capacity-unverified")).toBe(false);
+    expect(result.warnings.some((w) => w.code === "redemption-capacity-unverified")).toBe(true);
     expect(result.warnings.some((w) => w.code === "freshness-mode-disallowed")).toBe(false);
   });
 

--- a/worker/src/cron/reserve-adapters/reservoir.ts
+++ b/worker/src/cron/reserve-adapters/reservoir.ts
@@ -5,7 +5,7 @@ import {
   buildUnknownExposureWarning,
   classifyBucketedValues,
   fetchJsonWithRetry,
-  notApplicableFreshnessMetadata,
+  unverifiedFreshnessMetadata,
   requireJsonInputFromConfig,
 } from "./helpers";
 import type { ValueBucketRule } from "./classification";
@@ -296,18 +296,10 @@ export async function fetchReservoirReserves(
       unknownAssetCount: adapted.unknownAssets.length,
       ...(adapted.unknownAssets.length > 0 ? { unknownAssetLabels: adapted.unknownAssets } : {}),
       ...(adapted.sourceTotalGapPct > 0 ? { sourceTotalGapPct: adapted.sourceTotalGapPct } : {}),
-      // Reviewed latest-state read (2026-06-10): every balance-sheet asset row
-      // maps 1:1 to an on-chain position whose token + holder adapter contracts
-      // are disclosed by the sibling /api/reserves endpoint, accruing rows drift
-      // continuously between fetches, and spot RPC verification matched the
-      // steakUSDC row to convertToAssets(balanceOf(adapter)) within seconds of
-      // accrual. The payload is latest-state contract/API state, not a
-      // separately timestamped disclosure.
-      ...notApplicableFreshnessMetadata({
-        freshnessSource: "protocol-balance-sheet-api",
-        freshnessReason:
-          "Balance-sheet rows mirror Reservoir's disclosed on-chain adapter holdings (/api/reserves) and re-derive from live contract state on fetch",
-      }),
+      ...unverifiedFreshnessMetadata(
+        "protocol-balance-sheet-api",
+        "Reservoir's timestamp-less protocol API payload is not independently freshness-verified during this adapter run",
+      ),
       unknownExposurePct: adapted.unknownExposurePct,
       ...(Number.isFinite(totalAssetsUsd) && totalAssetsUsd > 0 ? { totalAssetsUsd } : {}),
       ...(Number.isFinite(totalLiabilitiesUsd) && totalLiabilitiesUsd > 0 ? { totalLiabilitiesUsd } : {}),
@@ -328,9 +320,7 @@ export async function fetchReservoirReserves(
                 ? { capacityRatioOfSupply: adapted.immediateRedeemableUsd / adapted.supplyUsd }
                 : {}),
               capacityKind: "live-proxy-validated" as const,
-              // Capacity derives from the same latest-state balance-sheet read
-              // as the reserve slices (see freshness note above).
-              freshnessKind: "same-run-api" as const,
+              freshnessKind: "unverified" as const,
               routeStatus: "unknown" as const,
               routeStatusSource: "protocol-api" as const,
               sourceUrls: [primaryInput.url],


### PR DESCRIPTION
### Motivation

- The Reservoir adapter previously labeled a timestamp-less protocol HTTP balance-sheet payload as `not-applicable` and promoted derived redemption telemetry to `same-run-api`, which made timestamp-less upstream responses score-eligible without independent same-run verification.
- That change bypassed staleness checks (which only apply when a `sourceTimestamp` exists) and could let stale or forged protocol API data be treated as fresh score-grade evidence.

### Description

- Change Reservoir adapter freshness handling so timestamp-less protocol payloads are treated as `unverified` instead of `not-applicable` by emitting `unverifiedFreshnessMetadata` in `worker/src/cron/reserve-adapters/reservoir.ts` and updating the redemption `freshnessKind` to `unverified`.
- Allow `unverified` freshness for the Reservoir adapter in the adapter definitions by updating `shared/lib/live-reserve-adapters-definitions.ts` to include `unverified` in the allowed freshness modes for `reservoir`.
- Update unit tests to assert the new unverified semantics by editing `worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts` and `worker/src/cron/reserve-adapters/__tests__/validate.test.ts` to cover the unverified reserve metadata and expected validation warnings.

### Testing

- Ran the focused Vitest suites: `npx vitest run worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts worker/src/cron/reserve-adapters/__tests__/validate.test.ts --reporter=dot`, and both files passed (35 tests total).
- Verified TypeScript worker build with `cd worker && npx tsc --noEmit`, which completed without errors.
- Ran repository checks (`git diff --check`) and updated tests to reflect the new validation behavior; the adapted tests confirm `redemption-capacity-unverified` is emitted when appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343f15c0c48332a5e21553b04a7b62)