### PR TITLE
Fix live-reserve cursor priority starvation

### DIFF
--- a/worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts
+++ b/worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts
@@ -203,7 +203,7 @@ describe("syncLiveReserves orchestrator run-budget behavior", () => {
     });
   });
 
-  it("resumes from the first deferred coin on the next run and wraps around to cover the head", async () => {
+  it("resumes from the first deferred coin on the next run without wrapping into the priority head", async () => {
     let activeRun = 1;
     let fetches = 0;
     const visitedByRun = new Map<number, string[]>();
@@ -233,11 +233,14 @@ describe("syncLiveReserves orchestrator run-budget behavior", () => {
     const secondRun = await syncLiveReserves(resumedDb, new AbortController().signal, {}, undefined, TIGHT_BUDGET);
     const secondMetadata = parseMetadata(secondRun?.metadata);
 
-    // The cursored run starts at the first deferred coin, then wraps so the
-    // head coins from run 1 are still covered in run 2.
+    // The cursored run starts at the first deferred coin and drains only that
+    // deferred suffix. It does not wrap into the priority head until the next
+    // clean run, so a low-priority tail resume cannot mark head coins skipped.
+    const cursorIndex = SYNC_ORDERED_CONFIGURED_COINS.findIndex((coin) => coin.id === firstMetadata.nextCursorStablecoinId);
     expect(visitedByRun.get(2)?.[0]).toBe(firstMetadata.nextCursorStablecoinId);
-    expect(visitedByRun.get(2)).toContain(visitedByRun.get(1)?.[0]);
-    expect(secondMetadata.synced).toBe(CONFIGURED_COIN_COUNT);
+    expect(visitedByRun.get(2)).not.toContain(visitedByRun.get(1)?.[0]);
+    expect(secondMetadata.synced).toBe(CONFIGURED_COIN_COUNT - cursorIndex);
+    expect(secondMetadata.total).toBe(CONFIGURED_COIN_COUNT - cursorIndex);
     expect(secondMetadata.deferredCoins).toBe(0);
 
     // The evidence-class ordering keeps independents at the queue head, so a
@@ -257,6 +260,47 @@ describe("syncLiveReserves orchestrator run-budget behavior", () => {
       && entry.binds[0] === CURSOR_CACHE_KEY
     ));
     expect(cursorDelete).toBeDefined();
+  });
+
+
+  it("does not defer the high-priority head when a resumed weak-probe tail truncates again", async () => {
+    const weakTail = [...SYNC_ORDERED_CONFIGURED_COINS].reverse().find(
+      (coin) => LIVE_RESERVE_ADAPTER_DEFINITIONS[coin.liveReservesConfig!.adapter].evidenceClass === "weak-live-probe",
+    );
+    const independentHead = SYNC_ORDERED_CONFIGURED_COINS.find(
+      (coin) => LIVE_RESERVE_ADAPTER_DEFINITIONS[coin.liveReservesConfig!.adapter].evidenceClass === "independent",
+    );
+    expect(weakTail).toBeDefined();
+    expect(independentHead).toBeDefined();
+
+    const visited: string[] = [];
+    mockAdapterRegistry(async (coin) => {
+      visited.push(coin?.id ?? "unknown");
+      nowMs += TIGHT_BUDGET.runBudgetMs;
+      return { slices: [{ name: "Mock Farm", pct: 100, risk: "low" as const }] };
+    });
+
+    const { syncLiveReserves } = await import("../sync-live-reserves");
+    const db = mockD1([cursorTable(JSON.stringify({
+      nextStablecoinId: weakTail!.id,
+      deferredCount: 1,
+      deferredAt: 1_700_000_000,
+      reason: "run-budget-exhausted",
+      runBudgetTruncationCount: 1,
+    }))]);
+
+    const result = await syncLiveReserves(db, new AbortController().signal, {}, undefined, TIGHT_BUDGET);
+    const metadata = parseMetadata(result?.metadata);
+
+    expect(visited).toEqual([weakTail!.id]);
+    expect(metadata.runBudgetTruncated).toBe(false);
+    expect(metadata.deferredCoins).toBe(0);
+
+    const deferredStateRows = db.getHistory().filter((entry) => (
+      entry.sql.includes("INSERT INTO reserve_sync_state")
+      && entry.binds.some((bind) => bind === "run-budget-exhausted")
+    ));
+    expect(deferredStateRows.some((entry) => entry.binds.includes(independentHead!.id))).toBe(false);
   });
 
   it("starts from the top of the queue when the persisted cursor JSON is malformed", async () => {

--- a/worker/src/cron/sync-live-reserves-run-state.ts
+++ b/worker/src/cron/sync-live-reserves-run-state.ts
@@ -3,7 +3,6 @@ import { batchExecute } from "../lib/db";
 import { throwIfAborted } from "../lib/abort";
 import { runWithOverloadRetry } from "../lib/cron-lease";
 import { breakerKeyForConfig, type ConfiguredCoin } from "./sync-live-reserves-shared";
-import { rotateFromCursor } from "./shared/cursor-rotation";
 import { toErrorMessage } from "../lib/error-utils";
 import {
   buildReserveSyncAttemptHistoryInsertStatement,
@@ -53,11 +52,16 @@ export interface RecordDeferredTailResult {
   additionalBreakerKeys: Set<string>;
 }
 
-export function rotateConfiguredCoins(
+export function selectConfiguredCoinRunQueue(
   configuredCoins: readonly ConfiguredCoin[],
   nextStablecoinId: string | null,
 ): ConfiguredCoin[] {
-  return rotateFromCursor(configuredCoins, nextStablecoinId, (coin) => coin.id).items;
+  if (!nextStablecoinId) return [...configuredCoins];
+
+  const cursorIndex = configuredCoins.findIndex((coin) => coin.id === nextStablecoinId);
+  if (cursorIndex < 0) return [...configuredCoins];
+
+  return configuredCoins.slice(cursorIndex);
 }
 
 export async function loadLiveReserveCursorState(db: D1Database): Promise<LoadedLiveReserveCursorState | null> {

--- a/worker/src/cron/sync-live-reserves.ts
+++ b/worker/src/cron/sync-live-reserves.ts
@@ -22,7 +22,7 @@ import { createAdapterIoLimiter, RESERVE_ADAPTER_MAX_PARALLEL_IO } from "./reser
 import {
   loadLiveReserveCursorState,
   recordDeferredTail,
-  rotateConfiguredCoins,
+  selectConfiguredCoinRunQueue,
   type LiveReserveCursorTailState,
   type LoadedLiveReserveCursorState,
 } from "./sync-live-reserves-run-state";
@@ -389,16 +389,16 @@ export async function syncLiveReserves(
   const runStartedMs = Date.now();
   const budgetConfig = resolveLiveReserveSyncBudgetConfig(budgetOverrides);
   const cursorState: LoadedLiveReserveCursorState | null = await loadLiveReserveCursorState(db);
-  // Cursor rotation semantics over the evidence-class-ordered queue: a
-  // cursored run rotates the full ordered queue to start at the first coin
-  // deferred by the previous run, processes that deferred tail first, then
-  // wraps around to the head until the budget is spent. Because any coin
-  // deferred in run N sits at the front of run N+1's queue, the weak-probe
-  // tail cannot starve indefinitely and a deferred independent coin is synced
-  // on the very next run. If the cursor coin is no longer in the queue (order
-  // or coverage changed between deploys), rotateFromCursor falls back to
-  // starting from the top of the ordered queue.
-  const orderedCoins = rotateConfiguredCoins(SYNC_ORDERED_CONFIGURED_COINS, cursorState?.nextStablecoinId ?? null);
+  // Cursor semantics over the evidence-class-ordered queue: a cursored run
+  // resumes at the first coin deferred by the previous run and processes only
+  // that deferred suffix. It deliberately does not wrap back to the
+  // high-priority head in the same run; otherwise a slow weak-probe tail could
+  // exhaust the resumed budget and rewrite independent head feeds as skipped.
+  // Once the deferred suffix completes, finalization clears the cursor and the
+  // next scheduled run starts again from the top of the priority queue. If the
+  // cursor coin is no longer in the queue (order or coverage changed between
+  // deploys), fall back to starting from the top of the ordered queue.
+  const orderedCoins = selectConfiguredCoinRunQueue(SYNC_ORDERED_CONFIGURED_COINS, cursorState?.nextStablecoinId ?? null);
   const syncStates = await loadReserveSyncStateMap(db, CONFIGURED_COINS.map((coin) => coin.id));
   const effectiveAdapterCtx: AdapterContext = {
     db,


### PR DESCRIPTION
### Motivation
- The evidence-class ordered queue places `independent` evidence at the head and `weak-live-probe` at the tail, but the previous cursored resume logic rotated the whole ordered queue so a resumed run could wrap back into the high-priority head and have that head marked `skipped` when the resumed budget exhausted again. 
- That behavior can persistently exclude high-value independent reserve feeds from scoring because deferred rows are written with `last_status='skipped'` and downstream scoring requires `last_status === 'ok'`.

### Description
- Replace whole-queue rotation with suffix-only resume semantics by adding `selectConfiguredCoinRunQueue(...)` and using it in `worker/src/cron/sync-live-reserves.ts` so a resumed run only processes the deferred suffix instead of wrapping into the priority head. (changed files: `worker/src/cron/sync-live-reserves-run-state.ts`, `worker/src/cron/sync-live-reserves.ts`).
- Preserve fallback behavior: missing/invalid cursors still start from the top of the ordered queue.
- Add regression coverage and update orchestrator tests to assert suffix-only drains and to verify a resumed weak-probe tail that truncates again does not cause independent head coins to be persisted as `skipped` (changed file: `worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts`).

### Testing
- Ran focused unit suites with `npx vitest run worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts worker/src/cron/__tests__/sync-live-reserves-run-state.test.ts` and they passed. 
- Typecheck and cron guards succeeded with `cd worker && npx tsc --noEmit`, `npm run check:cron-sync`, and `npm run check:cron-connections`. 
- Ran the broader reserve suite `npx vitest run worker/src/cron/__tests__/sync-live-reserves.test.ts` and it passed; all invoked checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1b580833290911a7e297248e9)