### PR TITLE
fix(mint-burn): retry tx-context shortfalls

### DIFF
--- a/worker/src/cron/__tests__/sync-mint-burn.test.ts
+++ b/worker/src/cron/__tests__/sync-mint-burn.test.ts
@@ -544,7 +544,7 @@ describe("syncMintBurn", () => {
     expect(meta.bridgeValidationErrors).toBe(0);
   });
 
-  it("persists tx-context shortfall rows as excluded bridge transfers", async () => {
+  it("withholds tx-context shortfall rows and keeps the frontier retryable", async () => {
     const db = makeDb();
 
     vi.mocked(fetchAlchemyLogs)
@@ -565,16 +565,18 @@ describe("syncMintBurn", () => {
     const usdt = meta.configBreakdown.find((entry: { symbol: string }) => entry.symbol === "USDT");
 
     expect(result.status).toBe("ok");
-    expect(result.itemCount).toBe(1);
+    expect(result.itemCount).toBe(0);
     expect(meta.rowsParsed).toBe(1);
-    expect(meta.rowsInserted).toBe(1);
+    expect(meta.rowsInserted).toBe(0);
+    expect(meta.apiErrors).toBe(1);
     expect(meta.bridgeClassification.txContextShortfalls).toBe(1);
     expect(meta.bridgeClassification.deferredRows).toBe(1);
-    expect(meta.degradedSignal).toBe(false);
+    expect(meta.degradedSignal).toBe(true);
     expect(usdt?.txContextShortfalls).toBe(1);
     expect(usdt?.bridgeClassificationDeferredRows).toBe(1);
     expect(usdt?.failedEventDefs).toContain("tx-context:1");
-    expect(usdt?.advanceReason).toBe("full-success-events");
+    expect(usdt?.advancedTo).toBe(21_999_999);
+    expect(usdt?.advanceReason).toBe("partial-frontier");
   });
 
   it("counts atomic roundtrips across mint and burn event definitions", async () => {

--- a/worker/src/cron/mint-burn/sync-config.ts
+++ b/worker/src/cron/mint-burn/sync-config.ts
@@ -294,6 +294,8 @@ export async function syncMintBurnConfig(input: SyncMintBurnConfigInput): Promis
     ? allParsedRows.filter((row) => deferredTxHashSet.has(row.tx_hash))
     : [];
   if (burnCounts.txContextShortfalls > 0) {
+    apiErrors++;
+    summary.errors++;
     summary.failedEventDefs.push(`tx-context:${burnCounts.txContextShortfalls}`);
     summary.bridgeClassificationDeferredRows = deferredRows.length;
   }
@@ -301,10 +303,14 @@ export async function syncMintBurnConfig(input: SyncMintBurnConfigInput): Promis
   bridgeBurns += burnCounts.bridgeBurns;
   reviewBurns += burnCounts.reviewBurns;
 
-  for (const row of allParsedRows) {
+  const persistableRows = deferredTxHashSet.size > 0
+    ? allParsedRows.filter((row) => !deferredTxHashSet.has(row.tx_hash))
+    : allParsedRows;
+
+  for (const row of persistableRows) {
     summary.maxBlockSeen = Math.max(summary.maxBlockSeen, row.block_number);
   }
-  const persistResult = await persistMintBurnRows(db, allParsedRows, affectedHours);
+  const persistResult = await persistMintBurnRows(db, persistableRows, affectedHours);
   summary.rowsInserted += persistResult.inserted;
   summary.rowsIgnored += persistResult.ignored;
 
@@ -317,14 +323,21 @@ export async function syncMintBurnConfig(input: SyncMintBurnConfigInput): Promis
   const timestampCoverageFrontier = summary.earliestMissingTimestampBlock != null
     ? summary.earliestMissingTimestampBlock - 1
     : null;
+  const txContextCoverageFrontier = deferredRows.length > 0
+    ? Math.min(...deferredRows.map((row) => row.block_number)) - 1
+    : null;
   const partialCoverageFrontier = minOrNull(
-    [eventCoverageFrontier, timestampCoverageFrontier]
+    [eventCoverageFrontier, timestampCoverageFrontier, txContextCoverageFrontier]
       .filter((value): value is number => value != null),
   );
   summary.coverageFrontier = partialCoverageFrontier;
 
   let newLastBlock: number | null = null;
-  if (fullEventCoverage && summary.missingTimestampCount === 0) {
+  if (
+    fullEventCoverage &&
+    summary.missingTimestampCount === 0 &&
+    summary.txContextShortfalls === 0
+  ) {
     if (summary.maxBlockSeen > 0) {
       newLastBlock = summary.maxBlockSeen;
       summary.advanceReason = "full-success-events";


### PR DESCRIPTION
### Motivation
- A tx/receipt context shortfall (e.g., transient or malicious RPC returning null tx/receipt) was being persisted by the mint/burn pipeline as `flow_type='bridge_transfer'`, and the sync frontier advanced past the affected blocks, making the exclusion durable and preventing retries after provider recovery. 
- The intent of this change is to restore safe retry semantics: treat tx-context shortfalls as retryable API errors, avoid persisting affected rows, and prevent the frontier from advancing past the first unavailable-context block so recovered providers can replay and reclassify rows.

### Description
- When `classifyBridgeBurnRows` reports `txContextShortfalls`, increment `apiErrors` and `summary.errors` again so the run reflects an upstream failure instead of silently accepting excluded rows (change in `worker/src/cron/mint-burn/sync-config.ts`).
- Withhold rows whose tx context was unavailable from persistence by filtering `allParsedRows` to `persistableRows` (exclude deferred tx hashes) before calling `persistMintBurnRows` so unavailable-context rows are not durably written.
- Add a `txContextCoverageFrontier` computed from the first block of deferred rows and include it in the `partialCoverageFrontier` calculation, and block `full-success-events` advancement when `summary.txContextShortfalls > 0`, capping `newLastBlock` to a safe retry boundary.
- Update the focused cron test in `worker/src/cron/__tests__/sync-mint-burn.test.ts` to assert that shortfall rows are not inserted, an API error is recorded, deferred diagnostics remain exposed, and the frontier advances only to the safe partial frontier.

### Testing
- Ran the targeted unit suites with `npx vitest run worker/src/cron/__tests__/sync-mint-burn.test.ts worker/src/lib/__tests__/mint-burn-pipeline.test.ts --reporter=verbose`, and the test suites passed.
- Performed a TypeScript check with `cd worker && npx tsc --noEmit`, which completed without errors.
- Verified the modified cron test covers the regression case: it now asserts withheld shortfall rows, incremented API error counters, and a capped frontier; the test passed under the updated behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345202eba083328bec88a08c7e66d0)