### PR TITLE
fix(yield): authenticate weighted pool inputs

### DIFF
--- a/worker/src/cron/__tests__/yield-weighted-pools.test.ts
+++ b/worker/src/cron/__tests__/yield-weighted-pools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildWeightedYieldPoolGroupSource } from "../yield-sync/weighted-pools";
 import type { DlPool } from "../yield-sync/types";
+import type { WeightedYieldPoolGroupConfig } from "../yield-config-weighted-pools";
 
 function makePool(overrides: Partial<DlPool> & Pick<DlPool, "pool" | "tvlUsd" | "apy">): DlPool {
   return {
@@ -20,15 +21,31 @@ function makePool(overrides: Partial<DlPool> & Pick<DlPool, "pool" | "tvlUsd" | 
   };
 }
 
+function makeConfig(overrides: Partial<WeightedYieldPoolGroupConfig> = {}): WeightedYieldPoolGroupConfig {
+  return {
+    sourceKey: "defillama-weighted:test",
+    yieldSource: "Test weighted source",
+    yieldType: "lending-vault",
+    poolIds: ["ethereum-pool", "fraxtal-pool"],
+    expectedProject: "dtrinity-dusd",
+    expectedSymbol: "SDUSD",
+    expectedChainsByPoolId: {
+      "ethereum-pool": "ethereum",
+      "fraxtal-pool": "fraxtal",
+      valid: "ethereum",
+      "zero-tvl": "ethereum",
+      multi: "ethereum",
+      "only-one": "ethereum",
+      spoofed: "ethereum",
+    },
+    ...overrides,
+  };
+}
+
 describe("buildWeightedYieldPoolGroupSource", () => {
   it("builds a TVL-weighted APY row from exact DeFiLlama pool members", () => {
     const source = buildWeightedYieldPoolGroupSource(
-      {
-        sourceKey: "defillama-weighted:test",
-        yieldSource: "Test weighted source",
-        yieldType: "lending-vault",
-        poolIds: ["ethereum-pool", "fraxtal-pool"],
-      },
+      makeConfig(),
       [
         makePool({ pool: "ethereum-pool", tvlUsd: 282_700, apy: 1.66 }),
         makePool({ pool: "fraxtal-pool", chain: "Fraxtal", tvlUsd: 135_700, apy: 14.49 }),
@@ -52,12 +69,9 @@ describe("buildWeightedYieldPoolGroupSource", () => {
 
   it("drops missing, zero-TVL, and non-single-exposure member pools", () => {
     const source = buildWeightedYieldPoolGroupSource(
-      {
-        sourceKey: "defillama-weighted:test",
-        yieldSource: "Test weighted source",
-        yieldType: "lending-vault",
+      makeConfig({
         poolIds: ["valid", "zero-tvl", "multi", "missing"],
-      },
+      }),
       [
         makePool({ pool: "valid", tvlUsd: 100, apy: 5 }),
         makePool({ pool: "zero-tvl", tvlUsd: 0, apy: 50 }),
@@ -71,14 +85,39 @@ describe("buildWeightedYieldPoolGroupSource", () => {
 
   it("returns null when the configured minimum member count is not met", () => {
     const source = buildWeightedYieldPoolGroupSource(
-      {
-        sourceKey: "defillama-weighted:test",
-        yieldSource: "Test weighted source",
-        yieldType: "lending-vault",
+      makeConfig({
         poolIds: ["only-one", "missing"],
         minPools: 2,
-      },
+      }),
       [makePool({ pool: "only-one", tvlUsd: 100, apy: 5 })],
+    );
+
+    expect(source).toBeNull();
+  });
+
+  it("rejects spoofed weighted members whose identity metadata does not match the curated pool", () => {
+    const source = buildWeightedYieldPoolGroupSource(
+      makeConfig({ poolIds: ["spoofed"] }),
+      [
+        makePool({
+          pool: "spoofed",
+          tvlUsd: 1_000_000,
+          apy: 987.65,
+          chain: "AttackerChain",
+          project: "attacker-project",
+          symbol: "FAKE",
+          stablecoin: false,
+        }),
+      ],
+    );
+
+    expect(source).toBeNull();
+  });
+
+  it("rejects weighted outputs that overflow finite numeric bounds", () => {
+    const source = buildWeightedYieldPoolGroupSource(
+      makeConfig({ poolIds: ["ethereum-pool"] }),
+      [makePool({ pool: "ethereum-pool", tvlUsd: 2, apy: Number.MAX_VALUE })],
     );
 
     expect(source).toBeNull();

--- a/worker/src/cron/yield-config-weighted-pools.ts
+++ b/worker/src/cron/yield-config-weighted-pools.ts
@@ -5,6 +5,9 @@ export interface WeightedYieldPoolGroupConfig {
   poolIds: string[];
   yieldSource: string;
   yieldType: YieldType;
+  expectedProject: string;
+  expectedSymbol: string;
+  expectedChainsByPoolId: Record<string, string>;
   minPools?: number;
 }
 
@@ -18,11 +21,18 @@ export const YIELD_WEIGHTED_POOL_GROUPS: Record<string, WeightedYieldPoolGroupCo
     sourceKey: "defillama-weighted:dtrinity-sdusd",
     yieldSource: "dTRINITY dStake (sdUSD)",
     yieldType: "lending-vault",
+    expectedProject: "dtrinity-dusd",
+    expectedSymbol: "SDUSD",
+    minPools: 2,
     poolIds: [
       // Ethereum sdUSD - dTRINITY dStake
       "78049985-79a8-4343-8618-3c27d41d5054",
       // Fraxtal sdUSD - dTRINITY dStake
       "f42cf641-393d-4671-895a-3c85cf7b1a57",
     ],
+    expectedChainsByPoolId: {
+      "78049985-79a8-4343-8618-3c27d41d5054": "ethereum",
+      "f42cf641-393d-4671-895a-3c85cf7b1a57": "fraxtal",
+    },
   },
 };

--- a/worker/src/cron/yield-sync/pool-filter.ts
+++ b/worker/src/cron/yield-sync/pool-filter.ts
@@ -2,7 +2,6 @@ import {
   EXPLICIT_YIELD_SOURCE_POOL_MAP,
   YIELD_POOL_MAP,
   YIELD_VARIANT_MAP,
-  YIELD_WEIGHTED_POOL_GROUPS,
 } from "../yield-config";
 import type { DlPool } from "./types";
 
@@ -14,11 +13,6 @@ function isExplicitYieldPoolId(poolId: string): boolean {
   return Object.values(EXPLICIT_YIELD_SOURCE_POOL_MAP)
     .flat()
     .some((config) => config.poolId === poolId);
-}
-
-function isWeightedYieldPoolId(poolId: string): boolean {
-  return Object.values(YIELD_WEIGHTED_POOL_GROUPS)
-    .some((config) => config.poolIds.includes(poolId));
 }
 
 function isYieldVariantSymbol(symbol: string): boolean {
@@ -34,6 +28,5 @@ export function isYieldRelevantDlPool(
   if (pool.stablecoin) return true;
   if (isNativeYieldPoolId(pool.pool)) return true;
   if (isExplicitYieldPoolId(pool.pool)) return true;
-  if (isWeightedYieldPoolId(pool.pool)) return true;
   return isYieldVariantSymbol(pool.symbol);
 }

--- a/worker/src/cron/yield-sync/weighted-pools.ts
+++ b/worker/src/cron/yield-sync/weighted-pools.ts
@@ -1,10 +1,23 @@
 import type { WeightedYieldPoolGroupConfig } from "../yield-config-weighted-pools";
 import type { DlPool, ResolvedYield } from "./types";
 
-function isUsableWeightedPool(pool: DlPool | undefined): pool is DlPool {
+function normalizeDlIdentity(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isUsableWeightedPool(
+  pool: DlPool | undefined,
+  config: WeightedYieldPoolGroupConfig,
+): pool is DlPool {
+  const expectedChain = pool ? config.expectedChainsByPoolId[pool.pool] : null;
   return Boolean(
     pool &&
+      expectedChain &&
       pool.exposure === "single" &&
+      pool.stablecoin &&
+      pool.project === config.expectedProject &&
+      normalizeDlIdentity(pool.symbol) === normalizeDlIdentity(config.expectedSymbol) &&
+      normalizeDlIdentity(pool.chain) === normalizeDlIdentity(expectedChain) &&
       Number.isFinite(pool.tvlUsd) &&
       pool.tvlUsd > 0 &&
       Number.isFinite(pool.apy) &&
@@ -20,8 +33,11 @@ function weightedAverage(
     .map((pool) => ({ value: readValue(pool), tvlUsd: pool.tvlUsd }))
     .filter((row): row is { value: number; tvlUsd: number } => row.value != null && Number.isFinite(row.value));
   const totalTvlUsd = rows.reduce((sum, row) => sum + row.tvlUsd, 0);
-  if (totalTvlUsd <= 0) return null;
-  return rows.reduce((sum, row) => sum + row.value * row.tvlUsd, 0) / totalTvlUsd;
+  if (!Number.isFinite(totalTvlUsd) || totalTvlUsd <= 0) return null;
+  const weightedTotal = rows.reduce((sum, row) => sum + row.value * row.tvlUsd, 0);
+  if (!Number.isFinite(weightedTotal)) return null;
+  const weightedValue = weightedTotal / totalTvlUsd;
+  return Number.isFinite(weightedValue) ? weightedValue : null;
 }
 
 function commonPoolValue(
@@ -56,20 +72,23 @@ export function buildWeightedYieldPoolGroupSource(
 ): ResolvedYield | null {
   const pools = config.poolIds
     .map((poolId) => dlPools.find((pool) => pool.pool === poolId))
-    .filter(isUsableWeightedPool);
+    .filter((pool): pool is DlPool => isUsableWeightedPool(pool, config));
 
   if (pools.length < (config.minPools ?? 1)) return null;
 
   const totalTvlUsd = pools.reduce((sum, pool) => sum + pool.tvlUsd, 0);
-  if (totalTvlUsd <= 0) return null;
+  if (!Number.isFinite(totalTvlUsd) || totalTvlUsd <= 0) return null;
 
   const currentApy = weightedAverage(pools, (pool) => pool.apy);
   if (currentApy == null) return null;
 
+  const apyBase = weightedAverage(pools, (pool) => pool.apyBase);
+  const apyReward = weightedAverage(pools, (pool) => pool.apyReward);
+
   return {
     currentApy,
-    apyBase: weightedAverage(pools, (pool) => pool.apyBase),
-    apyReward: weightedAverage(pools, (pool) => pool.apyReward),
+    apyBase,
+    apyReward,
     sourcePool: null,
     sourceTvlUsd: totalTvlUsd,
     dataSource: "defillama",


### PR DESCRIPTION
### Motivation
- The weighted-pool path admitted DeFiLlama rows by UUID with only exposure/TVL/APY checks, allowing spoofed rows or single-member publication and enabling numeric overflows in weighted averages.
- This could let a malicious or compromised upstream response inject arbitrary yield/TVL under a curated label or produce non-finite weighted results that break publication.

### Description
- Extend `WeightedYieldPoolGroupConfig` to include `expectedProject`, `expectedSymbol`, `expectedChainsByPoolId`, and set `minPools` for the dTRINITY sdUSD group so curated groups require expected members (`worker/src/cron/yield-config-weighted-pools.ts`).
- Harden weighted-pool acceptance in `buildWeightedYieldPoolGroupSource` by requiring per-pool identity matches (`stablecoin`, `project`, `symbol`, `chain`), honoring `minPools`, and rejecting non-finite or zero/negative TVL and weighted results (`worker/src/cron/yield-sync/weighted-pools.ts`).
- Remove the weighted-pool UUID exception from the broad DeFiLlama relevance filter so rows are not admitted solely because they reuse a curated UUID (`worker/src/cron/yield-sync/pool-filter.ts`).
- Add regression tests covering normal multi-pool weighting, rejection of spoofed metadata, `minPools` behavior, and numeric overflow rejection (`worker/src/cron/__tests__/yield-weighted-pools.test.ts`).

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/yield-weighted-pools.test.ts` and the suite passed (5 tests).
- Ran type-check `cd worker && npx tsc --noEmit` with no errors.
- Ran additional unit tests `npx vitest run worker/src/cron/__tests__/yield-config-registry.test.ts worker/src/cron/__tests__/yield-resolve.test.ts` and both test files passed (57 tests across them).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b158d48332b2fd4f77f2bbf619)