### PR TITLE
fix(telegram): stop pre-auth Mini App analytics writes

### DIFF
--- a/docs/telegram-architecture.md
+++ b/docs/telegram-architecture.md
@@ -297,7 +297,7 @@ Per-coin subscription writes have two deliberate modes: subscribe-style follows 
 **Must NOT.**
 - Accept mutation auth older than the 5-minute mutation window.
 - Mutate group/supergroup/channel chat rows until a fresh admin verification path and group-scoped launch ownership model exist.
-- Write user-scoped analytics or cooldown rows before signed `initData` validation succeeds. The only pre-auth exception is aggregate abuse/validation counters for body-too-large, malformed JSON, and schema-denied Mini App requests; those counters must not include Telegram user or chat identifiers.
+- Write analytics, aggregate counters, or cooldown rows before signed `initData` validation succeeds. Body-too-large, malformed JSON, and schema-denied Mini App requests must return without D1 writes because the endpoints are public API-key-exempt surfaces.
 - Duplicate per-coin or preset write SQL outside the existing State / persistence helpers.
 - Use `Telegram.WebApp.sendData` without updating `allowed_updates` and treating incoming `web_app_data` as untrusted.
 

--- a/docs/telegram-mini-app.md
+++ b/docs/telegram-mini-app.md
@@ -80,7 +80,7 @@ The load-bearing rules:
 
 - Do not duplicate per-coin or preset write SQL outside the existing State / persistence helpers. If a callback-shaped helper is too narrow, extract the shared D1 mutation into `worker/src/api/telegram-webhook-store.ts` (or the matching settings-mutation layer) and have both callbacks and Mini App call it.
 - Do not mutate group, supergroup, or channel chat rows until a fresh admin verification path and group-scoped launch ownership model exist. Direct-link `chat_type="sender"` launches are the user's *private* alert context, not a group surface.
-- Do not write user-scoped analytics or cooldown rows before signed `initData` validation succeeds. Aggregate abuse/validation counters for body-too-large, malformed JSON, and schema-denied requests are the sole pre-auth exception and must not include Telegram user or chat identifiers.
+- Do not write analytics, aggregate counters, or cooldown rows before signed `initData` validation succeeds. Body-too-large, malformed JSON, and schema-denied requests must fail without D1 writes because the Mini App endpoints are public API-key-exempt surfaces.
 - Do not accept mutation auth older than the 5-minute mutation window.
 - Do not use `Telegram.WebApp.sendData` without updating `allowed_updates` and treating incoming `web_app_data` as untrusted.
 
@@ -114,7 +114,7 @@ Freshness windows:
 
 Mutation auth is bounded by the short freshness window plus per-user mutation cooldowns. Do not add one-shot `initData` replay claims to the mutation path; they break normal multi-edit Mini App sessions because Telegram does not refresh `initData` between edits.
 
-Both Mini App API endpoints reject request bodies above 16 KiB before JSON parsing, schema validation, HMAC validation, user-scoped analytics, or cooldown writes. The limit is enforced with `Content-Length` when present and with a bounded stream reader for chunked or incorrect-length bodies. Body-cap, JSON-parse, and schema failures can increment aggregate abuse/validation counters before auth; those counters intentionally carry no user or chat identity.
+Both Mini App API endpoints reject request bodies above 16 KiB before JSON parsing, schema validation, HMAC validation, analytics, or cooldown writes. The limit is enforced with `Content-Length` when present and with a bounded stream reader for chunked or incorrect-length bodies. Body-cap, JSON-parse, and schema failures intentionally perform no D1 writes before auth so unauthenticated clients cannot amplify writes or pollute usage counters.
 
 Group, supergroup, and channel chat types are read-only in the current phase. The Mini App surfaces an explicit "Use `/settings@PharosWatchBot` in the group for now" affordance instead of failing silently.
 

--- a/worker/src/api/__tests__/telegram-mini-app.test.ts
+++ b/worker/src/api/__tests__/telegram-mini-app.test.ts
@@ -326,10 +326,9 @@ describe("handleTelegramMiniAppSession", () => {
     expect(deniedRows[0].binds).toContain("rate_limited");
   });
 
