### PR TITLE
Harden Reservoir reserve bucket matching

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts
@@ -143,6 +143,30 @@ describe("adaptReservoirReserves", () => {
     expect(unknownExposurePct).toBeCloseTo((3 / 103) * 100, 6);
   });
 
+  it("does not classify assets from non-authoritative description or icon metadata", () => {
+    const { slices, unknownAssets, unknownExposurePct, immediateRedeemableUsd } = adaptReservoirReserves({
+      assets: [
+        {
+          label: "Mystery Strategy Vault",
+          description: "opaque strategy; not USDC backed; not an AUSD market",
+          iconPath: "/icons/not-USDC-or-AUSD.svg",
+          totalBalanceValue: "100",
+        },
+      ],
+      liabilities: [],
+      totalAssets: "100",
+      totalLiabilities: "95",
+      equity: "5",
+    });
+
+    expect(slices).toEqual([
+      { name: "Unmapped reserve positions", pct: 100, risk: "high" },
+    ]);
+    expect(unknownAssets).toEqual(["Mystery Strategy Vault"]);
+    expect(unknownExposurePct).toBe(100);
+    expect(immediateRedeemableUsd).toBe(0);
+  });
+
   it("keeps source total-assets gaps explicit instead of renormalizing disclosed rows", () => {
     const { slices, unknownAssets, sourceTotalGapPct } = adaptReservoirReserves({
       ...SAMPLE_RESPONSE,

--- a/worker/src/cron/reserve-adapters/reservoir.ts
+++ b/worker/src/cron/reserve-adapters/reservoir.ts
@@ -59,14 +59,6 @@ const RESERVOIR_STABLE_BUCKET_KEYS: readonly ReservoirBucketKey[] = [
   "usdc",
 ];
 
-function searchableReservoirText(item: ReservoirBalanceItem): string {
-  return [
-    item.label,
-    item.description ?? "",
-    item.iconPath ?? "",
-  ].join(" ");
-}
-
 // Word-boundary regex rules are single-token exclusive; for multi-token
 // labels (e.g. "PYUSD/USDC") the first matching rule wins, so wrappers
 // (USD1/PYUSD/RLUSD/GHO) are listed before USDT/USDC.
@@ -98,7 +90,7 @@ const RESERVOIR_BUCKETS: readonly ValueBucketRule<ReservoirBalanceItem, Reservoi
     name: "AUSD lending markets",
     risk: "medium",
     ...wrapperAssetMeta("ausd"),
-    match: (item) => /\bAUSD\b/.test(searchableReservoirText(item)),
+    match: (item) => /\bAUSD\b/.test(item.label),
   },
   {
     key: "gho",
@@ -125,7 +117,7 @@ const RESERVOIR_BUCKETS: readonly ValueBucketRule<ReservoirBalanceItem, Reservoi
     // USDC standalone only; other stablecoins that contain "USD" (USD1/USDT/etc)
     // match their own rules first.
     match: (item) =>
-      /\bUSDC\b/.test(searchableReservoirText(item))
+      /\bUSDC\b/.test(item.label)
       || /\bSteakhouse Prime Instant\b/i.test(item.label),
   },
   {
@@ -138,13 +130,13 @@ const RESERVOIR_BUCKETS: readonly ValueBucketRule<ReservoirBalanceItem, Reservoi
     key: "prime",
     name: "Hastra / Sentora PRIME credit allocations",
     risk: "high",
-    match: (item) => /\bPRIME\b/.test(searchableReservoirText(item)),
+    match: (item) => /\bPRIME\b/.test(item.label),
   },
   {
     key: "usdat",
     name: "Pendle PT USDat tokenized-treasury principal token",
     risk: "high",
-    match: (item) => /\bUSDAT\b/i.test(searchableReservoirText(item)),
+    match: (item) => /\bUSDAT\b/i.test(item.label),
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Fix a data-integrity/security bug where non-authoritative presentation fields (`description`/`iconPath`) were used to classify Reservoir reserve rows, allowing an attacker or broken upstream to mark unknown positions as USDC/AUSD and inflate redemption-capacity metrics. 
- Ensure reserve bucket assignment and `immediateRedeemableUsd` derive only from authoritative labels so unknown positions remain visible for operator review.

### Description
- Remove the helper that concatenated `label`, `description`, and `iconPath` and stop matching against presentation text so classification only uses `item.label` for AUSD, USDC, PRIME, USDAT (preserving the reviewed Steakhouse fallback). (`worker/src/cron/reserve-adapters/reservoir.ts`)
- Adjust bucket `match` rules to test `item.label` exclusively for the affected buckets instead of the combined presentation string. (`worker/src/cron/reserve-adapters/reservoir.ts`)
- Add a regression test asserting that a row with `USDC`/`AUSD` mentions only in `description`/`iconPath` remains unmapped and does not increase `immediateRedeemableUsd`. (`worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts`)

### Testing
- Ran the focused suite with `npx vitest run worker/src/cron/reserve-adapters/__tests__/reservoir.test.ts --reporter=dot` and all tests passed (18 passed). 
- Type-checked the worker code with `cd worker && npx tsc --noEmit` and it completed without errors. 
- Verified diffs/linters with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b193108332abff0b89386b39ba)