### PR TITLE
fix(telegram): guard setup cancel pending state

### DIFF
--- a/worker/src/api/__tests__/telegram-webhook-callbacks.test.ts
+++ b/worker/src/api/__tests__/telegram-webhook-callbacks.test.ts
@@ -735,6 +735,27 @@ describe("handleCallbackQuery", () => {
       expect(lastAckBody().text).toBe("Cancelled.");
     });
 
+    it("setup:cancel does not clear unrelated pending rows when no active wizard exists", async () => {
+      const db = mockD1([
+        {
+          match: "FROM telegram_pending_disambiguation WHERE chat_id = ?",
+          rows: [],
+          first: pendingRowFromForget({ action_type: "confirm-bulk", initiator_user_id: "999" }),
+        },
+      ]);
+      await handleCallbackQuery(db, "fake-token", {
+        id: "cb-cancel-unrelated",
+        data: "setup:cancel",
+        from: { id: 7, username: "member" },
+        message: { chat: { id: -42, type: "supergroup" }, message_id: 1 },
+      });
+
+      expect(fetchSpy.mock.calls.some((call) => String(call[0]).includes("getChatMember"))).toBe(false);
+      expect(db.getHistory().some((h) => h.sql.includes("DELETE FROM telegram_pending_disambiguation"))).toBe(false);
+      expect(fetchSpy.mock.calls.some((call) => String(call[0]).includes("sendMessage"))).toBe(false);
+      expect(lastAckBody().text).toBe("Setup expired. Send /start to begin again.");
+    });
+
     it("setup:branch:recommended from a non-initiator user is refused", async () => {
       const db = mockD1([
         {

--- a/worker/src/api/telegram-webhook-setup.ts
+++ b/worker/src/api/telegram-webhook-setup.ts
@@ -613,7 +613,10 @@ export async function handleSetupCancel(
   context: CallbackContext,
   state: SetupWizardState | null,
 ): Promise<{ text: string }> {
-  if (state && state.initiatorUserId != null && state.initiatorUserId !== context.actorUserId) {
+  if (state == null) {
+    return { text: "Setup expired. Send /start to begin again." };
+  }
+  if (state.initiatorUserId != null && state.initiatorUserId !== context.actorUserId) {
     return { text: "Only the user who started this setup can cancel." };
   }
   await clearPendingDisambiguation(context.db, context.chatId);


### PR DESCRIPTION
### Motivation
- Prevent a stale `setup:cancel` callback from deleting unrelated chat-scoped pending rows by ensuring `setup:cancel` only clears state when an active setup wizard row exists. 
- Close an authorization/integrity gap where non-admin group members could trigger a stale cancel button and remove another user's pending confirmation. 
- Preserve the intended UX allowing non-admins to exit their *own* active wizard without an admin lookup.

### Description
- Require an active setup wizard state before performing the cancel flow by returning an expired acknowledgement when `state == null` in `handleSetupCancel` (file `worker/src/api/telegram-webhook-setup.ts`).
- Add a regression test `setup:cancel does not clear unrelated pending rows when no active wizard exists` to `worker/src/api/__tests__/telegram-webhook-callbacks.test.ts` that asserts stale cancels do not run `DELETE FROM telegram_pending_disambiguation`, do not call `sendMessage`, and do not trigger an admin lookup.
- Keep the existing non-admin bypass for non-mutating exits intact so the initiating user can still cancel their own active wizard without an admin check.

### Testing
- Ran the focused callback suite with `npx vitest run worker/src/api/__tests__/telegram-webhook-callbacks.test.ts --reporter=verbose` and all tests passed (`67 passed`).
- Verified TypeScript types with `cd worker && npx tsc --noEmit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3402c941308332b5e9984b5bee7d64)