### PR TITLE
Escape yield allowlist suggestion slugs

### DIFF
--- a/worker/src/cron/__tests__/yield-coverage-audit.test.ts
+++ b/worker/src/cron/__tests__/yield-coverage-audit.test.ts
@@ -24,6 +24,14 @@ afterEach(() => {
   mockFetchEvmUint256AtBlock.mockReset();
 });
 
+function inferExpectedProtocolLabel(project: string): string {
+  return project
+    .split(/[-_.]+/u)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
 describe("buildProtocolCategoryLookupFromCachePayload", () => {
   it("parses raw cached DeFiLlama protocol payloads by normalized slug", () => {
     const lookup = buildProtocolCategoryLookupFromCachePayload({
@@ -233,6 +241,45 @@ describe("identifyCoverageGaps", () => {
     expect(gaps.lendingAllowlistRecommendations).not.toContainEqual(
       expect.objectContaining({ project: "morpho-blue" }),
     );
+  });
+
+  it("escapes provider slugs in suggested lending allowlist snippets", () => {
+    const maliciousProject = 'evil"\n  __pwned__: (() => { throw new Error("injected"); })(),\n  "tail';
+    const dlPools: DlPool[] = [
+      {
+        pool: "evil-usdc",
+        chain: "Ethereum",
+        project: maliciousProject,
+        symbol: "USDC",
+        tvlUsd: 12_000_000,
+        apy: 4,
+        apyBase: 4,
+        apyReward: null,
+        apyMean30d: 4,
+        stablecoin: true,
+        exposure: "single",
+        underlyingTokens: null,
+      },
+    ];
+
+    const gaps = identifyCoverageGaps(
+      dlPools,
+      new Set(),
+      new Set(),
+      new Map([[maliciousProject.trim().toLowerCase(), "Lending"]]),
+    );
+
+    expect(gaps.lendingAllowlistRecommendations).toContainEqual(
+      expect.objectContaining({
+        project: maliciousProject,
+        suggestedConfig: expect.objectContaining({
+          snippet: `  ${JSON.stringify(maliciousProject)}: { label: ${JSON.stringify(
+            inferExpectedProtocolLabel(maliciousProject),
+          )} },`,
+        }),
+      }),
+    );
+    expect(gaps.lendingAllowlistRecommendations[0]?.suggestedConfig?.snippet).toMatch(/^  "evil\\"/u);
   });
 
   it("drives lending allowlist recommendations from the high-TVL queue and category gate", () => {

--- a/worker/src/cron/yield-coverage-audit.ts
+++ b/worker/src/cron/yield-coverage-audit.ts
@@ -377,7 +377,7 @@ function buildSuggestedLendingAllowlistConfig(project: string): ProtocolRecommen
     targetFile: "worker/src/cron/yield-config-lending-protocols.ts",
     exportName: "LENDING_PROTOCOLS",
     anchor: ALLOWLIST_AUDIT_QUEUE_ANCHOR,
-    snippet: `  "${project}": { label: ${JSON.stringify(inferProtocolLabel(project))} },`,
+    snippet: `  ${JSON.stringify(project)}: { label: ${JSON.stringify(inferProtocolLabel(project))} },`,
     notes: [
       "Verify the display label before promoting.",
       "Keep the protocol near the audit-queue comment anchor for the current round.",


### PR DESCRIPTION
### Motivation

- A provider-controlled DeFiLlama `project` slug was being interpolated directly into an operator-facing TypeScript snippet, creating an operator-assisted code-injection risk if a malicious slug contained quotes or newlines. 
- The change introduces minimal escaping to ensure generated suggested config snippets are safe to copy into `yield-config` modules.

### Description

- Build operator-facing allowlist snippets with an escaped object key by using `JSON.stringify(project)` in `buildSuggestedLendingAllowlistConfig` to prevent quotes/newlines from breaking out of the key position (`worker/src/cron/yield-coverage-audit.ts`).
- Add a regression test that feeds a malicious DeFiLlama project slug through the high-TVL lending recommendation path and asserts the generated `suggestedConfig.snippet` is properly escaped (`worker/src/cron/__tests__/yield-coverage-audit.test.ts`).
- Add a test-local `inferExpectedProtocolLabel` helper matching the existing label inference behavior and normalize the protocol-category lookup key in the test to `maliciousProject.trim().toLowerCase()` to align with runtime normalization.

### Testing

- Ran `npx vitest run worker/src/cron/__tests__/yield-coverage-audit.test.ts` and all tests passed (`26 passed`).
- Ran `npm run check:cron-connections` which reported all triggers within connection budget and succeeded.
- Ran `cd worker && npx tsc --noEmit` which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0c0488332ae5b85613805408e)