### PR TITLE
Harden Zephyr ZSD market cap pricing

### DIFF
--- a/worker/src/cron/__tests__/zephyr-zsd.test.ts
+++ b/worker/src/cron/__tests__/zephyr-zsd.test.ts
@@ -47,7 +47,7 @@ function makeZysMeta(): StablecoinMeta {
 }
 
 describe("parseZephyrZsdStats", () => {
-  it("uses official zsd_circ and live zsd_price for market cap", () => {
+  it("uses official zsd_circ and reasonable live zsd_price for fallback price metadata", () => {
     expect(parseZephyrZsdStats({
       zsd_circ: 385_038.0963333748,
       zsd_price: 1.003,
@@ -56,6 +56,28 @@ describe("parseZephyrZsdStats", () => {
       mcapPrice: 1.003,
       mcap: 386_193.2106223749,
       priceReported: true,
+    });
+  });
+
+  it("ignores unreasonable live zsd_price values for ZSD market-cap metadata", () => {
+    expect(parseZephyrZsdStats({
+      zsd_circ: 12_345,
+      zsd_price: "1000000000000",
+    })).toEqual({
+      supply: 12_345,
+      mcapPrice: 1,
+      mcap: 12_345,
+      priceReported: false,
+    });
+
+    expect(parseZephyrZsdStats({
+      zsd_circ: 12_345,
+      zsd_price: "0.000001",
+    })).toEqual({
+      supply: 12_345,
+      mcapPrice: 1,
+      mcap: 12_345,
+      priceReported: false,
     });
   });
 
@@ -144,7 +166,7 @@ describe("buildZephyrZsdPeggedAsset", () => {
       priceObservedAtMode: "upstream",
       priceSyncedAt: 1_700_000_060,
       supplySource: "zephyr-scanner",
-      circulating: { peggedUSD: 386_193.2106223749 },
+      circulating: { peggedUSD: 384_268.020140708 },
       chainCirculating: {},
       chains: [],
     });
@@ -167,7 +189,7 @@ describe("buildZephyrZsdPeggedAsset", () => {
       priceObservedAtMode: "local_fetch",
       priceSyncedAt: 1_700_000_060,
       supplySource: "zephyr-scanner",
-      circulating: { peggedUSD: 384_999.5925237415 },
+      circulating: { peggedUSD: 385_038.0963333748 },
     });
   });
 

--- a/worker/src/cron/sync-stablecoins/zephyr-zsd.ts
+++ b/worker/src/cron/sync-stablecoins/zephyr-zsd.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared/lib/onchain-supply-probe";
 import { USER_AGENT } from "../../lib/constants";
 import { fetchWithRetry } from "../../lib/fetch-retry";
+import { isReasonablePrice } from "../../lib/price-validation";
 import { cancelResponseBodyQuietly } from "../../lib/response-body";
 import type { PeggedAsset } from "./enrich-prices";
 import { pegTypeKey, getSupplementalChainLabels, toPositiveFiniteNumber } from "./supplemental-assets/shared";
@@ -41,13 +42,19 @@ function parseZephyrAssetStats(
   supplyKey: string,
   priceKey: string,
   fallbackPrice: number | null,
+  opts?: { pegType?: string; navToken?: boolean },
 ): ZephyrScannerAssetStats | null {
   if (!payload || typeof payload !== "object") return null;
   const record = payload as Record<string, unknown>;
   const supply = toPositiveFiniteNumber(record[supplyKey]);
   if (supply == null) return null;
 
-  const reportedPrice = toPositiveFiniteNumber(record[priceKey]);
+  const rawReportedPrice = toPositiveFiniteNumber(record[priceKey]);
+  const reportedPrice = rawReportedPrice != null && (
+    !opts?.pegType || isReasonablePrice(rawReportedPrice, opts.pegType, undefined, { navToken: opts.navToken })
+  )
+    ? rawReportedPrice
+    : undefined;
   const mcapPrice = reportedPrice ?? fallbackPrice;
   if (mcapPrice == null) return null;
 
@@ -60,11 +67,11 @@ function parseZephyrAssetStats(
 }
 
 export function parseZephyrZsdStats(payload: unknown): ZephyrScannerAssetStats | null {
-  return parseZephyrAssetStats(payload, "zsd_circ", "zsd_price", 1.0);
+  return parseZephyrAssetStats(payload, "zsd_circ", "zsd_price", 1.0, { pegType: "peggedUSD" });
 }
 
 export function parseZephyrZysStats(payload: unknown): ZephyrScannerAssetStats | null {
-  return parseZephyrAssetStats(payload, "zys_circ", "zys_price", null);
+  return parseZephyrAssetStats(payload, "zys_circ", "zys_price", null, { pegType: "peggedUSD", navToken: true });
 }
 
 export function parseZephyrProtocolStats(payload: unknown): ZephyrProtocolStats | null {
@@ -131,7 +138,10 @@ function buildZephyrPeggedAsset(
   nowSec = Math.floor(Date.now() / 1000),
 ): PeggedAsset | null {
   if (!isZephyrScannerAssetId(meta.id)) return null;
-  if (!Number.isFinite(stats.mcap) || stats.mcap <= 0) return null;
+  const circulatingMcap = meta.id === ZEPHYR_ZSD_ASSET_ID
+    ? stats.supply * (priceResolution?.price ?? 1.0)
+    : stats.mcap;
+  if (!Number.isFinite(circulatingMcap) || circulatingMcap <= 0) return null;
 
   const pKey = pegTypeKey(meta);
   const resolvedPrice = resolveZephyrPrice(stats, priceResolution, nowSec);
@@ -150,7 +160,7 @@ function buildZephyrPeggedAsset(
     priceObservedAtMode: resolvedPrice.observedAtMode,
     priceSyncedAt: resolvedPrice.syncedAt,
     supplySource: ZEPHYR_SUPPLY_SOURCE,
-    circulating: { [pKey]: stats.mcap },
+    circulating: { [pKey]: circulatingMcap },
     circulatingPrevDay: null,
     circulatingPrevWeek: null,
     circulatingPrevMonth: null,


### PR DESCRIPTION
### Motivation

- The Zephyr ZSD pipeline accepted any positive finite `zsd_price` from the external livestats JSON and multiplied it into persisted circulating `peggedUSD` market cap, allowing a malicious or compromised Zephyr response to poison published market-cap/analytics.  

### Description

- Validate reported Zephyr asset prices before using them as fallback metadata by calling `isReasonablePrice(...)` (peg context `peggedUSD`, `navToken` for ZYS) when parsing livestats.  
- Stop persisting the untrusted `stats.mcap` for ZSD and instead compute ZSD circulating market-cap from the independently resolved price (`priceResolution?.price ?? 1.0`) so the persisted value follows validated/resolved prices or the USD peg fallback.  
- Add regression tests that assert extreme inflation/deflation `zsd_price` values are ignored for ZSD market-cap metadata and update builder expectations to reflect the new circulating-value behavior.  
- Files changed: `worker/src/cron/sync-stablecoins/zephyr-zsd.ts`, `worker/src/cron/__tests__/zephyr-zsd.test.ts`.

### Testing

- Ran the Zephyr unit suite with `npx vitest run worker/src/cron/__tests__/zephyr-zsd.test.ts` and all tests passed.  
- Ran worker type-check with `cd worker && npx tsc --noEmit` and the typecheck succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b176c48332bc16ea1d85c230d9)