### PR TITLE
fix(worker): redact provider retry logs

### DIFF
--- a/worker/src/lib/__tests__/fetch-retry.test.ts
+++ b/worker/src/lib/__tests__/fetch-retry.test.ts
@@ -22,6 +22,7 @@ describe("fetchWithRetry", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -102,6 +103,32 @@ describe("fetchWithRetry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(sleepWithSignalMock).toHaveBeenCalledWith(2000, undefined);
     await expect(res?.json()).resolves.toEqual({ error: "slow down" });
+  });
+
+  it("uses the configured log URL for passthrough 429 warnings", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "slow down" }), {
+        status: 429,
+        headers: { "Retry-After": "1" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithRetry(
+      "https://api.g.alchemy.com/prices/v1/ALCHEMY_SECRET_KEY_DO_NOT_LOG_12345/tokens/by-address",
+      undefined,
+      0,
+      {
+        passthroughStatuses: [429],
+        logUrl: "api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address",
+      },
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[fetch-retry] api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address rate-limited (429), waiting 1000ms before passthrough",
+    );
+    expect(warnSpy.mock.calls.join("\n")).not.toContain("ALCHEMY_SECRET_KEY_DO_NOT_LOG_12345");
   });
 
   it("backs off on 529 overload responses before succeeding", async () => {

--- a/worker/src/lib/address-price-providers/shared.ts
+++ b/worker/src/lib/address-price-providers/shared.ts
@@ -123,6 +123,7 @@ export async function fetchProviderJson(params: {
     {
       timeoutMs: ADDRESS_PROVIDER_TIMEOUT_MS,
       passthroughStatuses: PASSTHROUGH_STATUSES,
+      logUrl: baseDiagnostic.endpoint,
     },
   );
   if (!response) {

--- a/worker/src/lib/fetch-retry.ts
+++ b/worker/src/lib/fetch-retry.ts
@@ -6,6 +6,7 @@ interface FetchWithRetryOptions {
   passthroughStatuses?: number[];
   returnFinalResponse?: boolean;
   timeoutMs?: number;
+  logUrl?: string;
 }
 function getRetryDelayMs(response: Response, attempt: number): number | null {
   if (response.status === 429) {
@@ -37,6 +38,7 @@ export async function fetchWithRetry(
   const passthroughStatuses = new Set<number>(options?.passthroughStatuses ?? []);
   if (passthrough404) passthroughStatuses.add(404);
   const timeoutMs = options?.timeoutMs ?? 15_000;
+  const logUrl = options?.logUrl ?? url;
   const signal = opts?.signal ?? undefined;
   for (let i = 0; i <= maxRetries; i++) {
     throwIfAborted(signal);
@@ -60,7 +62,7 @@ export async function fetchWithRetry(
         const passthroughDelayMs = res.status === 429 ? getRetryDelayMs(res, i) : null;
         if (passthroughDelayMs != null) {
           const body = await res.text();
-          console.warn(`[fetch-retry] ${url} rate-limited (${res.status}), waiting ${passthroughDelayMs}ms before passthrough`);
+          console.warn(`[fetch-retry] ${logUrl} rate-limited (${res.status}), waiting ${passthroughDelayMs}ms before passthrough`);
           await sleepWithSignal(passthroughDelayMs, signal);
           return new Response(body, {
             status: res.status,
@@ -73,12 +75,12 @@ export async function fetchWithRetry(
       const retryDelayMs = i < maxRetries ? getRetryDelayMs(res, i) : null;
       if (retryDelayMs != null) {
         const label = res.status === 529 ? "overloaded" : "rate-limited";
-        console.warn(`[fetch-retry] ${url} ${label} (${res.status}), waiting ${retryDelayMs}ms`);
+        console.warn(`[fetch-retry] ${logUrl} ${label} (${res.status}), waiting ${retryDelayMs}ms`);
         await cancelResponseBodyQuietly(res);
         await sleepWithSignal(retryDelayMs, signal);
         continue;
       }
-      console.warn(`[fetch-retry] ${url} returned ${res.status} (attempt ${i + 1}/${maxRetries + 1})`);
+      console.warn(`[fetch-retry] ${logUrl} returned ${res.status} (attempt ${i + 1}/${maxRetries + 1})`);
       if (options?.returnFinalResponse && i >= maxRetries) {
         return res;
       }
@@ -87,7 +89,7 @@ export async function fetchWithRetry(
       if (signal?.aborted) {
         throw err instanceof Error ? err : new Error(String(err));
       }
-      console.warn(`[fetch-retry] ${url} failed (attempt ${i + 1}/${maxRetries + 1}):`, err);
+      console.warn(`[fetch-retry] ${logUrl} failed (attempt ${i + 1}/${maxRetries + 1}):`, err);
     }
     if (i < maxRetries) {
       await sleepWithSignal(1000 * 2 ** i, signal);


### PR DESCRIPTION
### Motivation
- Prevent leaking upstream provider credentials to runtime logs when `fetchWithRetry` handles passthrough 429 responses, because some providers (notably the Alchemy address-price endpoint) embed API keys in the request URL.\
- Ensure existing diagnostic endpoints (which are already redacted) are used for logging instead of raw request URLs containing secrets.\

### Description
- Add an explicit `logUrl` option to `fetchWithRetry` and use it for all retry/passthrough `console.warn` messages so logs can show a safe, redacted endpoint label rather than the raw request URL. (`worker/src/lib/fetch-retry.ts`).\
- Pass the address-provider diagnostic `endpoint` (the redacted label) into `fetchWithRetry` from `fetchProviderJson` so address-price providers (including Alchemy) do not cause secret-bearing URLs to be logged. (`worker/src/lib/address-price-providers/shared.ts`).\
- Add a regression test that simulates a passthrough 429 from an Alchemy-style URL and asserts the emitted warning uses the configured redacted `logUrl` and does not contain the secret. (`worker/src/lib/__tests__/fetch-retry.test.ts`).\

### Testing
- Ran the focused unit test with `npx vitest run worker/src/lib/__tests__/fetch-retry.test.ts` and it passed.\
- Type-checked the Worker code with `cd worker && npx tsc --noEmit` and there were no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b171d0833296bd13f09813bc6e)