### PR TITLE
fix(worker): harden OG image cache path

### DIFF
--- a/worker/src/api/__tests__/og.test.tsx
+++ b/worker/src/api/__tests__/og.test.tsx
@@ -279,6 +279,19 @@ describe("chain OG route", () => {
     const res = await handleOg(mockD1([]), "/api/og/chain/not-a-chain");
     expect(res?.status).toBe(404);
   });
+
+  it("answers HEAD without loading data or rendering the PNG", async () => {
+    const db = makeChainOgDb([makeAsset({ chainCirculating: {}, chains: [] })]);
+    const satoriMock = vi.mocked(satoriStandalone);
+    satoriMock.mockClear();
+
+    const res = await handleOg(db, "/api/og/chain/ethereum", "HEAD");
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get("Content-Type")).toBe("image/png");
+    expect((await res?.arrayBuffer())?.byteLength).toBe(0);
+    expect(satoriMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("depeg OG handler aggregation", () => {

--- a/worker/src/api/og.tsx
+++ b/worker/src/api/og.tsx
@@ -641,7 +641,39 @@ async function handleChainOg(db: D1Database, chainId: string): Promise<Response>
 const STABLECOIN_OG_PATTERN = /^\/api\/og\/stablecoin\/(.+)$/;
 const CHAIN_OG_PATTERN = /^\/api\/og\/chain\/([a-z0-9-]+)$/;
 
-export async function handleOg(db: D1Database, path: string): Promise<Response | null> {
+function handleOgHead(path: string): Response | null {
+  const stablecoinMatch = path.match(STABLECOIN_OG_PATTERN);
+  if (stablecoinMatch) {
+    try {
+      const resolved = resolveOrReject(decodeURIComponent(stablecoinMatch[1]));
+      if (resolved instanceof Response) {
+        return ogErrorResponse("Unknown stablecoin", 404);
+      }
+      return new Response(null, { headers: CACHE_HEADERS });
+    } catch {
+      return ogErrorResponse("Malformed URI", 400);
+    }
+  }
+
+  const chainMatch = path.match(CHAIN_OG_PATTERN);
+  if (chainMatch) {
+    return CHAIN_META[chainMatch[1]]
+      ? new Response(null, { headers: CACHE_HEADERS })
+      : ogErrorResponse("Unknown chain", 404);
+  }
+
+  if (path === "/api/og/safety-scores" || path === "/api/og/depeg" || path === "/api/og/stability-index") {
+    return new Response(null, { headers: CACHE_HEADERS });
+  }
+
+  return null;
+}
+
+export async function handleOg(db: D1Database, path: string, method = "GET"): Promise<Response | null> {
+  if (method === "HEAD") {
+    return handleOgHead(path);
+  }
+
   try {
     // /api/og/stablecoin/:id
     const stablecoinMatch = path.match(STABLECOIN_OG_PATTERN);

--- a/worker/src/handlers/http/__tests__/edge-cache.test.ts
+++ b/worker/src/handlers/http/__tests__/edge-cache.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { writeEdgeCache } from "../edge-cache";
+import { createEdgeCacheContext, writeEdgeCache } from "../edge-cache";
 
 function makeContext() {
   return {
@@ -13,6 +13,24 @@ function makeExecutionContext() {
     waitUntil: vi.fn(),
   } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
 }
+
+describe("createEdgeCacheContext", () => {
+  it("canonicalizes OG image cache keys by stripping arbitrary query strings", () => {
+    const request = new Request("https://api.pharos.watch/api/og/chain/ethereum?bust=random");
+    const context = createEdgeCacheContext(request, new URL(request.url));
+
+    expect(context.skipCache).toBe(false);
+    expect(context.cacheKey.url).toBe("https://api.pharos.watch/api/og/chain/ethereum");
+  });
+
+  it("still skips edge cache lookup for HEAD requests", () => {
+    const request = new Request("https://api.pharos.watch/api/og/chain/ethereum?bust=random", { method: "HEAD" });
+    const context = createEdgeCacheContext(request, new URL(request.url));
+
+    expect(context.skipCache).toBe(true);
+    expect(context.cacheKey.url).toBe("https://api.pharos.watch/api/og/chain/ethereum");
+  });
+});
 
 describe("writeEdgeCache", () => {
   const put = vi.fn(async () => undefined);

--- a/worker/src/handlers/http/edge-cache.ts
+++ b/worker/src/handlers/http/edge-cache.ts
@@ -6,9 +6,19 @@ interface EdgeCacheContext {
   skipCache: boolean;
 }
 
+function createCacheKeyRequest(request: Request, url: URL): Request {
+  if (url.pathname.startsWith("/api/og/")) {
+    const canonicalUrl = new URL(request.url);
+    canonicalUrl.search = "";
+    return new Request(canonicalUrl.toString(), { method: "GET" });
+  }
+
+  return new Request(request.url, { method: "GET" });
+}
+
 export function createEdgeCacheContext(request: Request, url: URL): EdgeCacheContext {
   return {
-    cacheKey: new Request(request.url, { method: "GET" }),
+    cacheKey: createCacheKeyRequest(request, url),
     skipCache: !isCacheableGetRequest(request, url),
   };
 }

--- a/worker/src/routes/dynamic-routes.ts
+++ b/worker/src/routes/dynamic-routes.ts
@@ -92,7 +92,9 @@ const DYNAMIC_ROUTE_DEFINITIONS = [
     ),
   ),
   defineDynamicRouteFromDescriptor("og-image", (routeCtx) =>
-    handleOg(routeCtx.db, routeCtx.url.pathname).then((response) => response ?? errorResponse(404, "Unknown OG route")),
+    handleOg(routeCtx.db, routeCtx.url.pathname, routeCtx.request.method).then(
+      (response) => response ?? errorResponse(404, "Unknown OG route"),
+    ),
   ),
   defineDynamicRouteFromDescriptor("snapshot-day", (routeCtx, match) => handleSnapshotDay(routeCtx.db, match[1])),
   defineDynamicRouteFromDescriptor("snapshot-coin", (routeCtx, match) => {


### PR DESCRIPTION
### Motivation
- Prevent costly unauthenticated requests from forcing full chain-aggregation + Satori/Resvg rendering (and exhausting CPU/D1/cache budget) via `HEAD` or cache-busting query strings to `/api/og/*`.
- Keep existing GET behavior and public exemption for OG images while limiting availability attack surface.

### Description
- Short-circuit `HEAD` requests for dynamic OG routes by adding a cheap `handleOgHead()` path that returns the same image headers with an empty body and avoids loading D1 caches, aggregating chains, or rendering PNG bytes. (`worker/src/api/og.tsx`)
- Thread the request method into the OG dispatcher so dynamic route bindings can call `handleOg(..., method)` and the handler can branch on `HEAD` early. (`worker/src/routes/dynamic-routes.ts`)
- Canonicalize edge-cache keys for `/api/og/*` by stripping the query string when building the cache key so arbitrary `?bust=` params do not bypass the cached PNG. (`worker/src/handlers/http/edge-cache.ts`)
- Add focused regression tests for OG HEAD short-circuiting and OG cache-key canonicalization, and small test-adjustments to exercise the new behavior. (`worker/src/api/__tests__/og.test.tsx`, `worker/src/handlers/http/__tests__/edge-cache.test.ts`) 

### Testing
- Ran targeted unit suites: `npx vitest run worker/src/api/__tests__/og.test.tsx worker/src/handlers/http/__tests__/edge-cache.test.ts worker/src/api/__tests__/router-contract.test.ts`, all tests passed.
- Ran worker TypeScript checks: `npm run typecheck:worker`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b2d76c8332a1dc7ebe6202a848)