### PR TITLE
Harden Accountable reserve bucket validation

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/accountable.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/accountable.test.ts
@@ -383,6 +383,99 @@ describe("adaptAccountableDashboard", () => {
     }).valid).toBe(true);
   });
 
+
+  it("rejects poisoned Apyx Accountable mapped buckets before reserve slice normalization", async () => {
+    const config = apxusd.liveReservesConfig as LiveReservesConfig;
+    const primary = config.inputs.primary;
+    if (primary.kind !== "http-json") {
+      throw new Error("expected Apyx Accountable primary input to be http-json");
+    }
+    const url = primary.url;
+
+    await expect(fetchAccountableReserves(
+      {} as never,
+      config,
+      signal,
+      {
+        requestCache: new Map([
+          [`json-get:${url}:12000:null`, Promise.resolve({
+            res: "ok",
+            data: {
+              collateralization: 1.001022,
+              ts: "1780583904415",
+              reserves: {
+                total_reserves: { value: 476_302_149.26, name: "Total Reserves" },
+                reserves_split: [
+                  { value: -296_181_048.36, name: "STRC" },
+                  { value: 180_040_870.38, name: "Cash & Equivalents" },
+                  { value: 0, name: "SATA" },
+                  { value: "not-a-number", name: "Other" },
+                ],
+              },
+            },
+          })],
+        ]),
+      },
+    )).rejects.toThrow(/Accountable reserves_split bucket "STRC" has invalid value/);
+  });
+
+  it("rejects Apyx Accountable mapped buckets that would be silently dropped as zero", async () => {
+    const config = apxusd.liveReservesConfig as LiveReservesConfig;
+    const primary = config.inputs.primary;
+    if (primary.kind !== "http-json") {
+      throw new Error("expected Apyx Accountable primary input to be http-json");
+    }
+    const url = primary.url;
+
+    await expect(fetchAccountableReserves(
+      {} as never,
+      config,
+      signal,
+      {
+        requestCache: new Map([
+          [`json-get:${url}:12000:null`, Promise.resolve({
+            res: "ok",
+            data: {
+              collateralization: 1.001022,
+              ts: "1780583904415",
+              reserves: {
+                total_reserves: { value: 180_040_870.38, name: "Total Reserves" },
+                reserves_split: [
+                  { value: 0, name: "STRC" },
+                  { value: 180_040_870.38, name: "Cash & Equivalents" },
+                  { value: 0, name: "SATA" },
+                  { value: 0, name: "Other" },
+                ],
+              },
+            },
+          })],
+        ]),
+      },
+    )).rejects.toThrow(/non-positive value: Other, SATA, STRC/);
+  });
+
+  it("rejects Accountable bucket totals that materially diverge from total_reserves", () => {
+    expect(() => adaptAccountableDashboard(
+      {
+        res: "ok",
+        data: {
+          collateralization: 1.01,
+          ts: "1773337492853",
+          reserves: {
+            total_reserves: { value: 1_000, name: "Total Reserves" },
+            reserves_split: [
+              { name: "Cash & Equivalents", value: 100 },
+            ],
+          },
+        },
+      },
+      {
+        bucket: "reserves_split",
+        riskMap: { "Cash & Equivalents": "very-low" },
+      },
+    )).toThrow(/bucket total 100 does not match total_reserves 1000/);
+  });
+
   it("maps the current Yuzu Accountable exposure buckets without unknown exposure warnings", async () => {
     const config = yzusd.liveReservesConfig as LiveReservesConfig;
     const primary = config.inputs.primary;

--- a/worker/src/cron/reserve-adapters/accountable.ts
+++ b/worker/src/cron/reserve-adapters/accountable.ts
@@ -21,14 +21,14 @@ interface AccountableDashboardResponse {
     reserves?: {
       interval?: string;
       verifiability?: string;
-      total_reserves?: number | { name?: string; value?: number };
-      type?: Record<string, number>;
-      reserves_split?: Array<{ name: string; value: number }>;
-      deployment?: Record<string, number>;
-      type_split?: Record<string, number>;
-      stablecoin_split?: Record<string, number>;
-      exposure_split?: Record<string, Record<string, number> | number>;
-      protocol_split?: Record<string, Record<string, number> | number>;
+      total_reserves?: unknown;
+      type?: Record<string, unknown>;
+      reserves_split?: unknown;
+      deployment?: Record<string, unknown>;
+      type_split?: Record<string, unknown>;
+      stablecoin_split?: Record<string, unknown>;
+      exposure_split?: Record<string, unknown>;
+      protocol_split?: Record<string, unknown>;
     };
   };
 }
@@ -42,6 +42,8 @@ interface AccountableParams {
 }
 
 const VALID_BUCKETS = new Set(["type", "reserves_split", "deployment", "type_split", "stablecoin_split", "exposure_split", "protocol_split"]);
+const TOTAL_RESERVES_RELATIVE_TOLERANCE = 0.01;
+const TOTAL_RESERVES_ABSOLUTE_TOLERANCE = 1;
 
 function parseAccountableParams(config: LiveReservesConfig): AccountableParams {
   const params = parseLiveReserveAdapterParams("accountable", config.params);
@@ -63,12 +65,50 @@ function extractAccountableBucketValue(value: unknown, depth = 0): number | null
     if (numeric != null) return numeric;
   }
 
-  const numericChildren = Object.values(record)
-    .map((nested) => extractAccountableBucketValue(nested, depth + 1))
-    .filter((numeric): numeric is number => numeric != null);
+  const childValues = Object.values(record).map((nested) => extractAccountableBucketValue(nested, depth + 1));
+  if (childValues.length === 0 || childValues.some((numeric) => numeric == null || numeric < 0)) return null;
+  return (childValues as number[]).reduce((sum, numeric) => sum + numeric, 0);
+}
 
