### PR TITLE
Prevent Telegram pulse fallback cohort leakage

### DIFF
--- a/worker/src/api/__tests__/telegram-pulse.test.ts
+++ b/worker/src/api/__tests__/telegram-pulse.test.ts
@@ -637,7 +637,7 @@ describe("handleTelegramPulse", () => {
     ]);
   });
 
-  it("keeps older lifecycle fallback days even after multiple snapshot days exist", async () => {
+  it("does not expose pre-snapshot fallback cohorts after multiple snapshot days exist", async () => {
     const db = mockD1([
       {
         match: "FROM telegram_watcher_lifecycle_daily",
@@ -711,15 +711,15 @@ describe("handleTelegramPulse", () => {
       watcherHistory: Array<{ date: string; activeWatchers: number; snapshotAt?: number | null }>;
     };
 
-    expect(body.historySource).toBe("live-fallback");
+    expect(body.historySource).toBe("snapshot");
     expect(body.lifecycleHistoryUpdatedAt).toBe(1_778_766_000);
     expect(body.watcherHistory.map((point) => point.date)).toEqual([
-      "2026-03-08",
-      "2026-05-11",
       "2026-05-13",
       "2026-05-14",
     ]);
-    expect(body.watcherHistory[0]?.activeWatchers).toBe(10);
+    expect(body.watcherHistory.some((point) => point.date === "2026-03-08")).toBe(false);
+    expect(body.watcherHistory.some((point) => point.date === "2026-05-11")).toBe(false);
+    expect(body.watcherHistory[0]?.activeWatchers).toBe(519);
     const lastPoint = body.watcherHistory[body.watcherHistory.length - 1];
     expect(lastPoint?.activeWatchers).toBe(540);
     expect(lastPoint?.snapshotAt).toBe(1_778_766_000);

--- a/worker/src/api/telegram-pulse.ts
+++ b/worker/src/api/telegram-pulse.ts
@@ -138,7 +138,7 @@ function buildLifecycleHistory(
     };
   }
 
-  if (fallbackHistory.length === 0) {
+  if (snapshotHistory.length > 1 || fallbackHistory.length === 0) {
     return { source: "snapshot", points: snapshotHistory };
   }
 


### PR DESCRIPTION
### Motivation
- Fix a privacy regression where pre-snapshot fallback rows (which expose cumulative `activeWatchers`) could be prefixed into the public `telegram-pulse` history even after multiple snapshot days existed, allowing suppressed low-cardinality daily `newWatchers` to be inferred by differencing.

### Description
- Tighten `buildLifecycleHistory` in `worker/src/api/telegram-pulse.ts` to avoid prefixing cumulative fallback history once more than one lifecycle snapshot day exists so public history remains on snapshot data after bootstrap.
- Preserve the existing bootstrap behavior where fallback history is used when there are no snapshot rows or only a single bootstrap snapshot point.
- Update the worker test `worker/src/api/__tests__/telegram-pulse.test.ts` to assert that pre-snapshot fallback cohort days are omitted when multiple snapshot days exist and to rename the test to reflect the new expectation.

### Testing
- Ran the focused unit suite with `npx vitest run worker/src/api/__tests__/telegram-pulse.test.ts --reporter=verbose` and all tests passed (11/11).
- Verified TypeScript correctness with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b14be883328ba4a1ddffe255c1)