### PR TITLE
fix(api-keys): repair rejected request cleanup retries

### DIFF
--- a/worker/src/api/__tests__/api-key-requests.test.ts
+++ b/worker/src/api/__tests__/api-key-requests.test.ts
@@ -678,4 +678,63 @@ describe("api key self-serve request handlers", () => {
     expect(sqlite.prepare("SELECT reason FROM api_key_self_serve_revocations").get()).toEqual({ reason: "admin_reject" });
     expect(sqlite.prepare("SELECT status FROM api_key_self_serve_email_claims").get()).toEqual({ status: "released" });
   });
+
+  it("repairs linked key revocation when retrying a partially failed reject", async () => {
+    await handleApiKeyRequest(db, postRequest("/api/api-key-requests", validBody()), env());
+    const token = extractVerificationToken(sentEmails[0]);
+    const issued = await handleApiKeyRequestVerify(
+      db,
+      postRequest("/api/api-key-requests/verify", { token }),
+      env(),
+      "api-key-pepper",
+    );
+    expect(issued.status).toBe(201);
+    const { request_id: requestId } = sqlite.prepare("SELECT request_id FROM api_key_requests").get() as { request_id: string };
+
+    const failRevocationDb = {
+      ...db,
+      prepare: (sql: string) => {
+        const statement = db.prepare(sql);
+        if (!sql.includes("INSERT INTO api_key_self_serve_revocations")) {
+          return statement;
+        }
+        return {
+          ...statement,
+          bind: (...values: unknown[]) => {
+            const bound = statement.bind(...values);
+            return {
+              ...bound,
+              run: async () => {
+                throw new Error("injected revocation write failure");
+              },
+            };
+          },
+        };
+      },
+    } as unknown as D1Database;
+
+    const failedReject = await handleApiKeyRequestReject(
+      failRevocationDb,
+      requestId,
+      true,
+      postRequest(`/api/api-key-requests-admin/${requestId}/reject`, {}, { "X-Pharos-Admin": "1" }),
+    );
+    expect(failedReject.status).toBe(500);
+    expect(sqlite.prepare("SELECT status FROM api_key_requests").get()).toEqual({ status: "rejected" });
+    expect(sqlite.prepare("SELECT is_active FROM api_keys").get()).toEqual({ is_active: 1 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM api_key_self_serve_revocations").get()).toEqual({ count: 0 });
+
+    const retry = await handleApiKeyRequestReject(
+      db,
+      requestId,
+      true,
+      postRequest(`/api/api-key-requests-admin/${requestId}/reject`, {}, { "X-Pharos-Admin": "1" }),
+    );
+
+    expect(retry.status).toBe(200);
+    expect(sqlite.prepare("SELECT status FROM api_key_requests").get()).toEqual({ status: "rejected" });
+    expect(sqlite.prepare("SELECT is_active FROM api_keys").get()).toEqual({ is_active: 0 });
+    expect(sqlite.prepare("SELECT reason FROM api_key_self_serve_revocations").get()).toEqual({ reason: "admin_reject" });
+    expect(sqlite.prepare("SELECT status FROM api_key_self_serve_email_claims").get()).toEqual({ status: "released" });
+  });
 });

--- a/worker/src/api/api-key-requests/admin-handlers.ts
+++ b/worker/src/api/api-key-requests/admin-handlers.ts
@@ -41,6 +41,25 @@ interface ApiKeyRequestByIdRouteContext extends AdminRouteContext {
   requestId: string;
 }
 