-  if (numericChildren.length === 0) return null;
-  return numericChildren.reduce((sum, numeric) => sum + numeric, 0);
+function requireAccountableBucketValue(name: string, value: unknown, bucket: string): number {
+  const numeric = extractAccountableBucketValue(value);
+  if (numeric == null || numeric < 0) {
+    throw new Error(`Accountable ${bucket} bucket "${name}" has invalid value: ${String(value)}`);
+  }
+  return numeric;
+}
+
+function extractRecordBucketEntries(
+  entries: Record<string, unknown> | undefined,
+  bucket: string,
+): Array<{ name: string; value: number }> {
+  return Object.entries(entries ?? {}).map(([name, value]) => ({
+    name,
+    value: requireAccountableBucketValue(name, value, bucket),
+  }));
+}
+
+function extractReservesSplitEntries(
+  value: unknown,
+): Array<{ name: string; value: number }> {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error("Accountable reserves_split bucket must be an array");
+  }
+
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Accountable reserves_split entry ${index} is invalid`);
+    }
+    const record = entry as Record<string, unknown>;
+    if (typeof record.name !== "string" || record.name.trim() === "") {
+      throw new Error(`Accountable reserves_split entry ${index} has invalid name`);
+    }
+    return {
+      name: record.name,
+      value: requireAccountableBucketValue(record.name, record.value, "reserves_split"),
+    };
+  });
 }
 
 function extractBucketEntries(
@@ -77,24 +117,50 @@ function extractBucketEntries(
 ): Array<{ name: string; value: number }> {
   switch (bucket) {
     case "type":
-      return Object.entries(reserves.type ?? {}).map(([name, value]) => ({ name, value }));
+      return extractRecordBucketEntries(reserves.type, bucket);
     case "reserves_split":
-      return (reserves.reserves_split ?? [])
-        .map((entry) => ({ name: entry.name, value: entry.value }));
+      return extractReservesSplitEntries(reserves.reserves_split);
     case "deployment":
-      return Object.entries(reserves.deployment ?? {}).map(([name, value]) => ({ name, value }));
+      return extractRecordBucketEntries(reserves.deployment, bucket);
     case "type_split":
-      return Object.entries(reserves.type_split ?? {}).map(([name, value]) => ({ name, value }));
+      return extractRecordBucketEntries(reserves.type_split, bucket);
     case "stablecoin_split":
-      return Object.entries(reserves.stablecoin_split ?? {}).map(([name, value]) => ({ name, value }));
+      return extractRecordBucketEntries(reserves.stablecoin_split, bucket);
     case "exposure_split":
-      return Object.entries(reserves.exposure_split ?? {})
-        .map(([name, value]) => ({ name, value: extractAccountableBucketValue(value) ?? 0 }));
+      return extractRecordBucketEntries(reserves.exposure_split, bucket);
     case "protocol_split":
-      return Object.entries(reserves.protocol_split ?? {})
-        .map(([name, value]) => ({ name, value: extractAccountableBucketValue(value) ?? 0 }));
+      return extractRecordBucketEntries(reserves.protocol_split, bucket);
     default:
       return [];
+  }
+}
+
+function extractTotalReserves(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const numeric = extractAccountableBucketValue(value);
+  if (numeric == null || numeric <= 0) {
+    throw new Error(`Accountable total_reserves has invalid value: ${String(value)}`);
+  }
+  return numeric;
+}
+
+function validateMappedBucketValues(mapped: Array<{ name: string; value: number }>, bucket: string): void {
+  const invalid = mapped.filter((entry) => entry.value <= 0);
+  if (invalid.length > 0) {
+    throw new Error(`Accountable ${bucket} mapped bucket has non-positive value: ${invalid.map((entry) => entry.name).sort().join(", ")}`);
+  }
+}
+
+function validateBucketTotalAgainstReserves(
+  breakdown: Array<{ name: string; value: number }>,
+  totalReserves: number | undefined,
+  bucket: string,
+): void {
+  if (totalReserves == null) return;
+  const totalValue = breakdown.reduce((sum, entry) => sum + entry.value, 0);
+  const tolerance = Math.max(TOTAL_RESERVES_ABSOLUTE_TOLERANCE, totalReserves * TOTAL_RESERVES_RELATIVE_TOLERANCE);
+  if (Math.abs(totalValue - totalReserves) > tolerance) {
+    throw new Error(`Accountable ${bucket} bucket total ${totalValue} does not match total_reserves ${totalReserves}`);
   }
 }
 
@@ -117,6 +183,9 @@ export function adaptAccountableDashboard(
   const coinIdMap = params.coinIdMap ?? {};
   const depTypeMap = params.depTypeMap ?? {};
   const mapped = breakdown.filter(({ name }) => name in riskMap);
+  validateMappedBucketValues(mapped, bucket);
+  const totalReserves = extractTotalReserves(payload.data.reserves.total_reserves);
+  validateBucketTotalAgainstReserves(breakdown, totalReserves, bucket);
   const unknown = breakdown.filter(({ name }) => !(name in riskMap));
   const totalValue = breakdown.reduce((sum, entry) => sum + entry.value, 0);
   const unknownValue = unknown.reduce((sum, entry) => sum + entry.value, 0);
@@ -147,10 +216,6 @@ export function adaptAccountableDashboard(
     })),
   );
 
-  const totalReserves =
-    typeof payload.data.reserves.total_reserves === "object"
-      ? payload.data.reserves.total_reserves?.value
-      : payload.data.reserves.total_reserves;
   const sourceTimestamp = parseTimestampLikeToUnixSeconds(payload.data.ts);
 
   return {


### PR DESCRIPTION
### Motivation
- Prevent a data-integrity vulnerability where the Accountable `reserves_split` (and other buckets) could contain negative, zero, or non-numeric values that get silently filtered out and allow a malicious feed to renormalize low-risk buckets to 100%.
- apxUSD was switched to the Accountable adapter and became exposed to this normalization attack, so upstream values must be treated as untrusted and validated before normalization.

### Description
- Treat Accountable reserve fields as untrusted `unknown` and add runtime shape/value validation in `worker/src/cron/reserve-adapters/accountable.ts` to reject malformed input rather than letting `slicesFromValues()` drop it silently.
- Add `requireAccountableBucketValue`, `extractReservesSplitEntries`, `extractRecordBucketEntries`, and `extractTotalReserves` helpers to validate bucket items, names, and totals; reject negative/non-finite values and non-array `reserves_split` shapes. (file: `worker/src/cron/reserve-adapters/accountable.ts`)
- Enforce that mapped buckets have positive values and, when `total_reserves` is provided, check bucket totals against `total_reserves` with a small relative/absolute tolerance to catch material mismatches. (file: `worker/src/cron/reserve-adapters/accountable.ts`)
- Add regression tests that exercise the apxUSD poisoning path, zero/negative/non-numeric mapped buckets, and mismatched bucket totals to ensure invalid upstream payloads are rejected. (file: `worker/src/cron/reserve-adapters/__tests__/accountable.test.ts`)

### Testing
- Ran the focused adapter test suite with `npx vitest run worker/src/cron/reserve-adapters/__tests__/accountable.test.ts`, which completed with all tests passing (`13 passed`).
- Ran the worker TypeScript check with `npm run typecheck:worker`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0cab483329348936fba11daea)