### PR TITLE
Harden supplemental yield family cache writes

### DIFF
--- a/docs/worker-infrastructure.md
+++ b/docs/worker-infrastructure.md
@@ -1196,6 +1196,8 @@ The response uses the realtime cache profile (`public, s-maxage=60, max-age=10`)
 | `yield-data`        | 3,600s (1h)     |
 | `dews`              | 1,800s (30 min) |
 
+Supplemental yield family caches are published by `syncYieldSupplemental` only for families with non-empty deduplicated candidates. Empty resolved family results are skipped so transient optional-provider failures that resolve to `[]` cannot overwrite a previously populated per-family cache; aggregate-cache fallback remains available until a later non-empty family refresh succeeds.
+
 Health freshness checks for mint/burn major symbols and scheduler stale alerts use the same shared resolver in `worker/src/lib/mint-burn-health-config.ts`, including env overrides (`MINT_BURN_MAJOR_SYMBOLS`, `MINT_BURN_STALE_WARN_SEC`, `MINT_BURN_STALE_CRIT_SEC`, `MINT_BURN_ALERT_COOLDOWN_SEC`). The public `/api/health` status itself now follows critical-lane sync freshness (`lastSuccessfulSyncAt` + latest run status) rather than raw event recency, so quiet majors do not produce false stale health.
 
 `/api/health` also returns a `warnings: string[]` field. Subquery failures (for example blacklist or circuit-state lookups) no longer silently degrade to zero-like values; instead the endpoint downgrades `status` and emits machine-readable warning strings while still returning `200`. Those warning strings are intentionally sanitized for public output; raw exception detail stays in worker logs.

