### PR TITLE
fix(pricing): reject non-decimal CEX prices

### DIFF
--- a/worker/src/lib/__tests__/cex-tickers.test.ts
+++ b/worker/src/lib/__tests__/cex-tickers.test.ts
@@ -361,6 +361,26 @@ describe("fetchCoinbasePrices", () => {
     expect(outcome.value.prices.has("USDT")).toBe(false);
   });
 
+  it("rejects non-decimal JavaScript numeric literal price strings", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/products/USDT-USD/ticker")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ bid: "0x10", ask: "0b10", price: "0o10" }),
+          });
+        }
+        return Promise.resolve({ ok: false, status: 404 });
+      }),
+    );
+
+    const outcome = await fetchCoinbasePrices(["USDT"]);
+
+    expect(outcome.kind).toBe("no-data");
+    expect(outcome.value.prices.has("USDT")).toBe(false);
+  });
+
   it("keeps Coinbase product fetches serial inside the primary-provider budget", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/worker/src/lib/cex-tickers.ts
+++ b/worker/src/lib/cex-tickers.ts
@@ -15,7 +15,6 @@ import { fetchWithRetry } from "./fetch-retry";
 import { cancelResponseBodyQuietly } from "./response-body";
 import { sleepWithSignal, throwIfAborted } from "./abort";
 import { mapWithConcurrency } from "./concurrency";
-import { parsePositiveNumber } from "./number-utils";
 import {
   endpointLabel,
   errorClassFor,
@@ -32,6 +31,21 @@ const BINANCE_TICKER_URLS = [
   "https://data-api.binance.vision/api/v3/ticker/price",
   "https://api.binance.com/api/v3/ticker/price",
 ] as const;
+
+const DECIMAL_PRICE_PATTERN = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function parseCexPrice(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!DECIMAL_PRICE_PATTERN.test(trimmed)) return null;
+
+  const numeric = Number(trimmed);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
 
 const BINANCE_PAIR_TO_MARKET = new Map<string, (typeof BINANCE_MARKETS)[number]>(
   BINANCE_MARKETS.map((market) => [market.pair, market]),
@@ -67,8 +81,8 @@ function midpointFromBidAsk(
   bid: string | number | null | undefined,
   ask: string | number | null | undefined,
 ): number | null {
-  const parsedBid = parsePositiveNumber(bid);
-  const parsedAsk = parsePositiveNumber(ask);
+  const parsedBid = parseCexPrice(bid);
+  const parsedAsk = parseCexPrice(ask);
   if (parsedBid == null || parsedAsk == null) {
     return null;
   }
@@ -90,7 +104,7 @@ function applyTickerRows<T>(
     if (!symbol) continue;
 
     const midpoint = midpointFromBidAsk(getBid(row), getAsk(row));
-    const lastTrade = parsePositiveNumber(getLastTrade(row));
+    const lastTrade = parseCexPrice(getLastTrade(row));
     const price = midpoint ?? lastTrade;
     if (price != null) {
       results.set(symbol, price);
@@ -191,7 +205,7 @@ async function fetchBinanceTickerUrl(
       const pendingStableQuoted: Array<{ symbol: string; quoteSymbol: string; quotePrice: number }> = [];
       for (const ticker of payload as Array<{ symbol?: string; price?: string }>) {
         const market = ticker.symbol ? BINANCE_PAIR_TO_MARKET.get(ticker.symbol) : undefined;
-        const price = parsePositiveNumber(ticker.price);
+        const price = parseCexPrice(ticker.price);
         if (!market || price == null) continue;
 
         if ("quoteSymbol" in market) {
@@ -385,7 +399,7 @@ export async function fetchCoinbasePrices(
 
         const payload = (await response.json()) as { bid?: string; ask?: string; price?: string; time?: string };
         const midpoint = midpointFromBidAsk(payload.bid, payload.ask);
-        const lastTrade = parsePositiveNumber(payload.price);
+        const lastTrade = parseCexPrice(payload.price);
         const price = midpoint ?? lastTrade;
         if (price != null) {
           const symbol = COINBASE_PRODUCT_TO_SYMBOL.get(product.productId) ?? product.symbol;


### PR DESCRIPTION
### Motivation
- A refactor replaced a local parseFloat-based parser with the shared `Number()`-based `parsePositiveNumber`, which accepts JavaScript numeric-literal strings like `0x10`, `0b10`, and `0o10` and weakens upstream response validation.
- CEX ticker ingestion needs stricter validation because accepted malformed prices propagate into primary provider maps and affect downstream consensus/depeg analytics.
- The goal is to restore the previous decimal-only acceptance semantics for CEX APIs while preserving correct handling of positive numeric and decimal-string prices.

### Description
- Add a CEX-specific decimal validator `DECIMAL_PRICE_PATTERN` and a new `parseCexPrice` helper that only accepts decimal numeric strings (and finite numeric values) before coercion via `Number`.
- Replace imports/usages of the shared `parsePositiveNumber` in CEX ingestion paths with `parseCexPrice`, including bid/ask midpoint parsing, generic ticker row handling, Binance ticker parsing, and Coinbase ticker parsing.
- Remove the local import of the shared parser in the CEX module and route all CEX price fields (`bid`, `ask`, `price`, last-trade) through the stricter parser.
- Add a regression test `rejects non-decimal JavaScript numeric literal price strings` to `worker/src/lib/__tests__/cex-tickers.test.ts` that verifies `0x`, `0b`, and `0o` price strings are rejected.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/lib/__tests__/cex-tickers.test.ts` and all tests passed (`1 test file, 36 tests` passed).
- Performed a TypeScript check with `cd worker && npx tsc --noEmit` which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b124a083328fdaf93adfeeac1e)