### PR TITLE
Prevent auto lending rows from variant projection

### DIFF
--- a/worker/src/cron/__tests__/yield-linked-variant-projection.test.ts
+++ b/worker/src/cron/__tests__/yield-linked-variant-projection.test.ts
@@ -91,6 +91,26 @@ describe("appendLinkedVariantParentYieldSources", () => {
     expect(resolved).toHaveLength(1);
   });
 
+  it("does not project auto-discovered lending rows using variant metadata defaults", () => {
+    const resolved: ResolvedYieldEntry[] = [
+      {
+        id: "ybold-yearn",
+        symbol: "yBOLD",
+        yield: source({
+          dataSource: "defillama-auto",
+          sourcePool: "attacker-third-party-lending-pool",
+          sourceKey: "attacker-third-party-lending-pool",
+          project: "example-lender",
+          yieldSource: undefined,
+          yieldType: undefined,
+        }),
+      },
+    ];
+
+    expect(appendLinkedVariantParentYieldSources(resolved)).toBe(0);
+    expect(resolved).toHaveLength(1);
+  });
+
   it("does not project fixed-yield PT opportunities from variants to parents", () => {
     const resolved: ResolvedYieldEntry[] = [
       {

--- a/worker/src/cron/yield-sync/resolve-helpers.ts
+++ b/worker/src/cron/yield-sync/resolve-helpers.ts
@@ -309,6 +309,7 @@ export function appendLinkedVariantParentYieldSources(resolved: ResolvedYieldEnt
 
   for (const entry of resolved) {
     if (!entry.yield) continue;
+    if (entry.yield.dataSource === "defillama-auto") continue;
 
     const childMeta = getActiveStablecoinMeta(entry.id);
     if (!childMeta?.variantOf) continue;


### PR DESCRIPTION
### Motivation
- Prevent auto-discovered third-party lending markets from being projected onto parent stablecoins when variant metadata would otherwise override their classification, which can corrupt public yield rankings and PYS data. 
- The linked-variant projection previously fell back to variant `yieldConfig` for rows with `dataSource === "defillama-auto"`, allowing implicit discovered lending rows to inherit curated wrapper labels.

### Description
- Reject `defillama-auto` rows early in `appendLinkedVariantParentYieldSources` by skipping entries where `entry.yield.dataSource === "defillama-auto"`, implemented in `worker/src/cron/yield-sync/resolve-helpers.ts`.
- Add a focused regression test `does not project auto-discovered lending rows using variant metadata defaults` to `worker/src/cron/__tests__/yield-linked-variant-projection.test.ts` that verifies an implicit `defillama-auto` row is not projected to its parent.
- Preserve existing behavior for curated/explicit sources and keep other projection guards (source-pool dedupe and external-yield-type rejection) unchanged.

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/yield-linked-variant-projection.test.ts` and all tests in that file passed.
- Ran `cd worker && npx tsc --noEmit` and TypeScript type-checking completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0bc4c83328e285b1ec94bbfa5)