### PR TITLE
ci(security): scope ops smoke access secrets

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -260,7 +260,9 @@ jobs:
 
           npm run test:smoke-ui -- --url https://pharos.watch --mode live &
           ui_pid=$!
-          npm run test:smoke-ops &
+          OPS_SMOKE_CF_ACCESS_CLIENT_ID='${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_ID }}' \
+            OPS_SMOKE_CF_ACCESS_CLIENT_SECRET='${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_SECRET }}' \
+            npm run test:smoke-ops &
           ops_pid=$!
           npm run test:smoke-transport &
           transport_pid=$!
@@ -283,8 +285,6 @@ jobs:
           SMOKE_OPS_UI_URL: ${{ vars.SMOKE_OPS_UI_URL || 'https://ops.pharos.watch/admin/' }}
           SMOKE_OPS_API_BASE: ${{ vars.SMOKE_OPS_API_BASE || 'https://ops-api.pharos.watch' }}
           SMOKE_OPS_SCOPE: "canary"
-          OPS_SMOKE_CF_ACCESS_CLIENT_ID: ${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_ID }}
-          OPS_SMOKE_CF_ACCESS_CLIENT_SECRET: ${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_SECRET }}
       - name: Roll back production worker to previous stable version
         if: >-
           ${{

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -318,8 +318,6 @@ jobs:
           SMOKE_OPS_UI_URL: ${{ vars.SMOKE_OPS_UI_URL || 'https://ops.pharos.watch/admin/' }}
           SMOKE_OPS_API_BASE: ${{ vars.SMOKE_OPS_API_BASE || 'https://ops-api.pharos.watch' }}
           SMOKE_OPS_SCOPE: "canary"
-          OPS_SMOKE_CF_ACCESS_CLIENT_ID: ${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_ID }}
-          OPS_SMOKE_CF_ACCESS_CLIENT_SECRET: ${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_SECRET }}
         run: |
           set +e
 
@@ -338,7 +336,9 @@ jobs:
 
           npm run test:smoke-ui -- --url https://pharos.watch --mode live &
           ui_pid=$!
-          npm run test:smoke-ops &
+          OPS_SMOKE_CF_ACCESS_CLIENT_ID='${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_ID }}' \
+            OPS_SMOKE_CF_ACCESS_CLIENT_SECRET='${{ secrets.OPS_SMOKE_CF_ACCESS_CLIENT_SECRET }}' \
+            npm run test:smoke-ops &
           ops_pid=$!
           npm run test:smoke-transport &
           transport_pid=$!


### PR DESCRIPTION
### Motivation
- Fix a CI secret-scoping regression where `OPS_SMOKE_CF_ACCESS_CLIENT_ID` / `OPS_SMOKE_CF_ACCESS_CLIENT_SECRET` were set at a shared step-level `env`, causing non-ops smoke child processes to inherit ops-only Cloudflare Access credentials.

### Description
- Removed ops Cloudflare Access secrets from the step-level `env` in `/.github/workflows/deploy-cloudflare.yml` and `/.github/workflows/pages-release.yml`.
- Scoped the secrets to the ops smoke process by prefixing the `npm run test:smoke-ops` invocation with inline environment assignments so only that command inherits the credentials while keeping the parallel smoke execution.
- Preserved existing smoke sequencing and exit-status aggregation behavior.

### Testing
- Ran `npx vitest run scripts/__tests__/validate-ci-parity.test.ts scripts/__tests__/classify-deploy-changes.test.ts` and all tests passed.
- Validated workflow YAML parsing with `ruby -e 'require "yaml"; ...'` which parsed the modified files successfully.
- Ran `git diff --check` to confirm no whitespace/format errors; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34acd0d92c8332ad81cd40df233c1e)