--- a/worker/src/cron/__tests__/sync-yield-supplemental.test.ts
+++ b/worker/src/cron/__tests__/sync-yield-supplemental.test.ts
@@ -178,7 +178,9 @@ describe("syncYieldSupplemental", () => {
 
     const cacheCall = vi.mocked(setCacheIfNewer).mock.calls[0];
     expect(cacheCall?.[1]).toBe("yield:supplemental-sources:v1");
-    expect(vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:aaveV3")).toBe(true);
+    expect(
+      vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:aaveV3"),
+    ).toBe(true);
 
     const payload = JSON.parse(String(cacheCall?.[2])) as {
       sourceCount: number;
@@ -222,7 +224,7 @@ describe("syncYieldSupplemental", () => {
     expect(metadata.sourceCoverage?.optionalRpcTelemetry?.aaveV3?.missingTargetCount).toBe(0);
   });
 
-  it("publishes fresh empty cache rows for successful zero-candidate families", async () => {
+  it("skips empty family cache rows to preserve previous non-empty caches", async () => {
     vi.mocked(fetchBeefySources).mockResolvedValue([
       {
         symbol: "USDC",
@@ -247,30 +249,23 @@ describe("syncYieldSupplemental", () => {
 
     const result = await syncYieldSupplemental({} as D1Database, undefined, new Map());
 
-    for (const family of SUPPLEMENTAL_SOURCE_FAMILY_KEYS) {
-      expect(
-        vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === `yield:supplemental-sources:v1:${family}`),
-      ).toBe(true);
-    }
-
-    const morphoCall = vi.mocked(setCacheIfNewer).mock.calls.find((call) =>
-      call[1] === "yield:supplemental-sources:v1:morpho"
-    );
-    const morphoPayload = JSON.parse(String(morphoCall?.[2])) as { sourceCount: number; data: unknown[] };
-    expect(morphoPayload.sourceCount).toBe(0);
-    expect(morphoPayload.data).toEqual([]);
+    expect(
+      vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:beefy"),
+    ).toBe(true);
+    expect(
+      vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:morpho"),
+    ).toBe(false);
 
     const metadata = JSON.parse(result.metadata ?? "{}") as {
-      familyCacheResults?: Record<string, "published" | "skipped-newer" | "empty">;
+      familyCacheResults?: Record<string, "published" | "skipped-newer" | "empty" | "empty-skipped">;
     };
-    expect(metadata.familyCacheResults?.morpho).toBe("published");
+    expect(metadata.familyCacheResults?.beefy).toBe("published");
+    expect(metadata.familyCacheResults?.morpho).toBe("empty-skipped");
   });
 
   it("keeps same-asset Aave markets on different chains when per-target results are available", async () => {
     vi.mocked(fetchAaveV3SupplyRates).mockResolvedValue({
-      rates: new Map([
-        ["usdc-circle", { apy: 4.25, chain: "ethereum", sourceTvlUsd: 100_000_000 }],
-      ]),
+      rates: new Map([["usdc-circle", { apy: 4.25, chain: "ethereum", sourceTvlUsd: 100_000_000 }]]),
       results: [
         {
           stablecoinId: "usdc-circle",
@@ -304,7 +299,10 @@ describe("syncYieldSupplemental", () => {
 
     const payload = JSON.parse(String(vi.mocked(setCacheIfNewer).mock.calls[0]?.[2])) as {
       sourceCount: number;
-      data: Array<{ stablecoinId?: string; yield: { sourceKey: string; currentApy: number; sourceTvlUsd: number | null } }>;
+      data: Array<{
+        stablecoinId?: string;
+        yield: { sourceKey: string; currentApy: number; sourceTvlUsd: number | null };
+      }>;
     };
     expect(payload.sourceCount).toBe(2);
     expect(payload.data).toEqual([
@@ -506,7 +504,8 @@ describe("syncYieldSupplemental", () => {
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.total).toBe(1);
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.bySourceFamily?.beefy).toBe(1);
     expect(
-      metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.exampleSourceKeysBySourceFamily?.beefy,
+      metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.exampleSourceKeysBySourceFamily
+        ?.beefy,
     ).toEqual(["(missing-source-key)"]);
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.sizeGatedDrops?.total).toBe(0);
   });
@@ -539,15 +538,19 @@ describe("syncYieldSupplemental", () => {
     vi.mocked(fetchYearnKongSources).mockImplementation(trackFamily("yearnKong", []));
     vi.mocked(fetchBeefySources).mockImplementation(trackFamily("beefy", []));
     vi.mocked(fetchRoycoDawnSources).mockImplementation(trackFamily("roycoDawn", []));
-    vi.mocked(fetchCompoundV3SupplyRates).mockImplementation(trackFamily("compoundV3", {
-      results: [],
-      telemetry: emptyTelemetry,
-    }));
-    vi.mocked(fetchAaveV3SupplyRates).mockImplementation(trackFamily("aaveV3", {
-      rates: new Map(),
-      results: [],
-      telemetry: emptyTelemetry,
-    }));
+    vi.mocked(fetchCompoundV3SupplyRates).mockImplementation(
+      trackFamily("compoundV3", {
+        results: [],
+        telemetry: emptyTelemetry,
+      }),
+    );
+    vi.mocked(fetchAaveV3SupplyRates).mockImplementation(
+      trackFamily("aaveV3", {
+        rates: new Map(),
+        results: [],
+        telemetry: emptyTelemetry,
+      }),
+    );
 
     const loadPromise = loadSupplementalSourceFamilies({ startSec: 1 });
     await flushMicrotasks();

--- a/worker/src/cron/sync-yield-supplemental.ts
+++ b/worker/src/cron/sync-yield-supplemental.ts
@@ -26,9 +26,10 @@ function buildSupplementalCandidateDedupKey(candidate: ResolvedYieldCandidate): 
   return `${sourceKey}|${chain}|${identity}`;
 }
 
-function dedupeCandidates(
-  candidates: ResolvedYieldCandidate[],
-): { candidates: ResolvedYieldCandidate[]; droppedCount: number } {
+function dedupeCandidates(candidates: ResolvedYieldCandidate[]): {
+  candidates: ResolvedYieldCandidate[];
+  droppedCount: number;
+} {
   const byDedupKey = new Map<string, ResolvedYieldCandidate>();
   let droppedCount = 0;
 
@@ -92,17 +93,12 @@ export async function syncYieldSupplemental(
       },
     },
   });
-  const {
-    candidates,
-    familyResults,
-    sourceFamilyCounts,
-    supplementalSourceAccounting,
-    optionalRpcTelemetry,
-  } = await loadSupplementalSourceFamilies({
-    startSec,
-    signal,
-    chainRpcs,
-  });
+  const { candidates, familyResults, sourceFamilyCounts, supplementalSourceAccounting, optionalRpcTelemetry } =
+    await loadSupplementalSourceFamilies({
+      startSec,
+      signal,
+      chainRpcs,
+    });
   await reportSupplementalProgress("source-family-fetch-complete", "Completed supplemental yield source fetches", {
     itemsDone: familyResults.length,
     metadata: {
@@ -146,15 +142,15 @@ export async function syncYieldSupplemental(
         rowsWritten: 0,
         rowsDropped: droppedCount,
         sourceCoverage: {
-        rawSupplementalCandidates: rawCandidateCount,
-        dedupedSupplementalCandidates: 0,
-        supplementalCandidatesWritten: 0,
-        sourceFamilyCounts,
-        supplementalSourceAccounting,
-        optionalRpcTelemetry,
-      },
-      fallbackMode: "empty-snapshot",
-      cacheWriteSkipped: true,
+          rawSupplementalCandidates: rawCandidateCount,
+          dedupedSupplementalCandidates: 0,
+          supplementalCandidatesWritten: 0,
+          sourceFamilyCounts,
+          supplementalSourceAccounting,
+          optionalRpcTelemetry,
+        },
+        fallbackMode: "empty-snapshot",
+        cacheWriteSkipped: true,
       }),
     };
   }
@@ -177,11 +173,13 @@ export async function syncYieldSupplemental(
     startSec,
     signal,
   );
-  const familyCacheResults: Record<SupplementalSourceFamilyKey, "published" | "skipped-newer" | "empty"> =
-    Object.fromEntries(SUPPLEMENTAL_SOURCE_FAMILY_KEYS.map((key) => [key, "empty"])) as Record<
-      SupplementalSourceFamilyKey,
-      "published" | "skipped-newer" | "empty"
-    >;
+  const familyCacheResults: Record<
+    SupplementalSourceFamilyKey,
+    "published" | "skipped-newer" | "empty" | "empty-skipped"
+  > = Object.fromEntries(SUPPLEMENTAL_SOURCE_FAMILY_KEYS.map((key) => [key, "empty"])) as Record<
+    SupplementalSourceFamilyKey,
+    "published" | "skipped-newer" | "empty" | "empty-skipped"
+  >;
 
   for (const family of familyResults) {
     if (family.status !== "ok") continue;
@@ -199,6 +197,10 @@ export async function syncYieldSupplemental(
       },
     });
     const { candidates: dedupedFamilyCandidates } = dedupeCandidates(family.candidates);
+    if (dedupedFamilyCandidates.length === 0) {
+      familyCacheResults[family.key] = "empty-skipped";
+      continue;
+    }
     const familyCacheResult = await setCacheIfNewer(
       db,
       getYieldSupplementalFamilyCacheKey(family.key),


### PR DESCRIPTION
### Motivation
- Prevent optional supplemental source failures that return `[]` from overwriting previously populated per-family supplemental caches and suppressing aggregate-cache fallback.
- The publishing loop previously treated any resolved family as `ok` and wrote empty caches; many fetchers return `[]` on upstream errors, so transient failures could clear good family caches.

### Description
- Change `syncYieldSupplemental` (`worker/src/cron/sync-yield-supplemental.ts`) to skip per-family cache writes when the family's deduplicated candidate list is empty and record the family status as `empty-skipped` instead of publishing an empty payload.
- Extend the `familyCacheResults` result set to include the new `"empty-skipped"` marker so callers/tests can observe skipped-empty behavior.
- Update the focused unit test `worker/src/cron/__tests__/sync-yield-supplemental.test.ts` to assert that non-empty families still publish while empty families do not call `setCacheIfNewer` and are reported as `empty-skipped`.
- Add a short note to `docs/worker-infrastructure.md` documenting that supplemental family caches are only published for families with non-empty deduplicated candidates to preserve aggregate fallback behavior.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/cron/__tests__/sync-yield-supplemental.test.ts --reporter=verbose`, which passed (`1 test file, 8 tests` passed).
- Ran cron/infra checks: `npm run check:cron-connections` and `npm run check:cron-sync`, both passed.
- Type-check: `cd worker && npx tsc --noEmit` succeeded with no errors.
- Ran repository sanity: `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b177008332b5f8fe9eb2a6a81c)