### PR TITLE
fix(reserves): harden InfiniFi freshness probe

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts
@@ -373,6 +373,44 @@ describe("adaptInfiniFi", () => {
     });
   });
 
+  it("falls back to unverified freshness when the optional rate-history probe has malformed data points", async () => {
+    const url = "https://example.com/infinifi";
+    const response: InfiniFiProtocolData = {
+      ...SAMPLE_RESPONSE,
+      data: {
+        ...SAMPLE_RESPONSE.data,
+        stats: {
+          asset: { totalTVLAssetNormalized: 100 },
+          staked: { exchangeRateNormalized: 1.0727 },
+        },
+      },
+    };
+
+    const result = await fetchInfiniFiReserves(
+      { id: "infinifi" } as never,
+      {
+        adapter: "infinifi",
+        version: 1,
+        semantics: "collateral-mix",
+        inputs: { primary: { kind: "http-json", url } },
+      },
+      new AbortController().signal,
+      {
+        requestCache: new Map<string, Promise<unknown>>([
+          [`json-get:${url}:12000:null`, Promise.resolve(response)],
+          [RATE_HISTORY_CACHE_KEY, Promise.resolve({ code: "OK", data: { dataPoints: [null] } })],
+        ]),
+      } as never,
+    );
+
+    expect(result.metadata).toMatchObject({
+      freshnessMode: "unverified",
+      details: {
+        freshnessReason: "InfiniFi protocol stats payload does not expose a trustworthy source timestamp",
+      },
+    });
+  });
+
   it("verifies freshness from the siUSD rate-history probe when it matches the live staked rate", async () => {
     const url = "https://example.com/infinifi";
     const response: InfiniFiProtocolData = {
@@ -449,6 +487,17 @@ describe("resolveInfiniFiFreshness", () => {
     const expectedReason = "InfiniFi protocol stats payload does not expose a trustworthy source timestamp";
     for (const rateHistory of [null, { code: "ERROR" }, { code: "OK", data: { dataPoints: [] } }] as const) {
       expect(resolveInfiniFiFreshness(payloadWithRate(1.07), rateHistory as InfiniFiRateHistoryResponse | null))
+        .toMatchObject({ freshnessMode: "unverified", details: { freshnessReason: expectedReason } });
+    }
+  });
+
+  it("stays unverified for malformed rate-history dataPoints payloads", () => {
+    const expectedReason = "InfiniFi protocol stats payload does not expose a trustworthy source timestamp";
+    for (const rateHistory of [
+      { code: "OK", data: { dataPoints: {} } },
+      { code: "OK", data: { dataPoints: [null] } },
+    ] as const) {
+      expect(resolveInfiniFiFreshness(payloadWithRate(1.07), rateHistory))
         .toMatchObject({ freshnessMode: "unverified", details: { freshnessReason: expectedReason } });
     }
   });

--- a/worker/src/cron/reserve-adapters/infinifi.ts
+++ b/worker/src/cron/reserve-adapters/infinifi.ts
@@ -46,7 +46,7 @@ export interface InfiniFiProtocolData {
 export interface InfiniFiRateHistoryResponse {
   code: string;
   data?: {
-    dataPoints?: Array<{ time?: number; value?: number }>;
+    dataPoints?: unknown;
   };
 }
 
@@ -104,11 +104,17 @@ export function resolveInfiniFiFreshness(
 ):
   | { sourceTimestamp: number; freshnessMode: "verified" }
   | { freshnessMode: "unverified"; details: { freshnessSource: string; freshnessReason: string } } {
-  const points = rateHistory?.code === "OK" ? rateHistory.data?.dataPoints ?? [] : [];
+  const points = rateHistory?.code === "OK" && Array.isArray(rateHistory.data?.dataPoints)
+    ? rateHistory.data.dataPoints
+    : [];
   let latest: { time: number; value: number } | null = null;
   for (const point of points) {
     if (
-      typeof point.time === "number" && Number.isFinite(point.time)
+      point != null
+      && typeof point === "object"
+      && "time" in point
+      && "value" in point
+      && typeof point.time === "number" && Number.isFinite(point.time)
       && typeof point.value === "number" && Number.isFinite(point.value)
     ) {
       latest = { time: point.time, value: point.value };


### PR DESCRIPTION
### Motivation

- The optional InfiniFi rate-history freshness probe previously trusted the upstream JSON shape and could throw when `dataPoints` was malformed, causing an otherwise-valid reserve snapshot to fail. 
- Under the attacker-controlled upstream model, syntactically valid but shape-invalid probe responses (e.g. non-array `dataPoints` or `[null]`) must not abort the adapter run. 
- Preserve the intended behavior that the probe is optional and that malformed probe responses fall back to `unverified` freshness instead of raising an exception. 

### Description

- Treat the probe payload as untrusted by changing `InfiniFiRateHistoryResponse.data.dataPoints` handling to `unknown` and only iterate when `Array.isArray(...)` is true in `worker/src/cron/reserve-adapters/infinifi.ts`.
- Add runtime checks that each `point` is a non-null object with finite numeric `time` and `value` before dereferencing, so malformed elements are ignored and the unverified fallback is preserved in `resolveInfiniFiFreshness`.
- Add focused regression tests in `worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts` covering non-array `dataPoints` and `null` entries, and an integration-style test asserting `fetchInfiniFiReserves` returns `unverified` freshness for a malformed probe. 

### Testing

- Ran the adapter unit tests with `npm exec -- vitest run worker/src/cron/reserve-adapters/__tests__/infinifi.test.ts`, and all tests passed (`21 passed`).
- Ran a TypeScript build check with `cd worker && npx tsc --noEmit`, which completed successfully. 
- Ran repository checks with `git diff --check` (no whitespace/errors) as part of validation and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0cf688332b875ecc96f866f70)