### PR TITLE
fix(api): deny events site-data lane

### DIFF
--- a/shared/lib/api-endpoints/definitions.ts
+++ b/shared/lib/api-endpoints/definitions.ts
@@ -287,6 +287,7 @@ const BASE_ENDPOINT_DEFINITIONS = [
     path: API_PATHS.events(),
     strictContract: true,
     probeGroup: "public",
+    siteDataAccess: "denied",
   }),
   publicGet({
     key: "usds-status",

--- a/src/lib/__tests__/api-endpoints.test.ts
+++ b/src/lib/__tests__/api-endpoints.test.ts
@@ -435,6 +435,7 @@ describe("api endpoint registry", () => {
     expect(getPublicApiAccess("/api/telegram-mini-app/session")).toBe("exempt");
     expect(getPublicApiAccess("/api/telegram-mini-app/mutate")).toBe("exempt");
     expect(getPublicApiAccess("/api/public-status-history")).toBe("protected");
+    expect(getPublicApiAccess("/api/events")).toBe("protected");
     expect(getPublicApiAccess("/api/telegram-pulse")).toBe("protected");
     expect(getPublicApiAccess("/api/og/stablecoin/usdt-tether")).toBe("exempt");
     expect(isProtectedPublicApiPath("/api/stablecoins")).toBe(true);
@@ -443,6 +444,7 @@ describe("api endpoint registry", () => {
     expect(isProtectedPublicApiPath("/api/telegram-pulse")).toBe(true);
     expect(getSiteDataAccess("/api/stablecoins")).toBe("allowed");
     expect(getSiteDataAccess("/api/public-status-history")).toBe("allowed");
+    expect(getSiteDataAccess("/api/events")).toBe("denied");
     expect(getSiteDataAccess("/api/telegram-pulse")).toBe("allowed");
     expect(getSiteDataAccess("/api/api-key-requests")).toBe("denied");
     expect(getSiteDataAccess("/api/api-key-requests/verify")).toBe("denied");
@@ -454,6 +456,7 @@ describe("api endpoint registry", () => {
     expect(isSiteDataAllowedPath("/api/stablecoin/usdt-tether")).toBe(true);
     expect(isSiteDataAllowedPath("/api/stablecoin-summary/usdt-tether")).toBe(true);
     expect(isSiteDataAllowedPath("/api/public-status-history")).toBe(true);
+    expect(isSiteDataAllowedPath("/api/events")).toBe(false);
     expect(isSiteDataAllowedPath("/api/telegram-pulse")).toBe(true);
     expect(isSiteDataAllowedPath("/api/status")).toBe(false);
   });


### PR DESCRIPTION
### Motivation
- The protected `GET /api/events` endpoint was implicitly allowed on the Pages site-data proxy because non-admin GET endpoints default to site-data `allowed`, which lets `/_site-data/events` bypass `X-API-Key` auth and public API quota checks.

### Description
- Explicitly set `siteDataAccess: "denied"` on the `events` endpoint in `shared/lib/api-endpoints/definitions.ts` so the route is not mapped to `/_site-data/events`.
- Updated registry tests in `src/lib/__tests__/api-endpoints.test.ts` to assert that `/api/events` remains `publicApiAccess: "protected"` while `siteDataAccess` is `denied` and `isSiteDataAllowedPath("/api/events")` is `false`.
- Change is minimal and preserves existing handler behavior on the public API host while preventing unauthenticated site-data proxy access.

### Testing
- Ran the focused unit suites with `npx vitest run src/lib/__tests__/api-endpoints.test.ts worker/src/api/__tests__/events.test.ts --reporter=dot`, which passed: 2 test files, 29 tests all passing.
- Ran worker type checking with `npm run typecheck:worker`, which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1ee148332905ff724f38b13ab)