### PR TITLE
fix(freezewatch): surface freeze ledger quality warnings

### DIFF
--- a/src/app/freezewatch/client.tsx
+++ b/src/app/freezewatch/client.tsx
@@ -137,7 +137,7 @@ export default function FreezeWatchClient() {
             onBucketSelect={handleStatusBucketChange}
           />
           <BlacklistStats
-            stats={summary?.stats}
+            summary={summary}
             isLoading={summaryLoading}
             blacklistStatusBuckets={blacklistStatusBuckets}
             supportDataLoading={supportDataLoading}

--- a/src/components/__tests__/blacklist-stats.test.tsx
+++ b/src/components/__tests__/blacklist-stats.test.tsx
@@ -14,6 +14,15 @@ function makePerCoinRecord(defaultValue: number) {
   return Object.fromEntries(BLACKLIST_STABLECOINS.map((symbol) => [symbol, defaultValue]));
 }
 
+function makeSummary(): BlacklistSummaryResponse {
+  return {
+    stats: makeStats(),
+    chart: [],
+    chains: [],
+    totalEvents: 0,
+  };
+}
+
 function makeStats(): BlacklistSummaryResponse["stats"] {
   return {
     usdcBlacklisted: 9_692,
@@ -50,7 +59,7 @@ describe("BlacklistStats", () => {
   it("renders the unfreezable market-share stat from the blacklist-status no bucket", () => {
     render(
       <BlacklistStats
-        stats={makeStats()}
+        summary={{ ...makeSummary(), stats: makeStats() }}
         isLoading={false}
         blacklistStatusBuckets={[
           { status: "Yes", key: "yes", count: 10, marketCap: 150_000_000_000 },
@@ -69,16 +78,56 @@ describe("BlacklistStats", () => {
     expect(screen.getByText("last-known freeze snapshots")).toBeTruthy();
     expect(screen.getByText("Total Wiped Value")).toBeTruthy();
     expect(screen.queryByText("Snapshot Basis")).toBeNull();
-    expect(screen.queryByText("Data Quality")).toBeNull();
     expect(screen.queryByText("Freeze Ledger")).toBeNull();
     expect(screen.queryByText("USDT Blacklisted")).toBeNull();
     expect(screen.queryByText("unique events")).toBeNull();
   });
 
+  it("surfaces freeze-ledger data-quality warnings", () => {
+    render(
+      <BlacklistStats
+        summary={{
+          ...makeSummary(),
+          dataQuality: {
+            status: "stale",
+            warnings: ["current-balance-provider-failures", "stale-current-balance-snapshots"],
+            amountGaps: {
+              totalEvents: 100,
+              recoverable: 2,
+              unrecoverable: 1,
+              recentRecoverable: 1,
+              missingRatio: 0.03,
+              recentWindowSec: 86_400,
+            },
+            freezeLedger: {
+              providerFailedCount: 4,
+              staleSnapshotCount: 3,
+              trackedGapCount: 2,
+              scopedRows: 10,
+              legacyRows: 0,
+            },
+            coverage: { supportedConfigs: 8, unsupportedDeferredConfigs: 1 },
+          },
+        }}
+        isLoading={false}
+        blacklistStatusBuckets={null}
+        supportDataLoading={false}
+      />,
+    );
+
+    expect(screen.getByText("Data Quality")).toBeTruthy();
+    expect(screen.getByText("Freeze ledger snapshots are stale")).toBeTruthy();
+    expect(screen.getByText("4 current-balance provider failures")).toBeTruthy();
+    expect(screen.getByText("3 stale current-balance snapshots")).toBeTruthy();
+    expect(screen.getByText("2 tracked ledger gaps")).toBeTruthy();
+    expect(screen.getByText(/3 amount gaps across/)).toBeTruthy();
+    expect(screen.getByText("1 deferred coverage configs")).toBeTruthy();
+  });
+
   it("keeps extra precision for sub-0.1% market-share values", () => {
     render(
       <BlacklistStats
-        stats={makeStats()}
+        summary={{ ...makeSummary(), stats: makeStats() }}
         isLoading={false}
         blacklistStatusBuckets={[
           { status: "Yes", key: "yes", count: 10, marketCap: 150_000_000_000 },
@@ -96,7 +145,7 @@ describe("BlacklistStats", () => {
   it("shows an unresolved unfreezable share while support data is still loading", () => {
     render(
       <BlacklistStats
-        stats={makeStats()}
+        summary={{ ...makeSummary(), stats: makeStats() }}
         isLoading={false}
         blacklistStatusBuckets={[
           { status: "Yes", key: "yes", count: 10, marketCap: 150_000_000_000 },

--- a/src/components/blacklist-stats.tsx
+++ b/src/components/blacklist-stats.tsx
@@ -8,7 +8,7 @@ import { formatCurrency, formatPercent } from "@shared/lib/format";
 import type { BlacklistSummaryResponse } from "@shared/types";
 
 interface BlacklistStatsProps {
-  stats: BlacklistSummaryResponse["stats"] | undefined;
+  summary: BlacklistSummaryResponse | undefined;
   isLoading: boolean;
   blacklistStatusBuckets: BlacklistStatusBucket[] | null;
   supportDataLoading: boolean;
@@ -22,12 +22,14 @@ function formatMarketSharePercentage(value: number): string {
 }
 
 export function BlacklistStats({
-  stats,
+  summary,
   isLoading,
   blacklistStatusBuckets,
   supportDataLoading,
   onUnfreezableSelect,
 }: BlacklistStatsProps) {
+  const stats = summary?.stats;
+  const dataQuality = summary?.dataQuality;
   const trackedFrozenTotal = stats?.trackedFrozenTotal ?? stats?.activeFrozenTotal ?? 0;
   const totalTrackedMarketCap = (blacklistStatusBuckets ?? []).reduce((sum, bucket) => sum + bucket.marketCap, 0);
   const unfreezableBucket = blacklistStatusBuckets?.find((bucket) => bucket.key === "no") ?? null;
@@ -47,6 +49,19 @@ export function BlacklistStats({
   const unfreezableMarketShareSubtext = canDrillIntoUnfreezable
     ? `${baseUnfreezableSubtext} · View list →`
     : baseUnfreezableSubtext;
+  const hasFreezeLedgerWarnings =
+    dataQuality &&
+    (dataQuality.status !== "ok" ||
+      dataQuality.warnings.length > 0 ||
+      dataQuality.freezeLedger.providerFailedCount > 0 ||
+      dataQuality.freezeLedger.staleSnapshotCount > 0 ||
+      dataQuality.freezeLedger.trackedGapCount > 0 ||
+      dataQuality.amountGaps.recoverable > 0 ||
+      dataQuality.amountGaps.unrecoverable > 0 ||
+      dataQuality.coverage.unsupportedDeferredConfigs > 0);
+  const qualityTone = dataQuality?.status === "stale" ? "stale" : "degraded";
+  const qualityTitle =
+    dataQuality?.status === "stale" ? "Freeze ledger snapshots are stale" : "Freeze ledger coverage is degraded";
 
   if (isLoading) {
     return (
@@ -67,6 +82,47 @@ export function BlacklistStats({
 
   return (
     <div className="grid grid-cols-1 gap-3 animate-in fade-in duration-300 sm:grid-cols-2 sm:gap-5">
+      {hasFreezeLedgerWarnings ? (
+        <Card
+          className={
+            qualityTone === "stale"
+              ? "rounded-xl border-amber-500/60 bg-amber-500/10 sm:col-span-2"
+              : "rounded-xl border-yellow-500/60 bg-yellow-500/10 sm:col-span-2"
+          }
+          role="status"
+        >
+          <CardHeader className="pb-2">
+            <p className="pharos-kicker">Data Quality</p>
+            <h3 className="text-sm font-semibold text-foreground">{qualityTitle}</h3>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              Tracked frozen totals use last-known freeze snapshots. Treat the exposure figures as provisional until the
+              freeze-ledger checks recover.
+            </p>
+            <ul className="grid gap-1 sm:grid-cols-2">
+              {dataQuality.freezeLedger.providerFailedCount > 0 ? (
+                <li>{dataQuality.freezeLedger.providerFailedCount} current-balance provider failures</li>
+              ) : null}
+              {dataQuality.freezeLedger.staleSnapshotCount > 0 ? (
+                <li>{dataQuality.freezeLedger.staleSnapshotCount} stale current-balance snapshots</li>
+              ) : null}
+              {dataQuality.freezeLedger.trackedGapCount > 0 ? (
+                <li>{dataQuality.freezeLedger.trackedGapCount} tracked ledger gaps</li>
+              ) : null}
+              {dataQuality.amountGaps.recoverable + dataQuality.amountGaps.unrecoverable > 0 ? (
+                <li>
+                  {dataQuality.amountGaps.recoverable + dataQuality.amountGaps.unrecoverable} amount gaps across freeze
+                  events
+                </li>
+              ) : null}
+              {dataQuality.coverage.unsupportedDeferredConfigs > 0 ? (
+                <li>{dataQuality.coverage.unsupportedDeferredConfigs} deferred coverage configs</li>
+              ) : null}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
       <MetricStatCard
         title="Unfreezable Market Share"
         value={unfreezableMarketShareValue}


### PR DESCRIPTION
### Motivation
- The blacklist summary API returns `dataQuality` and `freezeLedgerMeta` signals for provider failures, stale current-balance snapshots, amount gaps, and deferred coverage, but the refreshed FreezeWatch layout stopped passing those fields into the stats panel, hiding important integrity warnings.
- Restore a minimal UI path so users see a clear warning when last-known frozen totals are provisional due to degraded or stale freeze-ledger signals.

### Description
- Pass the full blacklist summary object into the stats panel by changing the prop from `stats={summary?.stats}` to `summary={summary}` in `src/app/freezewatch/client.tsx` so the component can inspect `dataQuality` metadata. 
- Update `src/components/blacklist-stats.tsx` to accept a `summary: BlacklistSummaryResponse | undefined` prop, derive `dataQuality` from `summary`, and render a visible `Data Quality` warning card when `dataQuality.status` is `stale` or `degraded` or when warnings/ledger gaps/amount gaps/deferred coverage exist. 
- Add a component test in `src/components/__tests__/blacklist-stats.test.tsx` that constructs a `BlacklistSummaryResponse` with `dataQuality.status = "stale"` and asserts the warning card and individual messages (provider failures, stale snapshots, tracked gaps, amount gaps, deferred coverage) are rendered.

### Testing
- Ran `npx vitest run src/components/__tests__/blacklist-stats.test.tsx --reporter=verbose` and all tests in that file passed. 
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors reported. 
- Ran `git diff --check` / whitespace checks with no issues reported. 
- Attempted to capture a Playwright screenshot during a local `npm run dev` session, but `npx playwright install chromium` failed in this environment due to CDN HTTP 403, so visual verification via Playwright was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0fc1c833287ad5a3d95ec8652)