### PR TITLE
fix(redemption): degrade unverified M0 extension routes

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/m0-wrapper-underlying.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/m0-wrapper-underlying.test.ts
@@ -137,6 +137,53 @@ describe("fetchM0WrapperUnderlyingReserves", () => {
     });
   });
 
+  it("degrades M extension capacity when route probes cannot be verified", async () => {
+    fetchWithRetryMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { params: [{ to?: string; data: string }] };
+      const call = body.params[0];
+      const to = call.to?.toLowerCase();
+      if (call.data === "0xc3b6f939") return jsonResponse({ result: addressResult(M_TOKEN) });
+      if (call.data === "0xae06b7e4") return jsonResponse({ result: addressResult(SWAP_FACILITY) });
+      if (call.data === "0x18160ddd") return jsonResponse({ result: uint256Result(4_000_000_000000n) });
+      if (call.data === "0x313ce567") return jsonResponse({ result: uint256Result(6) });
+      if (to === M_TOKEN && call.data.startsWith("0x70a08231")) {
+        return jsonResponse({ result: uint256Result(4_000_000_000000n) });
+      }
+      if (to === SWAP_FACILITY && (call.data === "0x5c975abb" || call.data.startsWith("0xd8e21132"))) {
+        return jsonResponse({ error: { code: -32000, message: "route probe unavailable" } });
+      }
+      return null;
+    });
+
+    const { fetchM0WrapperUnderlyingReserves } = await import("../m0-wrapper-underlying");
+    const result = await fetchM0WrapperUnderlyingReserves(
+      { id: "usdsc-startale" } as StablecoinMeta,
+      baseConfig({
+        mode: "m-extension",
+        expectedSwapFacilityAddress: SWAP_FACILITY,
+        swapperAddress: SWAPPER,
+      }),
+      new AbortController().signal,
+      { chainRpcs: testChainRpcs },
+    );
+
+    expect(result.metadata).toMatchObject({
+      redemption: {
+        capacityUsd: 4_000_000,
+        routeStatus: "unknown",
+        routeStatusSource: "onchain",
+        routeStatusReason: "Could not verify M0 SwapFacility redemption path status",
+      },
+    });
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: "m0-extension-route-unverified",
+        effect: "degraded",
+        severity: "warning",
+      }),
+    ]);
+  });
+
   it("degrades under-backed wrappers instead of publishing score-grade coverage", async () => {
     fetchWithRetryMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as { params: [{ to?: string; data: string }] };

--- a/worker/src/cron/reserve-adapters/m0-wrapper-underlying.ts
+++ b/worker/src/cron/reserve-adapters/m0-wrapper-underlying.ts
@@ -21,6 +21,7 @@ import {
   requireOnchainInput,
 } from "./helpers";
 import { ratioFromRaw } from "./slice-math";
+import { reserveDegradedWarning } from "./warnings";
 import type { AdapterContext, AdapterResult } from "./types";
 
 const ADAPTER_KEY = "m0-wrapper-underlying";
@@ -273,6 +274,14 @@ export async function fetchM0WrapperUnderlyingReserves(
     message: (pct) => `M0 wrapper underlying balance covers ${pct}% of wrapper supply`,
     coverageRatio: collateralizationRatio,
   });
+  if (params.mode === "m-extension" && routeStatus === "unknown") {
+    warnings.push(
+      reserveDegradedWarning(
+        "m0-extension-route-unverified",
+        routeStatusReason ?? "Could not verify M0 SwapFacility redemption path status",
+      ),
+    );
+  }
   const sliceConfig = parseSliceConfig(params);
 
   return {


### PR DESCRIPTION
### Motivation
- The M0 `m-extension` adapter previously treated unreadable `paused()` / `canSwapViaPath(...)` probes as `routeStatus = "unknown"` but still emitted `capacityKind: "live-direct"` and scoreable capacity, allowing transient or attacker-influenced RPC failures to keep live capacity as high-confidence.
- The intent is to fail closed (surface a degraded warning) when on-chain route verification cannot be completed so downstream scoring does not treat unverified live-direct capacity as warning-free.

### Description
- When `params.mode === "m-extension"` and the route probes decode to `unknown`, add a degraded reserve warning by importing and using `reserveDegradedWarning` from `./warnings` and pushing a `m0-extension-route-unverified` warning into the adapter `warnings` array in `worker/src/cron/reserve-adapters/m0-wrapper-underlying.ts`.
- Preserve the existing telemetry shape (still emit `redemption.capacityUsd`, `capacityKind: "live-direct"`, `freshnessKind: "same-run-onchain"`, and `routeStatusSource: "onchain"`) while ensuring a non-info degraded warning is present so downstream capacity logic treats the metadata as degraded.
- Add a unit test `degrades M extension capacity when route probes cannot be verified` to `worker/src/cron/reserve-adapters/__tests__/m0-wrapper-underlying.test.ts` that simulates RPC errors for `paused()` and `canSwapViaPath(...)`, asserts `routeStatus === "unknown"`, and expects the `m0-extension-route-unverified` degraded warning.

### Testing
- Ran the focused Vitest suite: `npm exec -- vitest run worker/src/cron/reserve-adapters/__tests__/m0-wrapper-underlying.test.ts`, which passed all tests in the file.
- Verified TypeScript compilation for the Worker: `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b17d148332955d2b6bd9fbeb9f)