### PR TITLE
Prevent unmapped live reserves from erasing dependencies

### DIFF
--- a/docs/report-cards.md
+++ b/docs/report-cards.md
@@ -151,8 +151,9 @@ The `collateralFromLive` flag in `RawDimensionInputs` indicates which collateral
 The `dependencyFromLive` flag indicates that the Dependency Risk input came from
 the same score-grade live reserve snapshot. Live slices with `coinId` links are
 converted to dependency weights; live slices without `coinId` stay as implicit
-self-backed / non-stablecoin reserve share instead of reviving older curated
-stablecoin-link percentages.
+self-backed / non-stablecoin reserve share. If a live snapshot contains no mapped
+`coinId` links at all, Dependency Risk falls back to curated reserve links or
+manual dependencies rather than treating an unmapped upstream feed as self-backed.
 
 A delta alert fires when the independent live-derived score diverges from curated by >15 points,
 signaling that curated metadata (and potentially the governance classification) may

--- a/shared/lib/__tests__/dependency-graph.test.ts
+++ b/shared/lib/__tests__/dependency-graph.test.ts
@@ -147,7 +147,7 @@ describe("dependency-graph", () => {
     ]);
   });
 
-  it("does not fall back to curated dependencies when live reserve slices have no tracked upstreams", () => {
+  it("falls back to curated dependencies when live reserve slices have no tracked upstreams", () => {
     const dependencies = deriveEffectiveDependencies(
       makeMeta({
         id: "dependent",
@@ -163,15 +163,38 @@ describe("dependency-graph", () => {
       },
     );
 
-    expect(dependencies).toEqual([]);
+    expect(dependencies).toEqual([
+      { id: "curated-upstream", weight: 1, type: "wrapper" },
+    ]);
   });
 
-  it("exposes live-unmapped provenance when live reserve slices resolve no tracked upstreams", () => {
+  it("exposes fallback provenance when live reserve slices resolve no tracked upstreams", () => {
     const result = deriveEffectiveDependencySet(
       makeMeta({
         id: "dependent",
         dependencies: [{ id: "manual-upstream", weight: 1, type: "collateral" }],
       }),
+      {
+        liveReserveSlices: [
+          { name: "Cash and bills", pct: 80, risk: "very-low" },
+          { name: "Tokenized treasuries", pct: 20, risk: "low" },
+        ],
+      },
+    );
+
+    expect(result).toMatchObject({
+      dependencies: [{ id: "manual-upstream", weight: 1, type: "collateral" }],
+      source: "manual",
+      baseSource: "manual",
+      dependencyFromLive: false,
+      mappedLiveReserveWeight: 0,
+    });
+  });
+
+
+  it("keeps live-unmapped provenance when unmapped live reserve slices have no fallback dependencies", () => {
+    const result = deriveEffectiveDependencySet(
+      makeMeta({ id: "dependent" }),
       {
         liveReserveSlices: [
           { name: "Cash and bills", pct: 80, risk: "very-low" },

--- a/shared/lib/dependency-derivation.ts
+++ b/shared/lib/dependency-derivation.ts
@@ -84,26 +84,10 @@ export function deriveDependencies(meta: Pick<StablecoinMeta, "reserves" | "depe
   return reserveDependencies;
 }
 
-export function deriveEffectiveDependencySet(
+function deriveCuratedDependencySet(
   meta: Pick<StablecoinMeta, "variantOf" | "reserves" | "dependencies">,
-  options?: { liveReserveSlices?: readonly ReserveSlice[] },
+  mappedLiveReserveWeight: number | null = null,
 ): DerivedDependencySet {
-  if (Array.isArray(options?.liveReserveSlices)) {
-    const liveDependencies = aggregateReserveDependencies(options.liveReserveSlices);
-    const dependencies = injectVariantParent(liveDependencies, meta.variantOf);
-    const baseSource: DependencyDerivationBaseSource = liveDependencies.length > 0
-      ? "live-reserve"
-      : "live-unmapped";
-
-    return {
-      dependencies,
-      source: resolveSource(baseSource, dependencies, meta.variantOf),
-      baseSource,
-      dependencyFromLive: true,
-      mappedLiveReserveWeight: sumDependencyWeight(liveDependencies),
-    };
-  }
-
   const reserveDependencies = meta.reserves?.length
     ? aggregateReserveDependencies(meta.reserves)
     : [];
@@ -121,8 +105,47 @@ export function deriveEffectiveDependencySet(
     source: resolveSource(baseSource, dependencies, meta.variantOf),
     baseSource,
     dependencyFromLive: false,
-    mappedLiveReserveWeight: null,
+    mappedLiveReserveWeight,
   };
+}
+
+export function deriveEffectiveDependencySet(
+  meta: Pick<StablecoinMeta, "variantOf" | "reserves" | "dependencies">,
+  options?: { liveReserveSlices?: readonly ReserveSlice[] },
+): DerivedDependencySet {
+  if (Array.isArray(options?.liveReserveSlices)) {
+    const liveDependencies = aggregateReserveDependencies(options.liveReserveSlices);
+    const mappedLiveReserveWeight = sumDependencyWeight(liveDependencies);
+
+    if (liveDependencies.length === 0) {
+      const fallbackSet = deriveCuratedDependencySet(meta, mappedLiveReserveWeight);
+      if (fallbackSet.dependencies.length > 0) return fallbackSet;
+
+      const dependencies = injectVariantParent(liveDependencies, meta.variantOf);
+      const baseSource: DependencyDerivationBaseSource = "live-unmapped";
+
+      return {
+        dependencies,
+        source: resolveSource(baseSource, dependencies, meta.variantOf),
+        baseSource,
+        dependencyFromLive: true,
+        mappedLiveReserveWeight,
+      };
+    }
+
+    const dependencies = injectVariantParent(liveDependencies, meta.variantOf);
+    const baseSource: DependencyDerivationBaseSource = "live-reserve";
+
+    return {
+      dependencies,
+      source: resolveSource(baseSource, dependencies, meta.variantOf),
+      baseSource,
+      dependencyFromLive: true,
+      mappedLiveReserveWeight,
+    };
+  }
+
+  return deriveCuratedDependencySet(meta);
 }
 
 export function deriveEffectiveDependencies(

--- a/worker/src/lib/__tests__/report-cards-snapshot.test.ts
+++ b/worker/src/lib/__tests__/report-cards-snapshot.test.ts
@@ -305,7 +305,7 @@ describe("buildReportCardsSnapshot", () => {
     );
   });
 
-  it("keeps live-unmapped reserve dependencies from falling back to curated dependencies", async () => {
+  it("keeps live-unmapped reserve dependencies empty when no curated dependencies exist", async () => {
     const db = makeReportCardsDb([makeAsset({ id: "dai-makerdao", symbol: "DAI" })]);
     loadFreshIndependentLiveReserveMapMock.mockResolvedValueOnce(
       new Map([


### PR DESCRIPTION
### Motivation
- Live reserve snapshots with no `coinId` mappings caused `deriveEffectiveDependencySet` to return an empty live-derived dependency set, which downstream scoring treated as self-backed and inflated dependency-risk and removed graph edges. This change closes that integrity gap by preferring curated/manual evidence when a live snapshot provides no mapped upstream links.

### Description
- Change `deriveEffectiveDependencySet` to compute `liveDependencies` and, when `liveDependencies.length === 0`, attempt a curated/manual fallback via a new `deriveCuratedDependencySet` before returning `live-unmapped` provenance. If fallback dependencies exist, return them; otherwise preserve `live-unmapped` and keep `dependencyFromLive: true` with `mappedLiveReserveWeight` set.
- Add focused unit test updates in `shared/lib/__tests__/dependency-graph.test.ts` to assert the new fallback behavior and to keep the `live-unmapped` case only when no fallback evidence exists.  
- Update `worker/src/lib/__tests__/report-cards-snapshot.test.ts` to reflect the adjusted snapshot semantics for the no-fallback case.  
- Update documentation in `docs/report-cards.md` to describe that fully unmapped live snapshots fall back to curated or manual dependency evidence rather than being treated as self-backed.

### Testing
- Ran the focused Vitest suites `npx vitest run shared/lib/__tests__/dependency-graph.test.ts worker/src/lib/__tests__/report-cards-snapshot.test.ts`, and all tests passed.  
- Ran repository checks `npm run check:worker-boundary` and `npm run check:shared-cycles`, both of which passed.  
- Type-checked the Worker with `cd worker && npx tsc --noEmit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348b28b0548332a1e14886d5a0c020)