### PR TITLE
fix(depeg): honor audit provenance in peg scoring

### DIFF
--- a/worker/src/api/__tests__/audit-depeg-history.test.ts
+++ b/worker/src/api/__tests__/audit-depeg-history.test.ts
@@ -200,7 +200,7 @@ describe("handleAuditDepegHistory method safety", () => {
     const db = mockD1([
       { match: "FROM depeg_events WHERE ended_at IS NOT NULL ORDER BY started_at", rows },
       {
-        match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events WHERE id NOT IN",
+        match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events_with_provenance WHERE",
         rows: [],
       },
       {
@@ -253,7 +253,7 @@ describe("handleAuditDepegHistory method safety", () => {
     const db = mockD1([
       { match: "FROM depeg_events WHERE ended_at IS NOT NULL ORDER BY started_at", rows },
       { match: "FROM depeg_events ORDER BY stablecoin_id, started_at", rows },
-      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events ORDER BY started_at", rows },
+      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events_with_provenance WHERE", rows },
       {
         match: "SELECT stablecoin_id, snapshot_date, circulating_usd FROM supply_history ORDER BY snapshot_date",
         rows: [{ stablecoin_id: "usdt-tether", snapshot_date: day, circulating_usd: 1_000_000_000 }],
@@ -348,7 +348,7 @@ describe("handleAuditDepegHistory method safety", () => {
     const db = mockD1([
       { match: "FROM depeg_events WHERE ended_at IS NOT NULL ORDER BY started_at", rows },
       { match: "FROM depeg_events ORDER BY stablecoin_id, started_at", rows },
-      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events ORDER BY started_at", rows },
+      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events_with_provenance WHERE", rows },
       {
         match: "SELECT stablecoin_id, snapshot_date, circulating_usd FROM supply_history ORDER BY snapshot_date",
         rows: [{ stablecoin_id: "susd-synthetix", snapshot_date: day, circulating_usd: 50_000_000 }],
@@ -631,7 +631,7 @@ describe("handleAuditDepegHistory method safety", () => {
     };
     const db = mockD1([
       { match: "INSERT INTO depeg_event_provenance", rows: [] },
-      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events ORDER BY started_at", rows: [event] },
+      { match: "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events_with_provenance WHERE", rows: [event] },
     ]) as MockD1Database;
 
     const result = await auditEvents(db, {

--- a/worker/src/api/audit-depeg-history.ts
+++ b/worker/src/api/audit-depeg-history.ts
@@ -534,16 +534,19 @@ async function loadRemainingDepegEvents(
   db: D1Database,
   excludedIds: readonly number[] = [],
 ): Promise<PsiDepegEventRow[]> {
-  const baseSql = "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events";
+  const baseSql =
+    "SELECT stablecoin_id, peak_deviation_bps, peg_reference, started_at, ended_at FROM depeg_events_with_provenance";
+  const auditEligibleWhere =
+    "(provenance_audit_verdict IS NULL OR provenance_audit_verdict NOT IN ('false_positive', 'disputed'))";
   const orderBy = " ORDER BY started_at";
   if (excludedIds.length === 0) {
-    const rows = await db.prepare(`${baseSql}${orderBy}`).all<PsiDepegEventRow>();
+    const rows = await db.prepare(`${baseSql} WHERE ${auditEligibleWhere}${orderBy}`).all<PsiDepegEventRow>();
     return rows.results ?? [];
   }
 
   const idClause = buildInClause(excludedIds);
   const rows = await db
-    .prepare(`${baseSql} WHERE id NOT IN (${idClause.sql})${orderBy}`)
+    .prepare(`${baseSql} WHERE ${auditEligibleWhere} AND id NOT IN (${idClause.sql})${orderBy}`)
     .bind(...idClause.binds)
     .all<PsiDepegEventRow>();
   return rows.results ?? [];
@@ -1085,6 +1088,7 @@ export async function auditEvents(
         if (!dryRun) {
           provenanceStatements.push(buildAuditVerdictProvenanceStmt(db, event, "no_data", nowSec));
           invalidatingProvenanceEventIds.push(event.id);
+          addAffectedDays(affectedDays, event.started_at, event.ended_at ?? event.started_at);
         }
         result.auditedEvents.push(toAuditedEvent(event, "no_data", { cgMaxBps: null }));
         continue;
@@ -1119,6 +1123,7 @@ export async function auditEvents(
         if (!dryRun) {
           provenanceStatements.push(buildAuditVerdictProvenanceStmt(db, event, "disputed", nowSec));
           invalidatingProvenanceEventIds.push(event.id);
+          addAffectedDays(affectedDays, event.started_at, event.ended_at ?? event.started_at);
         }
         result.auditedEvents.push(toAuditedEvent(event, "disputed", {
           cgMaxBps: maxCgBps,
@@ -1131,6 +1136,7 @@ export async function auditEvents(
         if (!dryRun) {
           provenanceStatements.push(buildAuditVerdictProvenanceStmt(db, event, "false_positive", nowSec));
           invalidatingProvenanceEventIds.push(event.id);
+          addAffectedDays(affectedDays, event.started_at, event.ended_at ?? event.started_at);
         }
         result.auditedEvents.push(toAuditedEvent(event, "false_positive", {
           cgMaxBps: maxCgBps,

--- a/worker/src/lib/__tests__/peg-analytics.test.ts
+++ b/worker/src/lib/__tests__/peg-analytics.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockD1 } from "../../test-helpers/__shared/mock-d1";
+import { mockD1, type MockD1Database } from "../../test-helpers/__shared/mock-d1";
 
 const { STABLECOINS_MOCK } = vi.hoisted(() => ({
   STABLECOINS_MOCK: [
@@ -76,7 +76,7 @@ vi.mock("../db", async (importOriginal) => {
 });
 
 import { derivePegAnalyticsSnapshot } from "../peg-analytics";
-import { coinTrackingStart } from "@shared/lib/peg-score";
+import { coinTrackingStart, computePegScore } from "@shared/lib/peg-score";
 import { getFirstSeenDates } from "../db";
 
 describe("derivePegAnalyticsSnapshot", () => {
@@ -86,6 +86,7 @@ describe("derivePegAnalyticsSnapshot", () => {
     vi.mocked(getFirstSeenDates).mockResolvedValue(new Map<string, number>());
     vi.mocked(getFirstSeenDates).mockClear();
     vi.mocked(coinTrackingStart).mockClear();
+    vi.mocked(computePegScore).mockClear();
     db = mockD1([
       {
         match: "depeg_events",
@@ -124,6 +125,51 @@ describe("derivePegAnalyticsSnapshot", () => {
     expect(snapshot.pegDataById.has("usdc-circle")).toBe(false); // nav token excluded by default
     expect(snapshot.pegDataById.get("usdt-tether")?.currentDeviationBps).toBe(100);
     expect(snapshot.pegDataById.get("usdt-tether")?.depegEventCoverageLimited).toBe(false);
+  });
+
+  it("loads depeg provenance so audited false positives are excluded from scoring", async () => {
+    db = mockD1([
+      {
+        match: "depeg_events_with_provenance",
+        rows: [
+          {
+            id: 123,
+            stablecoin_id: "usdt-tether",
+            symbol: "AAA",
+            peg_type: "peggedUSD",
+            started_at: 1_700_000_000,
+            ended_at: 1_700_003_600,
+            direction: "below",
+            peak_deviation_bps: -500,
+            source: "live",
+            provenance_audit_verdict: "false_positive",
+            provenance_confidence_tier: "medium",
+          },
+        ],
+      },
+    ]);
+
+    const snapshot = await derivePegAnalyticsSnapshot(db, {
+      peggedAssets: [
+        {
+          id: "usdt-tether",
+          symbol: "AAA",
+          name: "AAA Stable",
+          pegType: "peggedUSD",
+          price: 1,
+          circulating: { peggedUSD: 2_000_000 },
+        } as never,
+      ],
+      methodologyAsOf: 1_700_000_000,
+    });
+
+    expect((db as MockD1Database).getHistory()[0]?.sql).toContain("FROM depeg_events_with_provenance");
+    expect(snapshot.allEvents[0]?.provenance?.auditVerdict).toBe("false_positive");
+    expect(vi.mocked(computePegScore)).toHaveBeenCalledWith(
+      [expect.objectContaining({ provenance: expect.objectContaining({ auditVerdict: "false_positive" }) })],
+      expect.any(Number),
+      expect.any(Number),
+    );
   });
 
   it("includes NAV tokens as peg-ineligible rows when requested", async () => {

--- a/worker/src/lib/peg-analytics.ts
+++ b/worker/src/lib/peg-analytics.ts
@@ -69,7 +69,7 @@ export async function derivePegAnalyticsSnapshot(
   const [eventsResult, firstSeenMap] = await Promise.all([
     db.prepare(
       `SELECT /* pharos:peg-analytics:recent-depeg-events */
-         * FROM depeg_events WHERE started_at > ? ORDER BY started_at DESC`,
+         * FROM depeg_events_with_provenance WHERE started_at > ? ORDER BY started_at DESC`,
     )
       .bind(fourYearsAgoSec)
       .all<DepegRow>(),


### PR DESCRIPTION
### Motivation
- Audited `false_positive` and `disputed` depeg rows were being persisted to `depeg_event_provenance` but public analytics continued to read `depeg_events`, causing audited rows to still influence `PegScore` and stability-index inputs.
- The intent is to retain historical rows (provenance) while ensuring downstream scoring and recompute logic exclude audited-ineligible events.

### Description
- Load recent depeg rows for public analytics from the provenance-aware view by switching the query in `worker/src/lib/peg-analytics.ts` to select from `depeg_events_with_provenance` so `rowToDepegEvent` receives persisted provenance.
- Change `loadRemainingDepegEvents` in `worker/src/api/audit-depeg-history.ts` to read from `depeg_events_with_provenance` and apply an `auditEligibleWhere` clause to exclude rows with `provenance_audit_verdict` of `false_positive` or `disputed` when building stability-index inputs.
- Mark provenance-invalidating audit verdicts (`no_data`, `disputed`, `false_positive`) as affected days by calling `addAffectedDays` in the audit branches so downstream stability-index recomputation runs after provenance persistence.
- Add/update focused tests: extend `worker/src/lib/__tests__/peg-analytics.test.ts` with a provenance-aware case and update `worker/src/api/__tests__/audit-depeg-history.test.ts` expectations to use `depeg_events_with_provenance` query matches.

### Testing
- Ran unit tests for the changed modules: `npx vitest run worker/src/lib/__tests__/peg-analytics.test.ts worker/src/api/__tests__/audit-depeg-history.test.ts`, and both test files passed (all related tests green).
- Verified TypeScript build for worker with `cd worker && npx tsc --noEmit`, which completed successfully.
- Confirmed updated test harness expectations with the mock D1 helper by using `MockD1Database.getHistory()` typing adjustments and re-running the tests, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b151d08332ad394990353c355f)