### PR TITLE
Restore DEWS aggregate freshness to use oldest returned row

### DIFF
--- a/worker/src/api/__tests__/stress-signals.test.ts
+++ b/worker/src/api/__tests__/stress-signals.test.ts
@@ -634,7 +634,7 @@ describe("handleStressSignals contract tests", () => {
     expect(body.history[1].amplifiers).toEqual({ psi: 1.05, contagion: 1.2 });
   });
 
-  it("uses the newest aggregate row for freshness headers while exposing newest and oldest body timestamps", async () => {
+  it("uses the oldest aggregate row for freshness headers while exposing newest and oldest body timestamps", async () => {
     const requestNowSec = Math.floor(Date.now() / 1000);
     const freshComputedAt = requestNowSec - 60;
     const staleComputedAt = requestNowSec - 15_000;
@@ -665,8 +665,9 @@ describe("handleStressSignals contract tests", () => {
     };
     expect(body.updatedAt).toBe(freshComputedAt);
     expect(body.oldestComputedAt).toBe(staleComputedAt);
-    expect(Number(res.headers.get("X-Data-Age"))).toBeLessThan(300);
-    expect(res.headers.get("Warning")).toBeNull();
+    expect(Number(res.headers.get("X-Data-Age"))).toBeGreaterThanOrEqual(15_000);
+    expect(res.headers.get("Warning")).toContain("Response is stale");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(body.signals["usdt-tether"].ageClassification).toBe("fresh");
     expect(body.signals["usdc-circle"].ageClassification).toBe("retainedLastValid");
   });

--- a/worker/src/api/stress-signals.ts
+++ b/worker/src/api/stress-signals.ts
@@ -462,10 +462,11 @@ export const handleStressSignals = withErrorHandler(
     const methodologyVersion = updatedAt > 0
       ? getDepegDewsMethodologyVersionAt(updatedAt)
       : DEPEG_DEWS_METHODOLOGY_VERSION;
+    const aggregateFreshnessAt = oldestComputedAt ?? updatedAt;
     const responseHeaders = updatedAt > 0
       ? addFreshnessHeaders({
           "Cache-Control": CACHE_PROFILES.standard,
-        }, updatedAt, STRESS_SIGNALS_MAX_AGE_SEC)
+        }, aggregateFreshnessAt, STRESS_SIGNALS_MAX_AGE_SEC)
       : buildUnavailableHeaders("DEWS current rows unavailable");
 
     return jsonResponse({ signals, updatedAt, oldestComputedAt: oldestComputedAt ?? undefined, eligibleCount, computedCount, missingCount, malformedRows, coverageRatio, coverageStatus: coverage.status, coverageReasons: coverage.reasons, methodology: buildMethodologyEnvelope({


### PR DESCRIPTION
### Motivation
- Aggregate DEWS responses can contain per-coin retained stale rows while other coins are fresh, and freshness headers must reflect the presence of any stale retained rows so clients and the site-data proxy do not cache misleadingly fresh responses. 

### Description
- Change `worker/src/api/stress-signals.ts` to compute `aggregateFreshnessAt = oldestComputedAt ?? updatedAt` and pass that timestamp into `addFreshnessHeaders()` instead of using `updatedAt` (newest row). 
- Update the stress-signals regression test in `worker/src/api/__tests__/stress-signals.test.ts` to assert the mixed aggregate case (one fresh row, one stale retained row) emits a stale `X-Data-Age`, a `Warning` containing "Response is stale", and `Cache-Control: no-store`, while preserving `updatedAt`, `oldestComputedAt`, and per-row `ageClassification` values. 
- Modified files: `worker/src/api/stress-signals.ts`, `worker/src/api/__tests__/stress-signals.test.ts`.

### Testing
- Ran the focused unit suite with `npx vitest run worker/src/api/__tests__/stress-signals.test.ts --reporter=verbose` and all tests passed (23 tests). 
- Ran TypeScript worker typecheck with `npm run typecheck:worker` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b19d34833285d30d04709d333b)