### PR TITLE
fix(ddr): bound unsealed incident adoption

### DIFF
--- a/worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts
+++ b/worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts
@@ -97,7 +97,7 @@ function insertOpenEvent(db: SqliteD1, eventId = 1): void {
     .run(eventId);
 }
 
-async function ensureIncident(db: SqliteD1, eventId = 1) {
+async function ensureIncident(db: SqliteD1, eventId = 1, nowSec = 200000) {
   const [incident] = await ensureCanonicalIncidents(
     db,
     [
@@ -114,7 +114,7 @@ async function ensureIncident(db: SqliteD1, eventId = 1) {
       },
     ],
     {
-      nowSec: 200000,
+      nowSec,
       predictionPolicyVersion: "sticky-24h-v1",
       ddrV2EffectiveAt: 90000,
       createdBy: "vitest",
@@ -376,7 +376,7 @@ describe("DDRv2 storage migrations and stores", () => {
   it("adopts nearby pre-lock events into an unsealed canonical incident", async () => {
     const db = makeSqliteD1();
     try {
-      const incident = await ensureIncident(db);
+      const incident = await ensureIncident(db, 1, 100500);
       const [nearby] = await ensureCanonicalIncidents(
         db,
         [
@@ -390,7 +390,7 @@ describe("DDRv2 storage migrations and stores", () => {
             source: "live",
           },
         ],
-        { nowSec: 201000, predictionPolicyVersion: "sticky-24h-v1", ddrV2EffectiveAt: 90000, createdBy: "vitest" },
+        { nowSec: 101000, predictionPolicyVersion: "sticky-24h-v1", ddrV2EffectiveAt: 90000, createdBy: "vitest" },
       );
 
       expect(nearby?.incidentKey).toBe(incident.incidentKey);
@@ -415,6 +415,64 @@ describe("DDRv2 storage migrations and stores", () => {
         reason: "pre-lock nearby event adopted as current incident source",
         created_by: "vitest",
       });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("requires explicit repair for closed nearby pre-lock events", async () => {
+    const db = makeSqliteD1();
+    try {
+      const incident = await ensureIncident(db);
+      await expect(
+        ensureCanonicalIncidents(
+          db,
+          [
+            {
+              eventId: 2,
+              stablecoinId: "lusd-liquity",
+              pegCurrency: "USD",
+              direction: "below",
+              startedAt: 100900,
+              endedAt: 101200,
+              peakDeviationBps: -350,
+              source: "live",
+            },
+          ],
+          { nowSec: 101000, predictionPolicyVersion: "sticky-24h-v1", ddrV2EffectiveAt: 90000, createdBy: "vitest" },
+        ),
+      ).rejects.toThrow(`Unlinked depeg event 2 overlaps nearby canonical incident ${incident.incidentKey}; explicit repair required`);
+
+      const current = db.sqlite
+        .prepare("SELECT current_event_id, current_started_at FROM depeg_resolver_incidents WHERE incident_key = ?")
+        .get(incident.incidentKey) as { current_event_id: number; current_started_at: number };
+      expect(current).toEqual({ current_event_id: 1, current_started_at: 100000 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("requires explicit repair instead of sliding an unsealed incident beyond its original lock window", async () => {
+    const db = makeSqliteD1();
+    try {
+      const incident = await ensureIncident(db);
+      await expect(
+        ensureCanonicalIncidents(
+          db,
+          [
+            {
+              eventId: 2,
+              stablecoinId: "lusd-liquity",
+              pegCurrency: "USD",
+              direction: "below",
+              startedAt: 100900,
+              peakDeviationBps: -350,
+              source: "live",
+            },
+          ],
+          { nowSec: 186400, predictionPolicyVersion: "sticky-24h-v1", ddrV2EffectiveAt: 90000, createdBy: "vitest" },
+        ),
+      ).rejects.toThrow(`Unlinked depeg event 2 overlaps nearby canonical incident ${incident.incidentKey}; explicit repair required`);
     } finally {
       db.close();
     }

--- a/worker/src/lib/depeg-resolver-incident-store.ts
+++ b/worker/src/lib/depeg-resolver-incident-store.ts
@@ -581,6 +581,13 @@ ${DDR_INCIDENT_MEMBERSHIP_LOCK_PROJECTION}
     return linkSealedNearbyIncidentTail(db, event, row, options, policyDelaySec);
   }
 
+  if (!canAutoRepairUnsealedTail(event, row, nowSec, policyDelaySec)) {
+    throw new DdrIncidentRepairRequiredError(
+      event.eventId,
+      `Unlinked depeg event ${event.eventId} overlaps nearby canonical incident ${row.incident_key}; explicit repair required`,
+    );
+  }
+
   await db.batch([
     db
       .prepare(
@@ -624,6 +631,26 @@ ${DDR_INCIDENT_MEMBERSHIP_LOCK_PROJECTION}
       relation: "repair_replacement",
     },
     policyDelaySec,
+  );
+}
+
+function canAutoRepairUnsealedTail(
+  event: DdrCanonicalIncidentEventInput,
+  row: IncidentRow,
+  nowSec: number,
+  policyDelaySec: number,
+): boolean {
+  const originalEligibleAt = row.first_started_at + policyDelaySec;
+  return (
+    row.incident_state === "active" &&
+    event.source === "live" &&
+    event.endedAt == null &&
+    event.stablecoinId === row.stablecoin_id &&
+    event.pegCurrency === row.peg_currency &&
+    event.direction === row.direction &&
+    event.startedAt > row.current_started_at &&
+    event.startedAt <= originalEligibleAt &&
+    nowSec < originalEligibleAt
   );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent unsafe automatic pre-lock adoption of nearby depeg rows that could move an unsealed incident's `current_event_id/current_started_at` to a closed, late, or non-live row and thereby slide or break public prediction locks.

### Description
- Add a strict live-tail gate `canAutoRepairUnsealedTail()` in `worker/src/lib/depeg-resolver-incident-store.ts` that requires the incident to be `active`, the candidate event to be `source === "live"` and `endedAt == null`, the same stablecoin/peg/direction, the candidate to start after the current source, and the candidate to be within the original incident eligibility window (`event.startedAt <= first_started_at + policyDelaySec` and `nowSec < first_started_at + policyDelaySec`).
- If the gate fails, the unsealed adoption path now throws a `DdrIncidentRepairRequiredError` so the event follows the explicit repair/quarantine path instead of silently relinking and sliding lock eligibility.
- Preserve the existing sealed-tail automated repair path for sealed incidents; the change only restricts the unsealed adoption case.
- Add focused test coverage in `worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts` for the allowed pre-lock adoption, rejection of closed nearby rows, and rejection when the candidate would slide the incident past its original lock window, and adjust the incident-creation timing in the test harness to exercise the new gate.

### Testing
- Ran the focused store test suite with `npx vitest run worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts` and all tests passed.
- Verified TypeScript build with `cd worker && npx tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0dddc8332b1a6b463a51f1ff7)