### PR TITLE
Scrub API verification hashes before hydration

### DIFF
--- a/src/app/api/layout.tsx
+++ b/src/app/api/layout.tsx
@@ -1,0 +1,36 @@
+const apiKeyVerifyHashSanitizer = `(function(){
+  var tokenPrefix = "akv_";
+  var storageKey = "pharos:api-key-verify-token";
+  var hash = window.location.hash || "";
+  var rawHash = hash.charAt(0) === "#" ? hash.slice(1) : hash;
+  if (rawHash.indexOf(tokenPrefix) !== 0) return;
+  var token = null;
+  try {
+    token = decodeURIComponent(rawHash).trim();
+  } catch (error) {
+    token = null;
+  }
+  if (!token || token.indexOf(tokenPrefix) !== 0) return;
+  window.history.replaceState(null, "", window.location.pathname + window.location.search);
+  try {
+    window.sessionStorage.setItem(storageKey, token);
+  } catch (error) {
+    window.location.hash = token;
+  }
+})();`;
+
+export default function ApiAccessLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <script
+        id="api-key-verify-hash-sanitizer"
+        dangerouslySetInnerHTML={{ __html: apiKeyVerifyHashSanitizer }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/components/__tests__/api-key-request-form.test.tsx
+++ b/src/components/__tests__/api-key-request-form.test.tsx
@@ -10,6 +10,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   window.history.replaceState(null, "", "/");
+  window.sessionStorage.clear();
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: undefined,
@@ -112,6 +113,26 @@ describe("ApiKeyRequestForm", () => {
 
     expect(screen.queryByRole("heading", { name: "Your API Key Is Ready" })).toBeNull();
     expect(screen.queryByText("Copy this token now.")).toBeNull();
+  });
+
+  it("verifies a token staged by the pre-hydration hash sanitizer", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(issuedResponse(suffix, `ph_test_${suffix}_token`)), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    window.history.replaceState(null, "", `/api/?utm_source=email`);
+    window.sessionStorage.setItem("pharos:api-key-verify-token", `akv_${suffix}`);
+    render(<ApiKeyRequestForm />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(window.location.href).toContain("utm_source=email");
+    expect(window.location.href).not.toContain(`akv_${suffix}`);
+    expect(window.sessionStorage.getItem("pharos:api-key-verify-token")).toBeNull();
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String((init as RequestInit).body)).token).toBe(`akv_${suffix}`);
   });
 
   it("verifies via hash token and scrubs the fragment before posting", async () => {

--- a/src/lib/api-key-self-serve.ts
+++ b/src/lib/api-key-self-serve.ts
@@ -11,6 +11,7 @@ import type {
 import { buildApiUrl } from "@/lib/api";
 
 const VERIFICATION_TOKEN_PREFIX = "akv_";
+const VERIFICATION_TOKEN_SESSION_STORAGE_KEY = "pharos:api-key-verify-token";
 
 interface ApiErrorPayload {
   error?: string;
@@ -106,7 +107,19 @@ function scrubHashVerificationToken(hash: string): string {
 
 export function readVerificationTokenFromUrl(): string | null {
   if (typeof window === "undefined") return null;
-  return parseHashVerificationToken(window.location.hash);
+  const hashToken = parseHashVerificationToken(window.location.hash);
+  if (hashToken) return hashToken;
+  try {
+    const storedToken = window.sessionStorage?.getItem(VERIFICATION_TOKEN_SESSION_STORAGE_KEY)?.trim() ?? null;
+    if (storedToken?.startsWith(VERIFICATION_TOKEN_PREFIX)) {
+      window.sessionStorage.removeItem(VERIFICATION_TOKEN_SESSION_STORAGE_KEY);
+      return storedToken;
+    }
+  } catch {
+    // Storage can be disabled in privacy-restricted browsers; in that case the
+    // hash path above remains the best-effort fallback.
+  }
+  return null;
 }
 
 export function stripVerificationTokenFromUrl(): void {


### PR DESCRIPTION
### Motivation
- Prevent a client-side exposure window where one-time `#akv_…` verification tokens could be read by third-party or inline scripts before the API page React effect runs.  
- Preserve the existing single-use verification flow while removing the fragment from the address bar as early as possible.  
- Keep behavior compatible with privacy-restricted browsers (where `sessionStorage` may be unavailable) by keeping the original hash fallback.

### Description
- Add a pre-hydration sanitizer for the API route at `src/app/api/layout.tsx` that runs as an inline script during document parse, removes `#akv_…` from `window.location.hash`, and stages the token into `sessionStorage` under `pharos:api-key-verify-token`.  
- Update the client helper in `src/lib/api-key-self-serve.ts` (`readVerificationTokenFromUrl`) to consume the staged token from `sessionStorage`, remove it immediately, and fall back to the original hash-parsing behavior when necessary.  
- Add a test that covers the staged-token path and clear `sessionStorage` during test cleanup in `src/components/__tests__/api-key-request-form.test.tsx` so the new sanitizer path is exercised.  
- The sanitizer writes to `sessionStorage` in normal browsers and falls back to restoring the hash if storage fails, preserving the existing form workflow and single-use semantics.

### Testing
- Ran the component test file with `npx vitest run src/components/__tests__/api-key-request-form.test.tsx --reporter verbose` and all tests in that file passed (8 tests).  
- Ran type checking with `npm run typecheck` and it succeeded with no errors.  
- Ran linters (`npm run lint`) and code style checks and they passed.  
- Attempted a full `npm run build` which failed during a generated-artifacts step due to a missing Playwright Firefox executable in the container, so the build was blocked by the environment rather than the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0f1bc8332971830f4edfeb662)