### PR TITLE
Fix BRL peg alias canonicalization

### DIFF
--- a/shared/lib/__tests__/peg-rates.test.ts
+++ b/shared/lib/__tests__/peg-rates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { derivePegRates, getPegReference } from "@shared/lib/peg-rates";
+import { derivePegRates, getPegReference, normalizePegType } from "@shared/lib/peg-rates";
 import type { PegAssetBase, StablecoinMeta } from "@shared/types";
 
 function asset(
@@ -124,11 +124,30 @@ describe("derivePegRates", () => {
     expect(result.sources.peggedEUR).toBe("fallback");
   });
 
-  it("normalizes BRL peg types to the DefiLlama peggedREAL key", () => {
+  it("keeps BRL alias maps compatible with raw peggedBRL consumers", () => {
     const result = derivePegRates([asset("brl-token", "peggedBRL", 0.18, 2_000_000)]);
 
-    expect(result.rates.peggedBRL).toBeUndefined();
     expect(result.rates.peggedREAL).toBe(0.18);
+    expect(result.rates.peggedBRL).toBe(0.18);
+    expect(result.sources.peggedBRL).toBe("median");
+    expect(result.counts.peggedBRL).toBe(1);
+  });
+
+  it("normalizes fallback rates before aliasing", () => {
+    const result = derivePegRates([], new Map(), { peggedBRL: 0.2 });
+
+    expect(result.rates.peggedREAL).toBe(0.2);
+    expect(result.rates.peggedBRL).toBe(0.2);
+    expect(result.sources.peggedBRL).toBe("fallback");
+    expect(result.counts.peggedBRL).toBe(0);
+  });
+});
+
+describe("normalizePegType", () => {
+  it("canonicalizes the legacy BRL peg alias", () => {
+    expect(normalizePegType("peggedBRL")).toBe("peggedREAL");
+    expect(normalizePegType("peggedEUR")).toBe("peggedEUR");
+    expect(normalizePegType(undefined)).toBeUndefined();
   });
 });
 
@@ -140,5 +159,9 @@ describe("getPegReference", () => {
 
   it("returns 1 for unknown peg types when no rate is available", () => {
     expect(getPegReference("peggedDOGE", {})).toBe(1);
+  });
+
+  it("uses the canonical BRL peg rate for legacy peggedBRL references", () => {
+    expect(getPegReference("peggedBRL", { peggedREAL: 0.2 })).toBe(0.2);
   });
 });

--- a/shared/lib/peg-rates.ts
+++ b/shared/lib/peg-rates.ts
@@ -17,8 +17,25 @@ export interface PegRatesResult {
   counts: Record<string, number>;
 }
 
-function normalizePegType(pegType: string | undefined): string | undefined {
+export function normalizePegType(pegType: string | undefined): string | undefined {
   return pegType === "peggedBRL" ? "peggedREAL" : pegType;
+}
+
+function normalizeFallbackRates(fallbackRates: Record<string, number> | undefined): Record<string, number> {
+  const normalized: Record<string, number> = {};
+  for (const [pegType, rate] of Object.entries(fallbackRates ?? {})) {
+    const peg = normalizePegType(pegType);
+    if (!peg) continue;
+    normalized[peg] = rate;
+  }
+  return normalized;
+}
+
+function addPegRateAliases(result: PegRatesResult): void {
+  if (result.rates.peggedREAL == null || result.rates.peggedBRL != null) return;
+  result.rates.peggedBRL = result.rates.peggedREAL;
+  if (result.sources.peggedREAL != null) result.sources.peggedBRL = result.sources.peggedREAL;
+  if (result.counts.peggedREAL != null) result.counts.peggedBRL = result.counts.peggedREAL;
 }
 
 /**
@@ -69,7 +86,7 @@ export function derivePegRates(
   // Use only live cached FX rates — no stale hardcoded defaults.
   // On fresh deploy before first FX sync, fallbackRates is undefined
   // and thin-group validation is skipped for one cycle.
-  const mergedFallbacks = fallbackRates ?? {};
+  const mergedFallbacks = normalizeFallbackRates(fallbackRates);
 
   const rates: Record<string, number> = {};
   const sources: Record<string, PegRateSource> = {};
@@ -110,7 +127,9 @@ export function derivePegRates(
   if (!rates["peggedUSD"]) rates["peggedUSD"] = 1;
   if (!sources["peggedUSD"]) sources["peggedUSD"] = "median";
 
-  return { rates, sources, counts };
+  const result = { rates, sources, counts };
+  addPegRateAliases(result);
+  return result;
 }
 
 /**
@@ -124,9 +143,10 @@ export function getPegReference(
   commodityOunces?: number
 ): number {
   if (!pegType) return 1;
-  const rate = rates[pegType] ?? 1;
+  const peg = normalizePegType(pegType);
+  const rate = peg ? rates[peg] ?? 1 : 1;
   // For gold/silver tokens, scale the per-ounce rate by the token's weight
-  if ((pegType === "peggedGOLD" || pegType === "peggedSILVER") && commodityOunces && commodityOunces > 0) {
+  if ((peg === "peggedGOLD" || peg === "peggedSILVER") && commodityOunces && commodityOunces > 0) {
     return rate * commodityOunces;
   }
   return rate;

--- a/worker/src/cron/depeg-detection/decision-engine.ts
+++ b/worker/src/cron/depeg-detection/decision-engine.ts
@@ -1,4 +1,4 @@
-import { getPegReference } from "@shared/lib/peg-rates";
+import { getPegReference, normalizePegType } from "@shared/lib/peg-rates";
 import { normalizePricingSourceKeys } from "@shared/lib/pricing-sources";
 import { sumPegBuckets } from "@shared/lib/supply";
 import type { DepegEvent } from "@shared/types/market";
@@ -294,11 +294,12 @@ function deriveDecisionContext(input: DepegAssetDecisionInput): DecisionContextD
     return { kind: "skip", decision };
   }
 
+  const pegType = normalizePegType(asset.pegType);
   const pegReferenceIsAuthoritative = isAuthoritativeDepegPegReference({
     pegCurrency: meta.flags.pegCurrency,
-    pegType: asset.pegType,
-    pegRateSource: asset.pegType ? input.pegRateSources[asset.pegType] : undefined,
-    pegRateContributorCount: asset.pegType ? input.pegRateCounts[asset.pegType] : undefined,
+    pegType,
+    pegRateSource: pegType ? input.pegRateSources[pegType] : undefined,
+    pegRateContributorCount: pegType ? input.pegRateCounts[pegType] : undefined,
   });
   if (!pegReferenceIsAuthoritative) {
     const decision = emptyDecision(trackedCoinId);
@@ -313,7 +314,7 @@ function deriveDecisionContext(input: DepegAssetDecisionInput): DecisionContextD
     return { kind: "skip", decision };
   }
 
-  const pegRef = getPegReference(asset.pegType, input.pegRates, meta.commodityOunces);
+  const pegRef = getPegReference(pegType, input.pegRates, meta.commodityOunces);
   if (!Number.isFinite(pegRef) || pegRef <= 0) {
     return { kind: "skip", decision: emptyDecision(trackedCoinId) };
   }

--- a/worker/src/cron/dews/scoring.ts
+++ b/worker/src/cron/dews/scoring.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { getCirculatingRaw, getPrevDayRawOrNull, getPrevWeekRawOrNull } from "@shared/lib/supply";
 import { PSI_ELIGIBLE_STABLECOINS } from "@shared/lib/psi-eligible";
-import { getPegReference } from "@shared/lib/peg-rates";
+import { getPegReference, normalizePegType } from "@shared/lib/peg-rates";
 import { computeDEWS } from "../../lib/dews";
 import type { DEWSInput, DEWSResult, PoolEntry } from "../../lib/dews";
 import { isAuthoritativeDepegPegReference } from "../../lib/depeg-trust-policy";
@@ -121,7 +121,7 @@ export function buildDewsScoringResult(options: BuildDewsScoringResultOptions): 
       registerMalformedPersistedInput,
     );
 
-    const pegType = asset.pegType ?? "peggedUSD";
+    const pegType = normalizePegType(asset.pegType) ?? "peggedUSD";
     const hasPegReference = pegType === "peggedUSD" || Object.prototype.hasOwnProperty.call(pegRates, pegType);
     const pegRateSource = pegRateSources[pegType] ?? null;
     const pegRateContributorCount = pegRateContributorCounts[pegType] ?? null;

--- a/worker/src/cron/pending-depeg-confirmation.ts
+++ b/worker/src/cron/pending-depeg-confirmation.ts
@@ -1,6 +1,6 @@
 import type { PegAssetBase } from "@shared/types/core";
 import { ACTIVE_META_BY_ID } from "@shared/lib/stablecoins/registry";
-import { getPegReference, type PegRateSource } from "@shared/lib/peg-rates";
+import { getPegReference, normalizePegType, type PegRateSource } from "@shared/lib/peg-rates";
 import {
   DEPEG_PENDING_EXPIRY_SEC,
   DEPEG_PENDING_MIN_AGE_SEC,
@@ -331,18 +331,19 @@ export function buildConfirmationPlan(input: ConfirmationPlanInput): Confirmatio
     openSet,
     now,
   } = input;
+  const pegType = normalizePegType(asset?.pegType);
   const refreshedPegReferenceIsAuthoritative =
     asset && meta
       ? isAuthoritativeDepegPegReference({
         pegCurrency: meta.flags.pegCurrency,
-        pegType: asset.pegType,
-        pegRateSource: asset.pegType ? pegRateSources[asset.pegType] : undefined,
-        pegRateContributorCount: asset.pegType ? pegRateCounts[asset.pegType] : undefined,
+        pegType,
+        pegRateSource: pegType ? pegRateSources[pegType] : undefined,
+        pegRateContributorCount: pegType ? pegRateCounts[pegType] : undefined,
       })
       : false;
   const refreshedPegRef =
     asset && meta && refreshedPegReferenceIsAuthoritative
-      ? getPegReference(asset.pegType, pegRates, meta.commodityOunces)
+      ? getPegReference(pegType, pegRates, meta.commodityOunces)
       : Number.NaN;
   const pegReference =
     Number.isFinite(refreshedPegRef) && refreshedPegRef > 0

--- a/worker/src/lib/__tests__/peg-analytics.test.ts
+++ b/worker/src/lib/__tests__/peg-analytics.test.ts
@@ -61,6 +61,9 @@ vi.mock("@shared/lib/peg-score", () => ({
 vi.mock("@shared/lib/peg-rates", () => ({
   derivePegRates: vi.fn(() => ({ rates: { USD: 1 }, sources: {} })),
   getPegReference: vi.fn(() => 1),
+  normalizePegType: vi.fn((pegType: string | undefined) =>
+    pegType === "peggedBRL" ? "peggedREAL" : pegType,
+  ),
 }));
 
 vi.mock("@shared/lib/depeg-dews-version", () => ({

--- a/worker/src/lib/peg-analytics.ts
+++ b/worker/src/lib/peg-analytics.ts
@@ -5,7 +5,7 @@ import {
   NULL_PEG_SCORE_RESULT,
   PEG_SCORE_LOOKBACK_SEC,
 } from "@shared/lib/peg-score";
-import { derivePegRates, getPegReference } from "@shared/lib/peg-rates";
+import { derivePegRates, getPegReference, normalizePegType } from "@shared/lib/peg-rates";
 import { getDepegDewsMethodologyVersionAt } from "@shared/lib/depeg-dews-version";
 import { sumPegBuckets } from "@shared/lib/supply";
 import type { DepegEvent, PegSummaryCoin, StablecoinData } from "@shared/types/market";
@@ -116,17 +116,18 @@ export async function derivePegAnalyticsSnapshot(
         // peer median without a live FX fallback is self-referential (a lone
         // coin always reads ~0; a 2-coin group mirrors half of any real move
         // onto the healthy peer), so deviation is withheld instead of shown.
+        const pegType = normalizePegType(asset.pegType);
         if (
           !isAuthoritativeDepegPegReference({
-            pegType: asset.pegType,
+            pegType,
             pegCurrency: meta.flags.pegCurrency,
-            pegRateSource: pegRateSources[asset.pegType] ?? null,
-            pegRateContributorCount: pegRateCounts[asset.pegType] ?? null,
+            pegRateSource: pegType ? pegRateSources[pegType] ?? null : null,
+            pegRateContributorCount: pegType ? pegRateCounts[pegType] ?? null : null,
           })
         ) {
           pegReferenceUnavailable = true;
         } else {
-          const pegRef = getPegReference(asset.pegType, pegRates, meta.commodityOunces);
+          const pegRef = getPegReference(pegType, pegRates, meta.commodityOunces);
           currentDeviationBps =
             pegRef != null && Number.isFinite(pegRef) && pegRef > 0
               ? deriveDepegSignal(asset.price, pegRef)?.bps ?? null


### PR DESCRIPTION
### Motivation
- A recent refactor canonicalized `peggedBRL` -> `peggedREAL` when deriving peg rates but consumers still indexed maps with raw `asset.pegType`, causing BRL assets to miss rate/source/count entries and suppress depeg alerts or compute incorrect references.
- The change must preserve backward compatibility for raw-key consumers while ensuring all trust checks and reference calculations use a single canonical peg key.

### Description
- Export `normalizePegType()` from `shared/lib/peg-rates.ts` and use it to canonicalize legacy `peggedBRL` inputs to `peggedREAL` in producer and consumer paths.
- In `shared/lib/peg-rates.ts` add `normalizeFallbackRates()` and `addPegRateAliases()` so fallback rates are normalized and derived maps publish backward-compatible `peggedBRL` aliases alongside canonical `peggedREAL` entries.
- Make `getPegReference()` use the canonical peg key (`normalizePegType`) before looking up `rates`, and ensure gold/silver scaling still applies against the normalized key.
- Normalize peg keys before lookups in the depeg engine and analytics by updating `worker/src/cron/depeg-detection/decision-engine.ts`, `worker/src/cron/pending-depeg-confirmation.ts`, `worker/src/cron/dews/scoring.ts`, and `worker/src/lib/peg-analytics.ts` to call `normalizePegType()` for trust/source/count/`getPegReference` usages.
- Update tests and mocks: extend `shared/lib/__tests__/peg-rates.test.ts` with BRL-alias and fallback normalization assertions and export `normalizePegType` in the peg-analytics test mock (`worker/src/lib/__tests__/peg-analytics.test.ts`).

### Testing
- Ran `npx vitest run shared/lib/__tests__/peg-rates.test.ts` and the suite passed.
- Ran `npx vitest run shared/lib/__tests__/peg-rates.test.ts worker/src/lib/__tests__/peg-analytics.test.ts` after fixing mocks, and all unit tests for the affected areas passed (`19 passed`).
- Ran repository checks `npm run check:worker-boundary` and `npm run check:shared-cycles`, both succeeded.
- Verified TypeScript build for the Worker with `cd worker && npx tsc --noEmit`, which succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues; it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0add48332be7bafeb33f00267)