### PR TITLE
Harden Lighthouse static audit environment

### DIFF
--- a/scripts/__tests__/lighthouse-static-export.test.ts
+++ b/scripts/__tests__/lighthouse-static-export.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildLighthouseArgs, parseArgs } from "../maintenance/lighthouse-static-export.mjs";
+import {
+  buildLighthouseArgs,
+  createLighthouseChildEnv,
+  parseArgs,
+} from "../maintenance/lighthouse-static-export.mjs";
 
 function withEnv(key: string, value: string | undefined, fn: () => void) {
   const previous = process.env[key];
@@ -66,5 +70,23 @@ describe("buildLighthouseArgs", () => {
     expect(args).toContain("--form-factor=mobile");
     expect(args).toContain("--screenEmulation.mobile=true");
     expect(args).not.toContain("--screenEmulation.width=1350");
+  });
+});
+
+describe("createLighthouseChildEnv", () => {
+  it("passes only runtime essentials to npx and omits loaded secrets", () => {
+    const env = createLighthouseChildEnv({
+      CHROME_PATH: "/usr/bin/chromium",
+      LIGHTHOUSE_PACKAGE: "malicious-lighthouse",
+      PATH: "/usr/bin",
+      PHAROS_API_KEY: "secret",
+      SITE_PROXY_SHARED_SECRET: "secret",
+      STATIC_EXPORT_HOST: "127.0.0.1",
+    });
+
+    expect(env).toEqual({
+      CHROME_PATH: "/usr/bin/chromium",
+      PATH: "/usr/bin",
+    });
   });
 });

--- a/scripts/maintenance/lighthouse-static-export.mjs
+++ b/scripts/maintenance/lighthouse-static-export.mjs
@@ -18,6 +18,21 @@ const DEFAULT_FORM_FACTOR = "mobile";
 // probe; the pinned npx package makes the runtime-download tradeoff explicit.
 const LIGHTHOUSE_PACKAGE = process.env.LIGHTHOUSE_PACKAGE?.trim() || "lighthouse@13.3.0";
 const ENV_FILE = path.resolve(".env.local");
+const LIGHTHOUSE_CHILD_ENV_ALLOWLIST = [
+  "CHROME_PATH",
+  "CI",
+  "HOME",
+  "LOCALAPPDATA",
+  "PATH",
+  "PATHEXT",
+  "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH",
+  "SystemRoot",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "USERPROFILE",
+  "XDG_CACHE_HOME",
+];
 const VALID_FORM_FACTORS = new Set(["mobile", "desktop"]);
 const VALID_THROTTLING_METHODS = new Set(["devtools", "simulate", "provided"]);
 
@@ -126,10 +141,19 @@ async function waitForReady(url) {
   throw new Error(`Static export server did not become ready at ${url}`);
 }
 
+export function createLighthouseChildEnv(sourceEnv = process.env) {
+  const env = {};
+  for (const key of LIGHTHOUSE_CHILD_ENV_ALLOWLIST) {
+    const value = sourceEnv[key];
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
 function runCommand(command, args) {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
-      env: process.env,
+      env: createLighthouseChildEnv(),
       stdio: "inherit",
     });
     child.on("close", (code) => resolve(code ?? 1));


### PR DESCRIPTION
### Motivation
- Prevent accidental secret exposure when the Lighthouse audit is launched via `npx` by avoiding forwarding the full `process.env` (which may include `.env.local` or shell secrets) into the child process.
- Keep the static-export proxy and parent process able to load secrets locally while ensuring external package code run through `npx` cannot inherit them.

### Description
- Introduce a minimal allowlist `LIGHTHOUSE_CHILD_ENV_ALLOWLIST` and add `createLighthouseChildEnv(sourceEnv)` to construct a sanitized child environment containing only runtime essentials such as `PATH` and `CHROME_PATH`.
- Change `runCommand()` to spawn the `npx`/Lighthouse child with `env: createLighthouseChildEnv()` instead of `process.env` so secrets loaded into the parent remain private.
- Add a focused unit test `createLighthouseChildEnv` under `scripts/__tests__/lighthouse-static-export.test.ts` that proves secret-like variables and `LIGHTHOUSE_PACKAGE` are not forwarded while runtime essentials are preserved.

### Testing
- Ran `npx vitest run scripts/__tests__/lighthouse-static-export.test.ts` and the test file passed.
- Ran `npm run check:script-entrypoints` and it completed without errors.
- Ran ESLint on the changed files via `npx eslint scripts/maintenance/lighthouse-static-export.mjs scripts/__tests__/lighthouse-static-export.test.ts --max-warnings=0` and it passed with no warnings.
- Ran `git diff --check` (file checks) and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1cff88332b1614ae3929ce83a)