### PR TITLE
Harden Birdeye missing-price handling

### DIFF
--- a/worker/src/lib/__tests__/address-price-providers.test.ts
+++ b/worker/src/lib/__tests__/address-price-providers.test.ts
@@ -212,6 +212,44 @@ describe("address price providers", () => {
     ]);
   });
 
+  it("treats Birdeye 200-level error payloads as provider failures", async () => {
+    const target = makeDexScreenerTarget(0, {
+      chain: "solana",
+      providerChainId: "solana",
+      address: "So11111111111111111111111111111111111111112",
+    });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ success: false, message: "Invalid API key", data: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runBirdeyeAddressProvider(
+      [target],
+      { birdeyeApiKey: "test-key" },
+      undefined,
+      Date.now() + 60_000,
+    );
+
+    expect(result.attemptedRequests).toBe(1);
+    expect(result.successfulRequests).toBe(0);
+    expect(result.quotes).toEqual([]);
+    expect(result.rejectedTargets).toEqual({});
+    expect(result.diagnostics).toMatchObject([
+      {
+        source: "birdeye-address",
+        status: 200,
+        ok: true,
+        success: false,
+        errorClass: "invalid-shape",
+        errorMessage: "Expected Birdeye price data object",
+        rejectionReasonCounts: { "invalid-shape": 1 },
+      },
+    ]);
+  });
+
   it("limits DexScreener address augmentation to one batch per run", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify([]), { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);

--- a/worker/src/lib/address-price-providers/birdeye.ts
+++ b/worker/src/lib/address-price-providers/birdeye.ts
@@ -23,9 +23,7 @@ const BIRDEYE_ADDRESS_MAX_REQUESTS = 10;
 const BIRDEYE_REQUEST_SPACING_MS = 1_000;
 
 function isBirdeyeMissingPricePayload(json: unknown): json is Record<string, unknown> {
-  if (!isRecord(json)) return false;
-  if ("data" in json && json.data == null) return true;
-  return json.success === false && typeof json.message === "string";
+  return isRecord(json) && json.success === true && "data" in json && json.data == null;
 }
 
 export async function runBirdeyeAddressProvider(


### PR DESCRIPTION
### Motivation
- A broad Birdeye missing-price predicate treated 200-level error payloads (e.g. `{ success: false, message: ... }`) as successful coverage misses, which could falsely mark provider runs as `success` and keep provider circuit breakers closed.

### Description
- Tighten the Birdeye missing-price predicate to only classify explicit successful null-data responses (`success === true && data == null`) as coverage misses in `worker/src/lib/address-price-providers/birdeye.ts`.
- Preserve the existing invalid-shape path so 200 OK error-shaped responses are handled as provider failures and surface an `invalid-shape` diagnostic instead of incrementing `successfulRequests`.
- Add a regression test `it("treats Birdeye 200-level error payloads as provider failures")` in `worker/src/lib/__tests__/address-price-providers.test.ts` that verifies an `{ success: false, message: "..." }` payload does not count as a successful request.

### Testing
- Ran the focused test suite with `npx vitest run worker/src/lib/__tests__/address-price-providers.test.ts --reporter verbose` and all tests passed.
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b115e88332ae0226ef3c48d5f7)