### PR TITLE
Fix supply repair peg trust boundary

### DIFF
--- a/worker/src/cron/__tests__/sync-stablecoins.test.ts
+++ b/worker/src/cron/__tests__/sync-stablecoins.test.ts
@@ -2181,6 +2181,7 @@ describe("syncStablecoins", () => {
         first: {
           value: JSON.stringify({
             peggedCAD: 0.73,
+            peggedCHF: 1.20,
             peggedJPY: 0.00628,
             peggedZAR: 0.0608,
             peggedXOF: 0.00172,
@@ -2229,11 +2230,11 @@ describe("syncStablecoins", () => {
         name: "Mento Japanese Yen",
         symbol: "JPYm",
         geckoId: "celo-japanese-yen",
-        pegType: "peggedJPY",
+        pegType: "peggedCHF",
         pegMechanism: "crypto-backed",
         chains: ["Celo"],
         chainCirculating: {
-          Celo: { current: { peggedJPY: 0 }, circulatingPrevDay: { peggedJPY: 0 }, circulatingPrevWeek: { peggedJPY: 0 }, circulatingPrevMonth: { peggedJPY: 0 } },
+          Celo: { current: { peggedCHF: 0 }, circulatingPrevDay: { peggedCHF: 0 }, circulatingPrevWeek: { peggedCHF: 0 }, circulatingPrevMonth: { peggedCHF: 0 } },
         },
       },
       {
@@ -2331,6 +2332,7 @@ describe("syncStablecoins", () => {
     expect((cadd?.chainCirculating as Record<string, { current: number }> | undefined)?.Base.current).toBeCloseTo(189_873, 6);
     expect(jpym).toMatchObject({ supplySource: "onchain-total-supply", priceSource: "protocol-redeem", priceConfidence: "high", price: 0.00628 });
     expect((jpym?.circulating as Record<string, number> | undefined)?.peggedJPY).toBeCloseTo(103_627.12712522845, 6);
+    expect((jpym?.circulating as Record<string, number> | undefined)?.peggedCHF).toBeUndefined();
     expect(zarm).toMatchObject({ supplySource: "onchain-total-supply", priceSource: "protocol-redeem", priceConfidence: "high", price: 0.0608 });
     expect((zarm?.circulating as Record<string, number> | undefined)?.peggedZAR).toBeCloseTo(8_598.7022994136, 6);
     expect(xofm).toMatchObject({ supplySource: "onchain-total-supply", priceSource: "protocol-redeem", priceConfidence: "high", price: 0.00172 });

--- a/worker/src/cron/sync-stablecoins/supply-gap-reconciliation.ts
+++ b/worker/src/cron/sync-stablecoins/supply-gap-reconciliation.ts
@@ -1,5 +1,6 @@
 import { canonicalizeChainCirculating } from "@shared/lib/chain-circulating";
 import { CHAIN_META } from "@shared/lib/chains";
+import { normalizePegTypeFromCurrency } from "@shared/lib/peg-price-bounds";
 import { sumPegBuckets } from "@shared/lib/supply";
 import { ACTIVE_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import type { ChainRpcConfig } from "../../lib/chain-registry";
@@ -306,7 +307,7 @@ function buildSupplyGapCandidates(
     const meta = ACTIVE_META_BY_ID.get(assetId);
     if (!meta || meta.detailProvider !== "defillama") continue;
 
-    const pegKey = asset.pegType ?? Object.keys(asset.circulating ?? {})[0];
+    const pegKey = normalizePegTypeFromCurrency(meta.flags.pegCurrency);
     if (!pegKey) continue;
 
     const dlMarketCap = sumPegBuckets(asset.circulating);


### PR DESCRIPTION
### Motivation
- The on-chain zero-supply repair path took the peg key from upstream DefiLlama rows, which allows a poisoned provider response to steer FX lookup and the repaired output bucket and corrupt market-cap/supply data. 
- The repair must use the trusted registry peg from tracked stablecoin metadata to maintain integrity when provider payloads are attacker-controlled.

### Description
- Derive the supply-gap reconciliation `pegKey` from the tracked registry via `normalizePegTypeFromCurrency(meta.flags.pegCurrency)` instead of using `asset.pegType` or the provider `circulating` buckets in `worker/src/cron/sync-stablecoins/supply-gap-reconciliation.ts`.
- Import `normalizePegTypeFromCurrency` from `@shared/lib/peg-price-bounds` and ensure the curated on-chain repair path uses the registry-derived peg for both FX lookup and the repaired circulating output bucket.
- Add regression coverage in `worker/src/cron/__tests__/sync-stablecoins.test.ts` to assert a poisoned DefiLlama row advertising a wrong peg (CHF) cannot force the repair to use CHF when registry metadata indicates JPY.

### Testing
- Ran the focused Vitest case with `npx vitest run worker/src/cron/__tests__/sync-stablecoins.test.ts -t "repairs curated zero-supply"` and it passed.
- Type-checked the worker code with `cd worker && npx tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0ff508332bbcdd600edc81c08)