### PR TITLE
fix(psi): reject mixed-stale DEWS rows

### DIFF
--- a/worker/src/cron/__tests__/stability-index.test.ts
+++ b/worker/src/cron/__tests__/stability-index.test.ts
@@ -272,6 +272,105 @@ describe("computeAndStoreStabilityIndex", () => {
     ).toBe(false);
   });
 
+  it("returns degraded when any latest DEWS row is stale", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const staleComputedAt = nowSec - CRON_INTERVALS["compute-dews"] * 2 - 1;
+    const freshComputedAt = nowSec - 60;
+    vi.mocked(loadStablecoinsCache).mockResolvedValueOnce({
+      kind: "ok",
+      payload: {
+        peggedAssets: [
+          {
+            id: "usdt-tether",
+            name: "Tether USD",
+            symbol: "USDT",
+            geckoId: "tether",
+            pegType: "peggedUSD",
+            pegMechanism: "fiat-backed",
+            price: 1,
+            priceSource: "defillama",
+            priceConfidence: "high",
+            priceUpdatedAt: nowSec,
+            priceObservedAt: nowSec,
+            priceObservedAtMode: "upstream",
+            priceSyncedAt: nowSec,
+            consensusSources: [],
+            agreeSources: [],
+            supplySource: "defillama",
+            circulating: { peggedUSD: 100_000_000 },
+            circulatingPrevDay: { peggedUSD: 99_000_000 },
+            circulatingPrevWeek: { peggedUSD: 98_000_000 },
+            circulatingPrevMonth: { peggedUSD: 97_000_000 },
+            chainCirculating: {},
+            chains: [],
+          },
+          {
+            id: "usdc-circle",
+            name: "USD Coin",
+            symbol: "USDC",
+            geckoId: "usd-coin",
+            pegType: "peggedUSD",
+            pegMechanism: "fiat-backed",
+            price: 1,
+            priceSource: "defillama",
+            priceConfidence: "high",
+            priceUpdatedAt: nowSec,
+            priceObservedAt: nowSec,
+            priceObservedAtMode: "upstream",
+            priceSyncedAt: nowSec,
+            consensusSources: [],
+            agreeSources: [],
+            supplySource: "defillama",
+            circulating: { peggedUSD: 200_000_000 },
+            circulatingPrevDay: { peggedUSD: 199_000_000 },
+            circulatingPrevWeek: { peggedUSD: 198_000_000 },
+            circulatingPrevMonth: { peggedUSD: 197_000_000 },
+            chainCirculating: {},
+            chains: [],
+          },
+        ],
+      },
+      updatedAt: nowSec,
+    });
+    const db = makeDb({
+      dewsRows: [
+        {
+          stablecoin_id: "usdt-tether",
+          score: 72,
+          band: "WARNING",
+          computed_at: staleComputedAt,
+        },
+        {
+          stablecoin_id: "usdc-circle",
+          score: 12,
+          band: "NORMAL",
+          computed_at: freshComputedAt,
+        },
+      ],
+    });
+
+    const result = await computeAndStoreStabilityIndex(db);
+
+    expect(result.status).toBe("degraded");
+    expect(result.itemCount).toBe(0);
+    const metadata = JSON.parse(result.metadata ?? "{}") as {
+      fallbackMode: string;
+      dewsUnavailable: boolean;
+      dewsFailureReason: string | null;
+      dewsLatestComputedAt: number | null;
+      dewsRowsRead: number;
+    };
+    expect(metadata.fallbackMode).toBe("dews-unavailable");
+    expect(metadata.dewsUnavailable).toBe(true);
+    expect(metadata.dewsFailureReason).toContain("usdt-tether");
+    expect(metadata.dewsFailureReason).toContain("stale");
+    expect(metadata.dewsLatestComputedAt).toBe(freshComputedAt);
+    expect(metadata.dewsRowsRead).toBe(2);
+    expect(
+      db.runHistory.some((entry) => entry.sql.includes("INSERT OR REPLACE INTO stability_index_samples")),
+    ).toBe(false);
+  });
+
   it("bounds the no-publication-pointer fallback scan to a recent window", async () => {
     const nowSec = Math.floor(Date.now() / 1000);
     const fallbackWindowSec = CRON_INTERVALS["compute-dews"] * 4;

--- a/worker/src/cron/stability-index.ts
+++ b/worker/src/cron/stability-index.ts
@@ -159,24 +159,28 @@ export async function computeAndStoreStabilityIndex(db: D1Database, signal?: Abo
     const rows = dewsRows.results ?? [];
     dewsRowsRead = rows.length;
     for (const row of rows) {
-      if (Number.isFinite(row.computed_at)) {
-        dewsLatestComputedAt =
-          dewsLatestComputedAt == null
-            ? row.computed_at
-            : Math.max(dewsLatestComputedAt, row.computed_at);
+      if (!Number.isFinite(row.computed_at)) {
+        dewsUnavailable = true;
+        dewsFailureReason ??= "stress_signals latest rows are missing computed_at";
+        continue;
+      }
+
+      dewsLatestComputedAt =
+        dewsLatestComputedAt == null
+          ? row.computed_at
+          : Math.max(dewsLatestComputedAt, row.computed_at);
+
+      const rowAgeSec = now - row.computed_at;
+      if (rowAgeSec > DEWS_STRESS_MAX_AGE_SEC) {
+        dewsUnavailable = true;
+        dewsFailureReason ??=
+          `stress_signals latest row for ${row.stablecoin_id} is stale (ageSec=${rowAgeSec}, maxAgeSec=${DEWS_STRESS_MAX_AGE_SEC})`;
       }
     }
 
     if (rows.length === 0) {
       dewsUnavailable = true;
       dewsFailureReason = "stress_signals returned no latest rows";
-    } else if (dewsLatestComputedAt == null) {
-      dewsUnavailable = true;
-      dewsFailureReason = "stress_signals latest rows are missing computed_at";
-    } else if (now - dewsLatestComputedAt > DEWS_STRESS_MAX_AGE_SEC) {
-      dewsUnavailable = true;
-      dewsFailureReason =
-        `stress_signals latest row is stale (ageSec=${now - dewsLatestComputedAt}, maxAgeSec=${DEWS_STRESS_MAX_AGE_SEC})`;
     }
 
     if (!dewsUnavailable) {


### PR DESCRIPTION
### Motivation
- The DEWS freshness gate previously used the maximum `computed_at` across latest rows which allowed a single fresh row to mask other stale rows and permit PSI to publish with stale stress inputs.
- The goal is to make PSI fail-closed when any latest DEWS stress row is stale so published PSI samples cannot be influenced by partially-published or missing DEWS data.

### Description
- Update `worker/src/cron/stability-index.ts` to require every latest DEWS row to have a finite `computed_at` and to be within `DEWS_STRESS_MAX_AGE_SEC`, marking DEWS unavailable and setting `dewsFailureReason` when any row is stale or missing `computed_at`.
- Preserve the existing `dewsLatestComputedAt` computation while making the gate reject mixed stale/fresh sets instead of relying on the per-set maximum timestamp.
- Add a regression test in `worker/src/cron/__tests__/stability-index.test.ts` that exercises a mixed case (one stale `usdt-tether` row and one fresh `usdc-circle` row) and asserts PSI returns degraded and does not insert a stability sample.
- Keep the bounded fallback scan behavior intact when the publication pointer is missing.

### Testing
- Ran `npm test -- worker/src/cron/__tests__/stability-index.test.ts` and all targeted tests passed (`11/11`).
- Ran TypeScript check via `cd worker && npx tsc --noEmit` which completed without errors.
- Verified the new regression test asserts that a mixed stale/fresh DEWS latest-row set causes PSI to return degraded and prevents sample insertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b20e888332af81960cf9fdd2da)