### PR TITLE
fix(worker): bound DexScreener error diagnostics

### DIFF
--- a/worker/src/lib/__tests__/dexscreener.test.ts
+++ b/worker/src/lib/__tests__/dexscreener.test.ts
@@ -59,6 +59,37 @@ describe("dexscreener", () => {
     });
   });
 
+  it("bounds and cancels non-OK diagnostic body reads", async () => {
+    let bytesPulled = 0;
+    let cancelCalled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const chunk = new TextEncoder().encode("x".repeat(512));
+        bytesPulled += chunk.byteLength;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        cancelCalled = true;
+      },
+    });
+    vi.mocked(fetchWithRetry).mockResolvedValueOnce(
+      new Response(body, {
+        status: 500,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    await expect(fetchDsTokenPoolsWithStatus("base", "0xabc")).resolves.toMatchObject({
+      ok: false,
+      pairs: [],
+      status: 500,
+      contentType: "text/html",
+      error: `HTTP 500 for https://api.dexscreener.com/tokens/v1/base/0xabc; body starts with: ${"x".repeat(160)}`,
+    });
+    expect(bytesPulled).toBeLessThanOrEqual(2048);
+    expect(cancelCalled).toBe(true);
+  });
+
   it("keeps valid token-pool rows and drops malformed rows from mixed payloads", async () => {
     const validPair = {
       chainId: "base",

--- a/worker/src/lib/dexscreener.ts
+++ b/worker/src/lib/dexscreener.ts
@@ -77,11 +77,44 @@ function summarizeBody(raw: string, limit = 160): string {
   return raw.replace(/\s+/g, " ").trim().slice(0, limit);
 }
 
+async function readBodySnippet(res: Response, maxBytes = 1024): Promise<string> {
+  if (!res.body) return "";
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+  try {
+    while (bytesRead < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+      const remaining = maxBytes - bytesRead;
+      const chunk = value.byteLength > remaining ? value.slice(0, remaining) : value;
+      chunks.push(chunk);
+      bytesRead += chunk.byteLength;
+      if (value.byteLength > remaining) break;
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Best-effort cancellation only; diagnostics should never fail the fetch path.
+    }
+  }
+  if (chunks.length === 0) return "";
+  if (chunks.length === 1) return new TextDecoder().decode(chunks[0]);
+  const buffer = new Uint8Array(bytesRead);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(buffer);
+}
+
 async function describeNonOkResponse(url: string, res: Response): Promise<DsFetchPoolsResult> {
   const contentType = res.headers.get("content-type") ?? "unknown";
   let snippet = "";
   try {
-    snippet = summarizeBody(await res.text());
+    snippet = summarizeBody(await readBodySnippet(res));
   } catch {
     snippet = "";
   }


### PR DESCRIPTION
### Motivation

- The DexScreener diagnostic path previously called `res.text()` on non-OK responses, which can fully buffer an untrusted upstream error body and risk Worker memory/time exhaustion during cron runs.
- The intent is to preserve useful diagnostics while preventing unbounded I/O and memory use from malicious or overly large provider responses.

### Description

- Add `readBodySnippet(res, maxBytes)` to read and decode at most a small prefix (default 1024 bytes) from a `Response` stream and cancel the reader afterward so the rest of the body is not buffered.
- Replace the unbounded `await res.text()` usage in `describeNonOkResponse()` with a bounded read followed by `summarizeBody()` on the prefix so diagnostics stay compact and I/O-bounded.
- Add a unit test that simulates a streaming non-OK response and asserts the diagnostic path only pulls a bounded amount and that the stream `cancel()` is invoked.

### Testing

- Ran the targeted unit suite with `npx vitest run worker/src/lib/__tests__/dexscreener.test.ts`, which passed (including the new bounded-read test).
- Type-checked worker code with `cd worker && npx tsc --noEmit`, which succeeded.
- Verified cron connection budgets with `npm run check:cron-connections`, which reported all triggers within budget.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1d4088332a7686d4ff32b096a)