### PR TITLE
Cap crvUSD onchain market counts

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
@@ -217,6 +217,94 @@ describe("adaptCrvUsd", () => {
 });
 
 describe("fetchCrvUsdReserves", () => {
+  it("rejects untrusted LLAMMA market counts above the adapter cap before scheduling market reads", async () => {
+    vi.mocked(fetchDefiLlamaPrices).mockResolvedValue(new Map());
+    vi.mocked(fetchOnchainMulticall3).mockResolvedValue([]);
+    vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (_chain, address, data) => {
+      const normalizedAddress = address.toLowerCase();
+      const callData = data as `0x${string}`;
+
+      if (normalizedAddress === CURVE_CONTROLLER_FACTORY.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_FACTORY_ABI, data: callData });
+        if (decoded.functionName === "n_collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "n_collaterals", result: 257n });
+        }
+        throw new Error(`unexpected LLAMMA market read: ${decoded.functionName}`);
+      }
+
+      if (normalizedAddress === YIELD_BASIS_FACTORY) {
+        const decoded = decodeFunctionData({ abi: FACTORY_ABI, data: callData });
+        if (decoded.functionName === "market_count") {
+          return encodeFunctionResult({ abi: FACTORY_ABI, functionName: "market_count", result: 0n });
+        }
+      }
+
+      return null;
+    });
+
+    const config: LiveReservesConfig = {
+      adapter: "crvusd",
+      version: 3,
+      semantics: "collateral-mix",
+      inputs: {
+        primary: {
+          kind: "onchain-evm",
+          chain: "ethereum",
+          rpcMode: "public-rpc",
+        },
+      },
+    };
+
+    await expect(fetchCrvUsdReserves({} as never, config, signal)).rejects.toThrow(
+      "crvUSD ControllerFactory n_collaterals invalid: 257 (max 256)",
+    );
+    expect(fetchEvmCallHexAtBlock).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops Yield Basis when its untrusted market count exceeds the adapter cap before scheduling market reads", async () => {
+    vi.mocked(fetchJsonWithRetry).mockResolvedValue({
+      chains: {
+        ethereum: {
+          data: [{ collateral_amount_usd: 100, collateral_token: { symbol: "WBTC" } }],
+        },
+      },
+    });
+    vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (_chain, address, data) => {
+      const normalizedAddress = address.toLowerCase();
+      const callData = data as `0x${string}`;
+
+      if (normalizedAddress === YIELD_BASIS_FACTORY) {
+        const decoded = decodeFunctionData({ abi: FACTORY_ABI, data: callData });
+        if (decoded.functionName === "market_count") {
+          return encodeFunctionResult({ abi: FACTORY_ABI, functionName: "market_count", result: 257n });
+        }
+        throw new Error(`unexpected Yield Basis market read: ${decoded.functionName}`);
+      }
+
+      return null;
+    });
+
+    const config: LiveReservesConfig = {
+      adapter: "crvusd",
+      version: 2,
+      semantics: "collateral-mix",
+      inputs: {
+        primary: {
+          kind: "http-json",
+          url: "https://prices.curve.finance/v1/crvusd/markets",
+        },
+      },
+    };
+
+    const result = await fetchCrvUsdReserves({} as never, config, signal);
+
+    expect(result.slices).toEqual([{ name: "Custodied BTC (ex: wBTC/cbBTC)", pct: 100, risk: "medium" }]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "yield-basis-read-failed", effect: "degraded" })]),
+    );
+    expect(fetchEvmCallHexAtBlock).toHaveBeenCalledTimes(1);
+  });
+
   it("schedules Yield Basis market reads across markets before awaiting the first market", async () => {
     vi.mocked(fetchJsonWithRetry).mockResolvedValue({ chains: { ethereum: { data: [] } } });
     vi.mocked(fetchDefiLlamaPrices).mockResolvedValue(

--- a/worker/src/cron/reserve-adapters/crvusd.ts
+++ b/worker/src/cron/reserve-adapters/crvusd.ts
@@ -109,6 +109,8 @@ const ETHEREUM_RPC_URLS = [getPublicRpcUrl(ETHEREUM_CHAIN), getSecondaryFallback
 const CURVE_CONTROLLER_FACTORY = "0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC";
 const DIRECT_LLAMMA_MULTICALL_BATCH_SIZE = 500;
 const CRVUSD_MARKET_READ_CONCURRENCY = 2;
+const CRVUSD_MAX_LLAMMA_MARKETS = 256;
+const CRVUSD_MAX_YIELD_BASIS_MARKETS = 256;
 const YIELD_BASIS_FACTORY = "0x370a449febb9411c95bf897021377fe0b7d100c0";
 const YIELD_BASIS_VIEW_GAS = "0x5B8D80";
 const YIELD_BASIS_OPTIONAL_TIMEOUT_MS = 6_000;
@@ -297,6 +299,14 @@ function safeInt256ToNumber(value: bigint, label: string): number {
   return asNumber;
 }
 
+function validateOnchainMarketCount(raw: bigint, label: string, maxCount: number): number {
+  const marketCount = Number(raw);
+  if (!Number.isSafeInteger(marketCount) || marketCount < 0 || marketCount > maxCount) {
+    throw new Error(`crvUSD ${label} invalid: ${String(raw)} (max ${maxCount})`);
+  }
+  return marketCount;
+}
+
 async function fetchLlammaMarketDescriptors(
   signal: AbortSignal,
   ctx?: AdapterContext,
@@ -308,10 +318,11 @@ async function fetchLlammaMarketDescriptors(
     signal,
     ctx,
   )) as bigint;
-  const marketCount = Number(countRaw);
-  if (!Number.isSafeInteger(marketCount) || marketCount < 0) {
-    throw new Error(`crvUSD ControllerFactory n_collaterals invalid: ${String(countRaw)}`);
-  }
+  const marketCount = validateOnchainMarketCount(
+    countRaw,
+    "ControllerFactory n_collaterals",
+    CRVUSD_MAX_LLAMMA_MARKETS,
+  );
 
   const descriptors = await mapWithConcurrency(
     Array.from({ length: marketCount }, (_, marketId) => marketId),
@@ -468,10 +479,11 @@ async function fetchYieldBasisMarketPositions(
     signal,
     ctx,
   )) as bigint;
-  const marketCount = Number(marketCountRaw);
-  if (!Number.isSafeInteger(marketCount) || marketCount < 0) {
-    throw new Error(`crvUSD Yield Basis market_count invalid: ${String(marketCountRaw)}`);
-  }
+  const marketCount = validateOnchainMarketCount(
+    marketCountRaw,
+    "Yield Basis market_count",
+    CRVUSD_MAX_YIELD_BASIS_MARKETS,
+  );
 
   const positions = await mapWithConcurrency(
     Array.from({ length: marketCount }, (_, marketId) => marketId),


### PR DESCRIPTION
### Motivation
- Prevent a DoS/availability risk where externally-decoded on-chain market counts could be large but still safely-typed, allowing `Array.from({ length: marketCount })` + parallel reads to synchronously allocate huge task arrays and enqueue many RPC calls before abort/timeouts run.

### Description
- Add conservative per-adapter caps `CRVUSD_MAX_LLAMMA_MARKETS` and `CRVUSD_MAX_YIELD_BASIS_MARKETS` (256) and a `validateOnchainMarketCount` helper to centralize validation. 
- Replace raw `Number(...)` + `Number.isSafeInteger` checks with `validateOnchainMarketCount(...)` for LLAMMA `n_collaterals` and Yield Basis `market_count` before any `Array.from` or per-market work is materialized. 
- Keep bounded parallelism via the existing `mapWithConcurrency` scheduling while ensuring untrusted on-chain counts over the cap fail early. 
- Add focused tests to assert LLAMMA over-cap counts are rejected and Yield Basis over-cap counts cause the optional leg to degrade without scheduling per-market reads.

### Testing
- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts` and the suite passed (`13 passed`).
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation succeeded with no emit errors. 
- Ran `npm run check:cron-connections` and the cron connection budget checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1756c8332a512c5d71eda0a2f)