+async function revokeAndDeactivateLinkedSelfServeKey(
+  db: D1Database,
+  input: {
+    apiKeyId: number;
+    keyPrefix: string;
+    requestId: string;
+    nowSec: number;
+  },
+): Promise<void> {
+  await recordSelfServeRevocation(db, {
+    apiKeyId: input.apiKeyId,
+    keyPrefix: input.keyPrefix,
+    requestId: input.requestId,
+    nowSec: input.nowSec,
+    reason: "admin_reject",
+  });
+  await deactivateLinkedSelfServeKey(db, input);
+}
+
 export const handleApiKeyRequestsAdminRoute = makeAdminRoute<AdminRouteContext>(
   "api-key-requests-admin",
   async ({ db, request }) => {
@@ -75,12 +94,6 @@ export const handleApiKeyRequestRejectRoute = makeIdempotentAdminRoute<ApiKeyReq
     const row = await selectRequestWithKeyStateByRequestId(db, requestId);
     if (!row) return adminErrorResponse(404, "API key request not found");
     const nowSec = getNowSec();
-    if (row.status === "rejected") {
-      return adminJsonResponse(buildAdminMutationResponse(requestId, "rejected", "released"));
-    }
-    if (row.status !== "pending_verification" && row.status !== "issued") {
-      return adminErrorResponse(409, "Only pending or issued self-serve requests can be rejected");
-    }
     const linkedKeyPrefix = row.linked_key_prefix;
     if (row.api_key_id != null) {
       const mismatch = row.linked_key_tier !== "self-serve"
@@ -89,6 +102,21 @@ export const handleApiKeyRequestRejectRoute = makeIdempotentAdminRoute<ApiKeyReq
       if (mismatch) {
         return adminErrorResponse(409, "Linked API key does not match the self-serve request");
       }
+    }
+    if (row.status === "rejected") {
+      if (row.api_key_id != null && linkedKeyPrefix) {
+        await revokeAndDeactivateLinkedSelfServeKey(db, {
+          apiKeyId: row.api_key_id,
+          keyPrefix: linkedKeyPrefix,
+          requestId,
+          nowSec,
+        });
+      }
+      await releaseEmailClaim(db, row.email_hash, requestId, nowSec);
+      return adminJsonResponse(buildAdminMutationResponse(requestId, "rejected", "released"));
+    }
+    if (row.status !== "pending_verification" && row.status !== "issued") {
+      return adminErrorResponse(409, "Only pending or issued self-serve requests can be rejected");
     }
     // Flip the request status first: D1 has no multi-statement transactions, so
     // the 0-changes guard must short-circuit before any key mutation. Otherwise
@@ -103,14 +131,7 @@ export const handleApiKeyRequestRejectRoute = makeIdempotentAdminRoute<ApiKeyReq
       return adminErrorResponse(409, "API key request state changed before rejection");
     }
     if (row.api_key_id != null && linkedKeyPrefix) {
-      await recordSelfServeRevocation(db, {
-        apiKeyId: row.api_key_id,
-        keyPrefix: linkedKeyPrefix,
-        requestId,
-        nowSec,
-        reason: "admin_reject",
-      });
-      await deactivateLinkedSelfServeKey(db, {
+      await revokeAndDeactivateLinkedSelfServeKey(db, {
         apiKeyId: row.api_key_id,
         keyPrefix: linkedKeyPrefix,
         requestId,


### PR DESCRIPTION
### Motivation
- An admin reject flow could leave a self-serve API key active if the revocation-marker write or deactivation failed after the request status was updated to `rejected`, creating an unrecoverable fail-open state.
- The change aims to ensure retries against an already-`rejected` request re-run the revocation/deactivation cleanup so keys cannot continue authenticating after a partial failure.

### Description
- Add `revokeAndDeactivateLinkedSelfServeKey()` helper and use it from both the normal reject path and the already-`rejected` fast path so revocation and deactivation are retried on subsequent attempts; changed in `worker/src/api/api-key-requests/admin-handlers.ts`.
- Preserve existing linked-key mismatch validation before the repair path so repairs only target expected self-serve keys.
- Replace duplicated revocation/deactivation code with the helper to keep behavior consistent between the initial reject and repair attempt.
- Add a regression test that injects a revocation write failure and verifies a subsequent `reject` call repairs the revocation, deactivation, and claim release in `worker/src/api/__tests__/api-key-requests.test.ts`.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/api/__tests__/api-key-requests.test.ts`, and the test file passed (all tests green).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051eb5788332b5d2421ba793d1b9)