### PR TITLE
fix(pricing): remove low-liquidity Curve USD0 route

### DIFF
--- a/worker/src/lib/__tests__/curve-onchain.test.ts
+++ b/worker/src/lib/__tests__/curve-onchain.test.ts
@@ -53,7 +53,6 @@ describe("fetchCurveOnchainPrices", () => {
       ["fidd-fidelity", "0xE47E8Ced9D94AA43C922627782E29b41a93202AF", 1, 0, 6, 18],
       ["usdq-quantoz", "0x5a8C7623FEe10542614e492c670a67e3DfE922F8", 1, 0, 6, 6],
       ["susds-sky", "0x00836Fe54625BE242BcFA286207795405ca4fD10", 1, 0, 6, 18],
-      ["usd0-usual", "0x14100f81e33C33Ecc7CDac70181Fb45B6E78569F", 1, 0, 6, 18],
     ] as const;
 
     for (const [stablecoinId, poolAddress, inputIndex, outputIndex, inputDecimals, outputDecimals] of expectedConfigs) {
@@ -81,11 +80,6 @@ describe("fetchCurveOnchainPrices", () => {
         expect.objectContaining({
           stablecoinId: "dola-inverse-finance",
           hop: { viaStablecoinId: "susds-sky" },
-          routeType: "trusted-wrapper",
-        }),
-        expect.objectContaining({
-          stablecoinId: "busd0-usual",
-          hop: { viaStablecoinId: "usd0-usual" },
           routeType: "trusted-wrapper",
         }),
         expect.objectContaining({

--- a/worker/src/lib/curve-pool-configs.ts
+++ b/worker/src/lib/curve-pool-configs.ts
@@ -254,18 +254,6 @@ export const CURVE_POOL_CONFIGS: CurvePoolConfig[] = [
     chain: "ethereum",
     routeType: "direct",
   },
-  // USD0/USDC (factory-stable-ng, ~$0.6M TVL)
-  {
-    stablecoinId: "usd0-usual",
-    poolAddress: "0x14100f81e33C33Ecc7CDac70181Fb45B6E78569F",
-    inputIndex: 1,  // USDC
-    outputIndex: 0, // USD0
-    inputDecimals: 6,
-    outputDecimals: 18,
-    chain: "ethereum",
-    routeType: "direct",
-  },
-
   // ── Hop pools (paired against crvUSD or PYUSD, resolved via two-phase pricing) ──
 
   // pmUSD/crvUSD (factory-stable-ng, ~$19.4M TVL)
@@ -341,18 +329,6 @@ export const CURVE_POOL_CONFIGS: CurvePoolConfig[] = [
     outputDecimals: 18,
     chain: "ethereum",
     hop: { viaStablecoinId: "susds-sky" },
-    routeType: "trusted-wrapper",
-  },
-  // USD0/USD0++ (factory-stable-ng, ~$3.7M TVL)
-  {
-    stablecoinId: "busd0-usual",
-    poolAddress: "0x1d08E7adC263CfC70b1BaBe6dC5Bb339c16Eec52",
-    inputIndex: 0,  // USD0
-    outputIndex: 1, // bUSD0 / USD0++
-    inputDecimals: 18,
-    outputDecimals: 18,
-    chain: "ethereum",
-    hop: { viaStablecoinId: "usd0-usual" },
     routeType: "trusted-wrapper",
   },
 


### PR DESCRIPTION
### Motivation
- A sub-threshold Curve pool (~$0.6M TVL) for `usd0-usual` was added as a direct `curve-onchain` route and a dependent `busd0-usual` trusted-wrapper route, which weakens the high-trust `curve-onchain` voice and allows low-liquidity manipulation to propagate to a wrapper asset.
- The configuration file documents a safety threshold of `> $1M` TVL for Curve pools, so the low-liquidity route must be removed to preserve data integrity of pricing and depeg signals.

### Description
- Removed the `usd0-usual` direct Curve pool entry from `worker/src/lib/curve-pool-configs.ts` to eliminate the sub-threshold (~$0.6M TVL) route. 
- Removed the dependent `busd0-usual` trusted-wrapper entry that relied on `usd0-usual` so no trusted wrapper inherits the low-liquidity price.
- Updated `worker/src/lib/__tests__/curve-onchain.test.ts` to reflect the audited route roster (removed assertions referencing `usd0-usual` and `busd0-usual`).
- Changes are confined to Curve route configuration and the matching unit tests; no runtime logic changes were required.

### Testing
- Ran the focused Curve on-chain unit suite with `npx vitest run worker/src/lib/__tests__/curve-onchain.test.ts --reporter verbose` and all tests passed (`21 passed`).
- Verified TypeScript compilation for the worker with `cd worker && npx tsc --noEmit`, which completed without errors.
- Ran `git diff --check` to ensure no whitespace/format issues were introduced (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1b2f88332951e497b64880498)