### PR TITLE
fix(pricing): redact Alchemy key in retry logs

### DIFF
--- a/worker/src/lib/__tests__/address-price-providers.test.ts
+++ b/worker/src/lib/__tests__/address-price-providers.test.ts
@@ -5,6 +5,7 @@ import {
   resolveEnabledAddressPriceProviders,
   resolveFallbackChain,
 } from "../address-price-providers";
+import { runAlchemyAddressProvider } from "../address-price-providers/alchemy";
 import { runBirdeyeAddressProvider } from "../address-price-providers/birdeye";
 import { runDexPaprikaAddressProvider } from "../address-price-providers/dexpaprika";
 import { runDexScreenerAddressProvider } from "../address-price-providers/dexscreener";
@@ -210,6 +211,33 @@ describe("address price providers", () => {
         rejectionReasonCounts: { "missing-quote": 1 },
       },
     ]);
+  });
+
+  it("redacts the Alchemy API key from retry logs while fetching with the real endpoint", async () => {
+    const target = makeDexScreenerTarget(0);
+    const secret = "ALCH_SECRET_123/plus+space value";
+    const encodedSecret = encodeURIComponent(secret);
+    const fetchMock = vi.fn(async () => new Response("upstream error", { status: 520 }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runAlchemyAddressProvider(
+      [target],
+      { alchemyApiKey: secret },
+      undefined,
+      Date.now() + 60_000,
+    );
+
+    expect(result.attemptedRequests).toBe(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.g.alchemy.com/prices/v1/${encodedSecret}/tokens/by-address`,
+      expect.any(Object),
+    );
+    const warnOutput = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(warnOutput).toContain("https://api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address");
+    expect(warnOutput).not.toContain(secret);
+    expect(warnOutput).not.toContain(encodedSecret);
+    warnSpy.mockRestore();
   });
 
   it("limits DexScreener address augmentation to one batch per run", async () => {

--- a/worker/src/lib/__tests__/fetch-retry.test.ts
+++ b/worker/src/lib/__tests__/fetch-retry.test.ts
@@ -104,6 +104,24 @@ describe("fetchWithRetry", () => {
     await expect(res?.json()).resolves.toEqual({ error: "slow down" });
   });
 
+  it("uses an explicit safe URL in retry logs without changing the fetched URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("bad gateway", { status: 520 }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithRetry(
+      "https://example.com/secret-token/resource",
+      undefined,
+      0,
+      { logUrl: "https://example.com/<redacted>/resource" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/secret-token/resource", expect.any(Object));
+    expect(warnSpy).toHaveBeenCalledWith("[fetch-retry] https://example.com/<redacted>/resource returned 520 (attempt 1/1)");
+    expect(warnSpy.mock.calls.map((call) => call.join(" ")).join("\n")).not.toContain("secret-token");
+    warnSpy.mockRestore();
+  });
+
   it("backs off on 529 overload responses before succeeding", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ error: "overloaded" }), { status: 529 }))

--- a/worker/src/lib/address-price-providers/alchemy.ts
+++ b/worker/src/lib/address-price-providers/alchemy.ts
@@ -51,6 +51,7 @@ export async function runAlchemyAddressProvider(
       provider: "alchemy-address",
       url,
       endpoint: "api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address",
+      fetchLogUrl: "https://api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address",
       init: {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/worker/src/lib/address-price-providers/shared.ts
+++ b/worker/src/lib/address-price-providers/shared.ts
@@ -97,6 +97,7 @@ export async function fetchProviderJson(params: {
   provider: AddressPriceProviderKey;
   url: string;
   endpoint?: string;
+  fetchLogUrl?: string;
   init?: RequestInit;
   candidateCount: number;
   signal?: AbortSignal;
@@ -122,6 +123,7 @@ export async function fetchProviderJson(params: {
     ADDRESS_PROVIDER_MAX_RETRIES,
     {
       timeoutMs: ADDRESS_PROVIDER_TIMEOUT_MS,
+      logUrl: params.fetchLogUrl,
       passthroughStatuses: PASSTHROUGH_STATUSES,
     },
   );

--- a/worker/src/lib/fetch-retry.ts
+++ b/worker/src/lib/fetch-retry.ts
@@ -2,6 +2,7 @@ import { createTimeoutSignal } from "@shared/lib/timeout-signal";
 import { sleepWithSignal, throwIfAborted } from "./abort";
 import { cancelResponseBodyQuietly } from "./response-body";
 interface FetchWithRetryOptions {
+  logUrl?: string;
   passthrough404?: boolean;
   passthroughStatuses?: number[];
   returnFinalResponse?: boolean;
@@ -33,6 +34,7 @@ export async function fetchWithRetry(
   maxRetries = 2,
   options?: FetchWithRetryOptions,
 ): Promise<Response | null> {
+  const logUrl = options?.logUrl ?? url;
   const passthrough404 = options?.passthrough404 ?? false;
   const passthroughStatuses = new Set<number>(options?.passthroughStatuses ?? []);
   if (passthrough404) passthroughStatuses.add(404);
@@ -60,7 +62,7 @@ export async function fetchWithRetry(
         const passthroughDelayMs = res.status === 429 ? getRetryDelayMs(res, i) : null;
         if (passthroughDelayMs != null) {
           const body = await res.text();
-          console.warn(`[fetch-retry] ${url} rate-limited (${res.status}), waiting ${passthroughDelayMs}ms before passthrough`);
+          console.warn(`[fetch-retry] ${logUrl} rate-limited (${res.status}), waiting ${passthroughDelayMs}ms before passthrough`);
           await sleepWithSignal(passthroughDelayMs, signal);
           return new Response(body, {
             status: res.status,
@@ -73,12 +75,12 @@ export async function fetchWithRetry(
       const retryDelayMs = i < maxRetries ? getRetryDelayMs(res, i) : null;
       if (retryDelayMs != null) {
         const label = res.status === 529 ? "overloaded" : "rate-limited";
-        console.warn(`[fetch-retry] ${url} ${label} (${res.status}), waiting ${retryDelayMs}ms`);
+        console.warn(`[fetch-retry] ${logUrl} ${label} (${res.status}), waiting ${retryDelayMs}ms`);
         await cancelResponseBodyQuietly(res);
         await sleepWithSignal(retryDelayMs, signal);
         continue;
       }
-      console.warn(`[fetch-retry] ${url} returned ${res.status} (attempt ${i + 1}/${maxRetries + 1})`);
+      console.warn(`[fetch-retry] ${logUrl} returned ${res.status} (attempt ${i + 1}/${maxRetries + 1})`);
       if (options?.returnFinalResponse && i >= maxRetries) {
         return res;
       }
@@ -87,7 +89,7 @@ export async function fetchWithRetry(
       if (signal?.aborted) {
         throw err instanceof Error ? err : new Error(String(err));
       }
-      console.warn(`[fetch-retry] ${url} failed (attempt ${i + 1}/${maxRetries + 1}):`, err);
+      console.warn(`[fetch-retry] ${logUrl} failed (attempt ${i + 1}/${maxRetries + 1}):`, err);
     }
     if (i < maxRetries) {
       await sleepWithSignal(1000 * 2 ** i, signal);


### PR DESCRIPTION
### Motivation
- An Alchemy exact-address provider built request URLs that embedded the ALCHEMY_API_KEY and those URLs could be written to warning logs on fetch failures or retry paths, risking exposure of a secret in observability output. 
- The goal is to avoid logging secret-bearing URLs while preserving the actual fetch target and existing retry behavior.

### Description
- Add an optional `logUrl` option to `fetchWithRetry` and use it for all retry/non-OK/exception warning messages so callers can supply a redacted endpoint for logs while still fetching the real `url`.
- Thread a `fetchLogUrl` parameter through `fetchProviderJson` and pass it into `fetchWithRetry` as `logUrl` so address-price providers can redact secret-bearing endpoints in diagnostics.
- Wire the Alchemy exact-address provider to pass a redacted Alchemy Prices endpoint (`api.g.alchemy.com/prices/v1/<api-key>/tokens/by-address`) as the `fetchLogUrl` while continuing to fetch the real encoded-API-key URL, keeping runtime behavior unchanged.
- Add regression tests: one in `fetch-retry.test.ts` that verifies `fetchWithRetry` logs the supplied safe URL while still calling `fetch` with the real URL, and one in `address-price-providers.test.ts` that asserts the Alchemy provider does not write the raw or encoded API key to warning logs on an upstream error.

### Testing
- Ran the affected unit suites with `vitest` on `worker/src/lib/__tests__/fetch-retry.test.ts` and `worker/src/lib/__tests__/address-price-providers.test.ts`, and all tests passed (`Tests 20 passed (20)`).
- Ran the worker TypeScript check with `cd worker && npx tsc --noEmit`, which completed successfully.
- Executed `npm run check:cron-connections` to ensure cron connection budgets were unchanged and it passed.
- Ran typed lint with `npm run lint:typed` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1a2008332b19ee151bad3f52c)