-  it("emits mini_app_session_invalid with body-too-large on oversized session bodies", async () => {
-    // P1.3: 413 body-cap rejections fire BEFORE HMAC validation, but
-    // `recordTelegramUsageEvent` aggregates only on event_type / source /
-    // outcome / failure_class, so we can still surface the abuse signal.
+  it("does not emit analytics for oversized pre-auth session bodies", async () => {
+    // Body-cap rejections fire before HMAC validation and must not write
+    // unauthenticated analytics rows on the public Mini App endpoint.
     const db = mockD1();
     const req = new Request("https://api.pharos.watch/api/telegram-mini-app/session", {
       method: "POST",
@@ -340,14 +339,7 @@ describe("handleTelegramMiniAppSession", () => {
     const response = await handleTelegramMiniAppSession(db, req, BOT_TOKEN);
 
     expect(response.status).toBe(413);
-    const deniedRows = db
-      .getHistory()
-      .filter((entry) =>
-        entry.sql.includes("INSERT INTO telegram_usage_daily")
-        && entry.binds.includes("mini_app_session_invalid"),
-      );
-    expect(deniedRows).toHaveLength(1);
-    expect(deniedRows[0].binds).toContain("body-too-large");
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects oversized session bodies with 413 before parsing JSON", async () => {
@@ -362,9 +354,23 @@ describe("handleTelegramMiniAppSession", () => {
 
     expect(response.status).toBe(413);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    // P1.3: a single analytics row is the only side effect — no state SELECT,
-    // no cooldown INSERT, no HMAC validation.
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    // No state SELECT, cooldown INSERT, HMAC validation, or analytics write fires pre-auth.
+    expect(db.getHistory()).toHaveLength(0);
+  });
+
+  it("rejects malformed session JSON without pre-auth analytics writes", async () => {
+    const db = mockD1();
+    const req = new Request("https://api.pharos.watch/api/telegram-mini-app/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+
+    const response = await handleTelegramMiniAppSession(db, req, BOT_TOKEN);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ code: "validation-error" });
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects oversized streamed session bodies without relying on Content-Length", async () => {
@@ -379,8 +385,8 @@ describe("handleTelegramMiniAppSession", () => {
 
     expect(response.status).toBe(413);
     expect(await response.json()).toMatchObject({ code: "body-too-large" });
-    // P1.3: single analytics row only — no state SELECT or cooldown INSERT.
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    // No state SELECT, cooldown INSERT, HMAC validation, or analytics write fires pre-auth.
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects lying-small Content-Length session streams through the bounded reader", async () => {
@@ -399,15 +405,7 @@ describe("handleTelegramMiniAppSession", () => {
 
     expect(response.status).toBe(413);
     expect(await response.json()).toMatchObject({ code: "body-too-large" });
-    const deniedRows = db
-      .getHistory()
-      .filter((entry) =>
-        entry.sql.includes("INSERT INTO telegram_usage_daily")
-        && entry.binds.includes("mini_app_session_invalid"),
-      );
-    expect(deniedRows).toHaveLength(1);
-    expect(deniedRows[0].binds).toContain("body-too-large");
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects malformed hash with 401 without HMAC compute", async () => {
@@ -432,9 +430,8 @@ describe("handleTelegramMiniAppSession", () => {
     const response = await handleTelegramMiniAppSession(db, request("/api/telegram-mini-app/session", { initData: padded }), BOT_TOKEN);
 
     expect(response.status).toBe(400);
-    // P1.3: schema-validation failures emit a single analytics row; no other
-    // SQL fires before HMAC compute.
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    // Schema-validation failures happen before HMAC and must not write analytics.
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects an unsigned start_param body override", async () => {
@@ -930,17 +927,8 @@ describe("handleTelegramMiniAppMutation", () => {
 
     expect(response.status).toBe(413);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    // P1.3: emits mini_app_mutation_denied with body-too-large failure class.
-    const deniedRows = db
-      .getHistory()
-      .filter((entry) =>
-        entry.sql.includes("INSERT INTO telegram_usage_daily")
-        && entry.binds.includes("mini_app_mutation_denied"),
-      );
-    expect(deniedRows).toHaveLength(1);
-    expect(deniedRows[0].binds).toContain("body-too-large");
-    // Single analytics row only — no state SELECT or cooldown INSERT.
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    // No state SELECT, cooldown INSERT, HMAC validation, or analytics write fires pre-auth.
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects oversized streamed mutation bodies without relying on Content-Length", async () => {
@@ -955,8 +943,8 @@ describe("handleTelegramMiniAppMutation", () => {
 
     expect(response.status).toBe(413);
     expect(await response.json()).toMatchObject({ code: "body-too-large" });
-    // P1.3: streamed body-too-large also emits the abuse-signal row.
-    expect(db.getHistory().every((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"))).toBe(true);
+    // Streamed body-cap failures are also pre-auth and must not write analytics.
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects strict-schema violations on mutation payloads", async () => {
@@ -969,6 +957,7 @@ describe("handleTelegramMiniAppMutation", () => {
     }), BOT_TOKEN);
 
     expect(response.status).toBe(400);
+    expect(db.getHistory()).toHaveLength(0);
   });
 
   it("rejects empty set-coin patches", async () => {

--- a/worker/src/api/telegram-mini-app.ts
+++ b/worker/src/api/telegram-mini-app.ts
@@ -111,26 +111,6 @@ function rejectOversizedBody(request: Request): Response | null {
   return null;
 }
 
-type PreAuthDenialReason = "body-too-large" | "validation-error";
-
-async function recordPreAuthDenial(
-  db: D1Database,
-  deniedEventType: TelegramUsageEventType,
-  failureClass: PreAuthDenialReason,
-  latencyMs: number,
-): Promise<void> {
-  // Body-cap / JSON-parse denials fire BEFORE HMAC validation, so no auth
-  // context is available. recordTelegramUsageEvent aggregates by event_type /
-  // source / outcome / failure_class only (no chat_id key), so we can still
-  // emit a count for abuse-signal visibility.
-  await recordMiniAppEvent(db, {
-    eventType: deniedEventType,
-    outcome: "rejected",
-    failureClass,
-    latencyMs,
-  });
-}
-
 async function readBoundedRequestText(request: Request): Promise<string | Response> {
   const headerRejection = rejectOversizedBody(request);
   if (headerRejection) return headerRejection;
@@ -165,19 +145,12 @@ async function readBoundedRequestText(request: Request): Promise<string | Respon
 }
 
 async function parseMiniAppRequestJson<T>(
-  db: D1Database,
   request: Request,
   schema: ZodType<T>,
   invalidPayloadMessage: string,
-  deniedEventType: TelegramUsageEventType,
-  start: number,
 ): Promise<T | Response> {
   const text = await readBoundedRequestText(request);
   if (text instanceof Response) {
-    // 413 body-too-large or read-error path. Surface as an abuse signal so
-    // operators see body-cap rejections; emission is keyed on event_type only.
-    const failureClass: PreAuthDenialReason = text.status === 413 ? "body-too-large" : "validation-error";
-    await recordPreAuthDenial(db, deniedEventType, failureClass, Date.now() - start);
     return text;
   }
 
@@ -185,13 +158,11 @@ async function parseMiniAppRequestJson<T>(
   try {
     json = JSON.parse(text);
   } catch {
-    await recordPreAuthDenial(db, deniedEventType, "validation-error", Date.now() - start);
     return miniAppError(400, "validation-error", invalidPayloadMessage);
   }
 
   const parsed = schema.safeParse(json);
   if (!parsed.success) {
-    await recordPreAuthDenial(db, deniedEventType, "validation-error", Date.now() - start);
     return miniAppError(400, "validation-error", invalidPayloadMessage);
   }
   return parsed.data;
@@ -295,12 +266,9 @@ export const handleTelegramMiniAppSession = miniAppErrorHandler(
     const start = Date.now();
     if (!botToken?.trim()) return miniAppError(503, "not-configured", "Telegram Mini App auth is not configured");
     const parsed = await parseMiniAppRequestJson(
-      db,
       request,
       TelegramMiniAppSessionRequestSchema,
       "Invalid Mini App session payload",
-      "mini_app_session_invalid",
-      start,
     );
     if (parsed instanceof Response) {
       return parsed;
@@ -348,12 +316,9 @@ export const handleTelegramMiniAppMutation = miniAppErrorHandler(
     const start = Date.now();
     if (!botToken?.trim()) return miniAppError(503, "not-configured", "Telegram Mini App auth is not configured");
     const parsed = await parseMiniAppRequestJson(
-      db,
       request,
       TelegramMiniAppMutationRequestSchema,
       "Invalid Mini App mutation payload",
-      "mini_app_mutation_denied",
-      start,
     );
     if (parsed instanceof Response) {
       return parsed;


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated write-amplification and telemetry pollution from public Mini App endpoints by ensuring oversized, malformed, or schema-invalid requests do not cause D1 writes before Telegram HMAC validation. 
- The Mini App session/mutation endpoints are `publicApiAccess: "exempt"`, so pre-auth database side effects create a network-reachable abuse surface. 

### Description
- Removed the pre-auth analytics path that recorded denied mini-app events during request body read / JSON parse / schema validation, so `parseMiniAppRequestJson` no longer performs any `record*` or D1 writes on parse/size/schema failures. 
- Kept authenticated analytics and cooldown emissions that run after `validateTelegramMiniAppInitData` (e.g., stale-auth and rate-limited denials) intact so operator signals remain for validated contexts. 
- Updated Mini App handler usage to call the new `parseMiniAppRequestJson` signature that does not accept DB or denied-event parameters. 
- Updated tests in `worker/src/api/__tests__/telegram-mini-app.test.ts` to assert that pre-auth oversized, malformed JSON, and schema-invalid requests leave D1 untouched and added a test for malformed session JSON. 
- Clarified docs in `docs/telegram-mini-app.md` and `docs/telegram-architecture.md` to state the no-pre-auth-D1-write contract for the public API-key-exempt Mini App endpoints. 

### Testing
- Ran the Mini App unit suites: `npx vitest run worker/src/api/__tests__/telegram-mini-app.test.ts worker/src/lib/__tests__/telegram-mini-app-auth.test.ts`, all tests passed. 
- Type-check: `cd worker && npx tsc --noEmit` completed without errors. 
- Documentation sync: `npm run check:doc-sync` passed. 
- Additional local assertions confirm pre-auth parse/body-cap/schema failures produce only error responses (400/413) and do not execute any `INSERT INTO telegram_usage_daily` writes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1b7088332b7489f837024e36a)