### PR TITLE
fix(worker): renew PSI backfill lease

### DIFF
--- a/worker/src/api/__tests__/backfill-stability-index.test.ts
+++ b/worker/src/api/__tests__/backfill-stability-index.test.ts
@@ -514,6 +514,78 @@ describe("handleBackfillStabilityIndex", () => {
     expect(res.status).toBe(409);
   });
 
+  it("renews the advisory lease while a non-dry-run backfill is still running", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const start = nowSec - 86400;
+    let renewCalls = 0;
+    let batchCalls = 0;
+    let releaseBatch: (() => void) | undefined;
+    const holdBatch = new Promise<void>((resolve) => {
+      releaseBatch = resolve;
+    });
+    const db = makeDb({
+      earliest: start,
+      depegRows: [
+        {
+          stablecoin_id: "usdt-tether",
+          peak_deviation_bps: -120,
+          peg_reference: 1,
+          started_at: start,
+          ended_at: null,
+        },
+      ],
+      supplyRows: [
+        { stablecoin_id: "usdt-tether", snapshot_date: start - 7 * 86400, circulating_usd: 99_000_000, price: 1 },
+        { stablecoin_id: "usdt-tether", snapshot_date: start, circulating_usd: 100_000_000, price: 0.998 },
+      ],
+    });
+
+    const origPrepare = db.prepare.bind(db);
+    db.prepare = ((sql: string) => {
+      const stmt = origPrepare(sql);
+      if (sql.includes("UPDATE cron_leases")) {
+        const bind = stmt.bind.bind(stmt);
+        return {
+          ...stmt,
+          bind: (...args: unknown[]) => {
+            const bound = bind(...args);
+            return {
+              ...bound,
+              run: async () => {
+                renewCalls++;
+                return { success: true, meta: { changes: 1 } };
+              },
+            };
+          },
+        } as typeof stmt;
+      }
+      return stmt;
+    }) as typeof db.prepare;
+
+    const origBatch = db.batch.bind(db);
+    db.batch = (async (stmts: D1PreparedStatement[]) => {
+      batchCalls++;
+      if (batchCalls === 2) {
+        await holdBatch;
+      }
+      return origBatch(stmts);
+    }) as typeof db.batch;
+
+    const pending = handleBackfillStabilityIndex(
+      db,
+      true,
+      makeApiRequest("/api/backfill-stability-index", { method: "POST", adminKey: "secret" }),
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(renewCalls).toBeGreaterThanOrEqual(1);
+
+    releaseBatch?.();
+    const res = await pending;
+
+    expect(res.status).toBe(200);
+  });
+
   it("rejects invalid day parameters", async () => {
     const res = await handleBackfillStabilityIndex(
       makeDb({ earliest: 1 }),

--- a/worker/src/api/backfill-stability-index.ts
+++ b/worker/src/api/backfill-stability-index.ts
@@ -15,13 +15,14 @@ import {
 } from "../lib/psi-replay";
 import type { PsiUniverseCache } from "../lib/psi-history-universe";
 import { runAdminJob } from "../lib/admin-job";
-import { acquireCronLease, createLeaseOwner, releaseCronLease } from "../lib/cron-lease";
+import { acquireCronLease, createLeaseOwner, releaseCronLease, renewCronLease } from "../lib/cron-lease";
 import { parseOptionalDayWindow } from "./backfill-depegs-window";
 
 // Advisory lease key fencing concurrent admin invocations of this rebuild. It
 // is intentionally distinct from the "stability-index" cron job key.
 const BACKFILL_PSI_LEASE_JOB = "backfill-stability-index";
 const BACKFILL_PSI_LEASE_TTL_SEC = 10 * 60;
+const BACKFILL_PSI_LEASE_HEARTBEAT_SEC = 60;
 
 interface ExistingStabilityIndexRow {
   computed_at: number;
@@ -154,11 +155,15 @@ export async function handleBackfillStabilityIndex(
       // DELETE+INSERT swap, risking a partial or empty stability_index.
       const leaseOwner = createLeaseOwner(BACKFILL_PSI_LEASE_JOB);
       let leaseAcquired = false;
+      let leaseHeartbeat: ReturnType<typeof setInterval> | undefined;
       if (!dryRun) {
         leaseAcquired = await acquireCronLease(db, BACKFILL_PSI_LEASE_JOB, leaseOwner, BACKFILL_PSI_LEASE_TTL_SEC);
         if (!leaseAcquired) {
           return errorResponse(409, "A stability-index backfill is already running. Try again later.");
         }
+        leaseHeartbeat = setInterval(() => {
+          void renewCronLease(db, BACKFILL_PSI_LEASE_JOB, leaseOwner, BACKFILL_PSI_LEASE_TTL_SEC).catch(() => {});
+        }, BACKFILL_PSI_LEASE_HEARTBEAT_SEC * 1000);
       }
 
       try {
@@ -310,6 +315,9 @@ export async function handleBackfillStabilityIndex(
         endDay,
       });
       } finally {
+        if (leaseHeartbeat) {
+          clearInterval(leaseHeartbeat);
+        }
         if (leaseAcquired) {
           await releaseCronLease(db, BACKFILL_PSI_LEASE_JOB, leaseOwner).catch(() => {});
         }


### PR DESCRIPTION
### Motivation

- The advisory `backfill-stability-index` lease could expire during long non-dry-run backfills and allow a second invocation to take over, risking concurrent use of the shared `stability_index_rebuild` table and destructive DELETE+INSERT swaps.

### Description

- Import and use `renewCronLease` and add a `BACKFILL_PSI_LEASE_HEARTBEAT_SEC` (60s) constant.  
- After acquiring the non-dry-run advisory lease, start a heartbeat `setInterval` that calls `renewCronLease(db, BACKFILL_PSI_LEASE_JOB, leaseOwner, BACKFILL_PSI_LEASE_TTL_SEC)` periodically to keep the lease alive.  
- Clear the heartbeat `clearInterval` in the `finally` block before releasing the lease to avoid timer leakage.  
- Add a focused regression test that holds an in-flight backfill open long enough to exercise the heartbeat and asserts that the `cron_leases` renew path is invoked while the job runs.

### Testing

- Ran the focused suite: `npx vitest run worker/src/api/__tests__/backfill-stability-index.test.ts`, all tests passed (11 passed).  
- Performed TypeScript build check: `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051da4a483328b89691e849863fd)