### PR TITLE
fix(telegram): keep chat-scoped 429s isolated

### DIFF
--- a/worker/src/cron/__tests__/telegram-pending-queue.test.ts
+++ b/worker/src/cron/__tests__/telegram-pending-queue.test.ts
@@ -1234,7 +1234,7 @@ describe("drainPendingQueue", () => {
     expect(retryUpdates.every((entry) => entry.binds[0] === Math.floor(Date.now() / 1000) + 45)).toBe(true);
   });
 
-  it("escalates repeated pending 429s across distinct chats to global backoff", async () => {
+  it("keeps repeated pending 429s across distinct chats chat-scoped", async () => {
     const now = Math.floor(Date.now() / 1000);
     const okResult = {
       ok: true, blocked: false, retryable: false, permanentFailure: false,
@@ -1249,7 +1249,7 @@ describe("drainPendingQueue", () => {
       .mockResolvedValueOnce(rateLimitResult)
       .mockResolvedValueOnce(rateLimitResult)
       .mockResolvedValueOnce(rateLimitResult)
-      .mockResolvedValueOnce(okResult);
+      .mockResolvedValue(okResult);
 
     const rows = Array.from({ length: 5 }, (_, i) => ({
       id: i + 1, chat_id: `chat-${i}`, message_html: `msg${i}`, disable_notification: 0, created_at: 1000, attempts: 0,
@@ -1265,17 +1265,12 @@ describe("drainPendingQueue", () => {
 
     const result = await drainPendingQueue(db, "bot-token", 20);
 
-    expect(result.attempted).toBe(4);
-    expect(result.sent).toBe(1);
+    expect(result.attempted).toBe(5);
+    expect(result.sent).toBe(2);
     expect(result.retryQueued).toBe(3);
     expect(result.rateLimited).toBe(true);
-    expect(mockSendToChat).toHaveBeenCalledTimes(4);
-    const cacheWrite = db.getHistory().find((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"));
-    expect(cacheWrite?.binds).toEqual([
-      TELEGRAM_GLOBAL_BACKOFF_CACHE_KEY,
-      String(now + 10),
-      now,
-    ]);
+    expect(mockSendToChat).toHaveBeenCalledTimes(5);
+    expect(db.getHistory().some((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"))).toBe(false);
   });
 
   it("stamps row-level backoff without setting global backoff on a chat-scoped 429", async () => {

--- a/worker/src/cron/telegram-pending/drain.ts
+++ b/worker/src/cron/telegram-pending/drain.ts
@@ -45,7 +45,6 @@ import { logTelegramEvent } from "../../lib/telegram-log";
 
 const PENDING_CLAIM_TTL_SEC = 10 * 60;
 const DEFAULT_RETRY_DELAY_SEC = PENDING_BACKOFF_SCHEDULE_SEC[0];
-const GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD = 3;
 
 function isPendingRowSnoozed(row: PendingAlertRow, nowSec: number): boolean {
   return row.alert_snooze_until_ts != null && row.alert_snooze_until_ts > nowSec;
@@ -524,10 +523,6 @@ export async function drainPendingQueue(
             } else {
               distinctRateLimitedChats.add(result.chatId);
               chatRateLimitedThisLoop.set(result.chatId, { notBeforeAt: classification.rateLimit.notBeforeAt });
-              if (distinctRateLimitedChats.size >= GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD) {
-                globalRateLimited = true;
-                await setTelegramGlobalBackoff(db, rateLimitNotBeforeAt);
-              }
             }
           }
           break;

--- a/worker/src/lib/__tests__/telegram.test.ts
+++ b/worker/src/lib/__tests__/telegram.test.ts
@@ -135,7 +135,7 @@ describe("sendToChat", () => {
     expect(fetchSpy.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("classifies ambiguous long retry-after 429s as global", async () => {
+  it("keeps ambiguous long retry-after 429s chat-scoped", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response("Too Many Requests", {
         status: 429,
@@ -151,7 +151,7 @@ describe("sendToChat", () => {
       statusCode: 429,
       errorClass: "rate_limit",
       delivery: "retryable_failure",
-      rateLimitScope: "global",
+      rateLimitScope: "chat",
     });
     expect(result.retryAfterSec).toBe(30);
   });
@@ -335,7 +335,7 @@ describe("sendBatch", () => {
     expect(results[3].ok).toBe(true);
   });
 
-  it("escalates repeated 429s across distinct chats to global backoff", async () => {
+  it("keeps repeated 429s across distinct chats chat-scoped", async () => {
     fetchSpy
       .mockResolvedValueOnce(
         new Response("Too Many Requests: chat retry after 10", {
@@ -354,7 +354,8 @@ describe("sendBatch", () => {
           status: 429,
           headers: { "Retry-After": "10" },
         }),
-      );
+      )
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
     const messages = Array.from({ length: 5 }, (_, index) => ({
       chatId: `chat-${index}`,
@@ -364,10 +365,10 @@ describe("sendBatch", () => {
 
     const results = await sendBatch(messages, "bot-token", 3);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
     expect(results).toHaveLength(5);
-    expect(results.slice(0, 3).every((result) => result.rateLimitScope === "global" && result.attempted === true)).toBe(true);
-    expect(results.slice(3).every((result) => result.rateLimitScope === "global" && result.attempted === false)).toBe(true);
+    expect(results.slice(0, 3).every((result) => result.rateLimitScope === "chat" && result.attempted === true)).toBe(true);
+    expect(results.slice(3).every((result) => result.ok && result.attempted === true)).toBe(true);
   });
 
   it("marks the untouched tail as global retryable after a global rate limit stop", async () => {

--- a/worker/src/lib/telegram.ts
+++ b/worker/src/lib/telegram.ts
@@ -150,9 +150,6 @@ export interface SendToChatResult {
   rateLimitScope?: "chat" | "global";
 }
 
-const GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC = 30;
-const GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD = 3;
-
 function inferRateLimitScope(responseBody: string, retryAfterSec: number | null): "chat" | "global" {
   const lower = responseBody.toLowerCase();
   if (lower.includes("global") || lower.includes("bot-wide") || lower.includes("bot wide")) {
@@ -160,9 +157,6 @@ function inferRateLimitScope(responseBody: string, retryAfterSec: number | null)
   }
   if (lower.includes("chat") || lower.includes("group") || lower.includes("user")) {
     return "chat";
-  }
-  if (retryAfterSec != null && retryAfterSec >= GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC) {
-    return "global";
   }
   return "chat";
 }
@@ -420,7 +414,6 @@ export async function sendBatch(
 ): Promise<BatchResult[]> {
   const results: BatchResult[] = [];
   const chatRateLimitedUntil = new Map<string, number | null>();
-  const distinctRateLimitedChats = new Set<string>();
   for (let i = 0; i < messages.length; i += batchSize) {
     if (signal?.aborted) {
       results.push(...messages.slice(i).map((message) => buildUnsentRetryResult(message, "timeout", null)));
@@ -456,32 +449,18 @@ export async function sendBatch(
     const globalRateLimitedResult = batchResults.find(
       (r) => r.errorClass === "rate_limit" && r.rateLimitScope === "global",
     );
-    let escalatedGlobalRateLimitedResult = globalRateLimitedResult;
-    if (!escalatedGlobalRateLimitedResult) {
-      for (const result of batchResults) {
-        if (result.attempted === false) continue;
-        if (result.errorClass === "rate_limit" && result.rateLimitScope !== "global") {
-          distinctRateLimitedChats.add(result.chatId);
-          chatRateLimitedUntil.set(result.chatId, result.retryAfterSec);
-        }
-      }
-      if (distinctRateLimitedChats.size >= GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD) {
-        escalatedGlobalRateLimitedResult = batchResults.find(
-          (r) => r.errorClass === "rate_limit" && r.rateLimitScope !== "global" && r.attempted !== false,
-        );
-        for (const result of batchResults) {
-          if (result.errorClass === "rate_limit" && result.rateLimitScope !== "global") {
-            result.rateLimitScope = "global";
-          }
-        }
+    for (const result of batchResults) {
+      if (result.attempted === false) continue;
+      if (result.errorClass === "rate_limit" && result.rateLimitScope !== "global") {
+        chatRateLimitedUntil.set(result.chatId, result.retryAfterSec);
       }
     }
-    if (escalatedGlobalRateLimitedResult) {
+    if (globalRateLimitedResult) {
       for (const skippedMessage of messages.slice(i + batchSize)) {
         results.push(buildUnsentRetryResult(
           skippedMessage,
           "rate_limit",
-          escalatedGlobalRateLimitedResult.retryAfterSec,
+          globalRateLimitedResult.retryAfterSec,
           "global",
         ));
       }


### PR DESCRIPTION
### Motivation
- Prevent chat-scoped Telegram 429 responses from being misclassified as bot-wide/global and thereby suppressing alerts for all subscribers.
- Restore per-chat isolation so an attacker-controlled or noisy subset of chats cannot trigger a repository-wide alert backoff.

### Description
- Remove the ambiguous `Retry-After >= 30s` heuristic from `worker/src/lib/telegram.ts` so generic 429s are not auto-classified as global unless the response body explicitly indicates a bot-wide limit.
- Stop escalating multiple distinct chat-scoped 429s into a global short-circuit in the fresh `sendBatch` path by removing the distinct-chat-to-global promotion logic in `worker/src/lib/telegram.ts`. 
- Remove the distinct-chat escalation that persisted global backoff from pending-queue drains in `worker/src/cron/telegram-pending/drain.ts` so only explicitly global responses set the `telegram:global-send-backoff-until` cache. 
- Update tests to assert chat-scoped behavior remains isolated in `worker/src/lib/__tests__/telegram.test.ts` and `worker/src/cron/__tests__/telegram-pending-queue.test.ts` while keeping explicit global-rate-limit handling intact. 

### Testing
- Ran the unit suites `npx vitest run worker/src/lib/__tests__/telegram.test.ts worker/src/cron/__tests__/telegram-pending-queue.test.ts` and all tests in those files passed. 
- Compiled TypeScript with `cd worker && npx tsc --noEmit` which succeeded. 
- Ran `npx vitest run worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts` which passed. 
- Verified cron connection budget with `npm run check:cron-connections` which reported the triggers within budget.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3402cc95508332898780737dce43ed)