### PR TITLE
Fix apply_patch hook command inspection bypass

### DIFF
--- a/scripts/__tests__/pharos-change-contract.test.ts
+++ b/scripts/__tests__/pharos-change-contract.test.ts
@@ -366,6 +366,81 @@ describe("hard-block hook outputs", () => {
     expect(output).toEqual({ continue: true });
   });
 
+  it("blocks deploy commands appended after apply_patch heredocs", () => {
+    const output = buildPreToolUseHookOutput({
+      tool_input: {
+        command: [
+          "apply_patch <<'PATCH'",
+          "*** Begin Patch",
+          "*** Update File: docs/example.md",
+          "@@",
+          "+Do not run `wrangler deploy`; use the release workflow.",
+          "*** End Patch",
+          "PATCH",
+          "npx --no-install wrangler pages deploy out",
+        ].join("\n"),
+      },
+    });
+
+    expect(output).toMatchObject({
+      decision: "block",
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+      },
+    });
+    expect(output.reason).toContain("Raw production deploy commands");
+  });
+
+  it("blocks remote D1 mutations appended after apply_patch heredocs", () => {
+    const output = buildPreToolUseHookOutput({
+      tool_input: {
+        command: [
+          "apply_patch <<'PATCH'",
+          "*** Begin Patch",
+          "*** Update File: docs/example.md",
+          "@@",
+          "+Mention wrangler d1 execute stablecoin-db --remote without executing it.",
+          "*** End Patch",
+          "PATCH",
+          "npx --no-install wrangler d1 execute stablecoin-db --remote --command 'delete from cache'",
+        ].join("\n"),
+      },
+    });
+
+    expect(output).toMatchObject({
+      decision: "block",
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+      },
+    });
+    expect(output.reason).toContain("Remote D1 mutation commands");
+  });
+
+  it("blocks protected redirection writes appended after apply_patch heredocs", () => {
+    const output = buildPreToolUseHookOutput({
+      tool_input: {
+        command: [
+          "apply_patch <<'PATCH'",
+          "*** Begin Patch",
+          "*** Update File: docs/example.md",
+          "@@",
+          "+Document .env.local without writing it.",
+          "*** End Patch",
+          "PATCH",
+          "echo TOKEN=value > .env.local",
+        ].join("\n"),
+      },
+    });
+
+    expect(output).toMatchObject({
+      decision: "block",
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+      },
+    });
+    expect(output.reason).toContain("environment files");
+  });
+
   it("still blocks protected paths when patch payloads arrive as commands", () => {
     const output = buildPreToolUseHookOutput({
       tool_input: {

--- a/scripts/ci/pharos-change-contract.mjs
+++ b/scripts/ci/pharos-change-contract.mjs
@@ -373,9 +373,13 @@ const GIT_GLOBAL_FLAG_OPTIONS = new Set([
 ]);
 const WRANGLER_GLOBAL_VALUE_OPTIONS = new Set(["-c", "--config", "-e", "--env", "--cwd"]);
 
+function commandIsRawPatchPayload(command) {
+  return String(command ?? "").trimStart().startsWith("*** Begin Patch");
+}
+
 function commandLooksLikePatchPayload(command) {
   const text = String(command ?? "").trimStart();
-  return text.startsWith("*** Begin Patch") || /^apply_patch(?:\s|$)/.test(text);
+  return commandIsRawPatchPayload(text) || /^apply_patch(?:\s|$)/.test(text);
 }
 
 function stripHereDocBodies(command) {
@@ -402,7 +406,7 @@ function stripHereDocBodies(command) {
 }
 
 function getExecutableShellText(command) {
-  if (commandLooksLikePatchPayload(command)) return "";
+  if (commandIsRawPatchPayload(command)) return "";
   return stripHereDocBodies(command);
 }
 


### PR DESCRIPTION
### Motivation

- Close a security bypass where commands beginning with `apply_patch` suppressed executable scanning and allowed appended production deploys, remote D1 mutations, or protected redirections to evade the pre-tool-use guard. 
- Preserve the prior allowance for raw patch payload text that only *mentions* blocked commands while restoring protection for real shell commands that use heredocs.

### Description

- Add `commandIsRawPatchPayload` and change `getExecutableShellText` to only return an empty string for raw patch payloads that start with `*** Begin Patch`, while continuing to `stripHereDocBodies` for shell commands such as `apply_patch <<'PATCH' ... PATCH` so appended commands remain visible to scanners. (`scripts/ci/pharos-change-contract.mjs`).
- Update `commandLooksLikePatchPayload` to use the new helper so logic is clear and targeted. (`scripts/ci/pharos-change-contract.mjs`).
- Add regression tests that assert deploy, remote D1 mutation, and protected redirection writes appended after an `apply_patch` heredoc are blocked by the hook. (`scripts/__tests__/pharos-change-contract.test.ts`).

### Testing

- Ran the focused test suite with `npx vitest run scripts/__tests__/pharos-change-contract.test.ts`, which completed successfully with all tests passing. 
- The new regressions verify that appended `npx --no-install wrangler pages deploy out`, appended `wrangler d1 ... --remote`, and appended `echo ... > .env.local` after an `apply_patch` heredoc are detected and blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b2d9b0833290a0232473d74e42)