### PR TITLE
Harden Centrifuge reserve fallback

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts
@@ -181,62 +181,72 @@ describe("fetchCentrifugeVaultReserves", () => {
     expect(result.warnings).toEqual([
       expect.objectContaining({
         code: "centrifuge-vault-total-assets-unavailable",
-        effect: "info",
+        effect: "degraded",
       }),
     ]);
     expect(result.metadata).toMatchObject({
       freshnessMode: "not-applicable",
       chain: "ethereum",
       contractAddress: JTRSY_VAULT,
+      assetAddress: USDC_ASSET,
       totalSupplyRaw: "1031884381315470",
       details: {
         proofKind: "centrifuge-vault-total-supply-liveness",
         totalAssetsUnavailable: true,
+        assetAddressMatchesExpected: true,
+      },
+      redemption: {
+        capacityKind: "documented-eventual",
+        freshnessKind: "same-run-onchain",
+        routeStatus: "degraded",
+        routeStatusSource: "onchain",
       },
     });
   });
 
-  it("falls back when both totalAssets and totalSupply are unavailable", async () => {
+  it("throws when totalAssets and totalSupply are both unavailable", async () => {
     fetchWithRetryMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as { params: [{ data: string }] };
+      if (body.params[0].data === "0x38d52e0f") {
+        return jsonResponse({
+          result: "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        });
+      }
       if (body.params[0].data === "0x01e1d114" || body.params[0].data === "0x18160ddd") {
         return jsonResponse({ error: { code: 3, message: "execution reverted" } });
       }
       return null;
     });
 
-    const result = await fetchCentrifugeVaultReserves(makeCoin(), makeConfig(), new AbortController().signal, {
-      chainRpcs: testChainRpcs,
+    await expect(
+      fetchCentrifugeVaultReserves(makeCoin(), makeConfig(), new AbortController().signal, {
+        chainRpcs: testChainRpcs,
+      }),
+    ).rejects.toThrow(/totalAssets\(\) call failed/);
+  });
+
+  it("throws when totalAssets is unavailable and asset() returns a different token", async () => {
+    fetchWithRetryMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { params: [{ data: string }] };
+      if (body.params[0].data === "0x38d52e0f") {
+        return jsonResponse({
+          result: "0x000000000000000000000000000000000000000000000000000000000000dead",
+        });
+      }
+      if (body.params[0].data === "0x01e1d114") {
+        return jsonResponse({ error: { code: 3, message: "execution reverted" } });
+      }
+      if (body.params[0].data === "0x18160ddd") {
+        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000064" });
+      }
+      return null;
     });
 
-    expect(result.slices).toEqual([
-      {
-        name: "U.S. Treasury bills via Janus Henderson Anemoy fund",
-        pct: 100,
-        risk: "very-low",
-      },
-    ]);
-    expect(result.warnings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: "centrifuge-vault-asset-unavailable",
-          effect: "info",
-        }),
-        expect.objectContaining({
-          code: "centrifuge-vault-total-assets-unavailable",
-          effect: "info",
-        }),
-      ]),
-    );
-    expect(result.metadata).toMatchObject({
-      freshnessMode: "not-applicable",
-      chain: "ethereum",
-      contractAddress: JTRSY_VAULT,
-      details: {
-        proofKind: "centrifuge-vault-total-supply-liveness",
-        totalAssetsUnavailable: true,
-      },
-    });
+    await expect(
+      fetchCentrifugeVaultReserves(makeCoin(), makeConfig(), new AbortController().signal, {
+        chainRpcs: testChainRpcs,
+      }),
+    ).rejects.toThrow(/asset\(\) returned/);
   });
 
   it("throws when asset() cannot be read", async () => {

--- a/worker/src/cron/reserve-adapters/centrifuge-vault.ts
+++ b/worker/src/cron/reserve-adapters/centrifuge-vault.ts
@@ -7,7 +7,7 @@ import { parseEvmAddressResult, resolveCoinContractAddress } from "./evm";
 import {
   notApplicableFreshnessMetadata,
   requireOnchainInput,
-  reserveInfoWarning,
+  reserveDegradedWarning,
 } from "./helpers";
 import {
   ERC4626_ASSET_SELECTOR,
@@ -63,59 +63,18 @@ export async function fetchCentrifugeVaultReserves(
 
   if (!totalAssetsResult) {
     const assetAddress = assetResult ? parseEvmAddressResult(assetResult as `0x${string}`) : null;
-    const assetAddressMatchesExpected = assetAddress === expectedAssetAddress;
-    const livenessWarnings: LiveReserveWarning[] = [];
-
-    if (assetAddress == null) {
-      livenessWarnings.push(
-        reserveInfoWarning(
-          "centrifuge-vault-asset-unavailable",
-          `Centrifuge vault ${coin.id} asset() was unavailable while resolving fallback liveness`,
-        ),
-      );
-    } else if (!assetAddressMatchesExpected) {
-      livenessWarnings.push(
-        reserveInfoWarning(
-          "centrifuge-vault-asset-mismatch",
-          `Centrifuge vault ${coin.id} asset() read ${assetAddress}, expected ${expectedAssetAddress}`,
-        ),
+    if (!assetAddress) {
+      throw new Error(
+        `ERC-7540 asset() could not be read for ${coin.id}; expected ${expectedAssetAddress}`,
       );
     }
-
-    if (totalSupplyRaw == null || totalSupplyRaw <= 0n) {
-      livenessWarnings.push(
-        reserveInfoWarning(
-          "centrifuge-vault-total-assets-unavailable",
-          "Centrifuge vault totalAssets() and totalSupply() were both unavailable; scoring fallback uses configured slice coverage only.",
-        ),
+    if (assetAddress !== expectedAssetAddress) {
+      throw new Error(
+        `ERC-7540 asset() returned ${assetAddress}, expected ${expectedAssetAddress} for ${coin.id}`,
       );
-
-      return {
-        slices: [
-          {
-            name: params.slice.name,
-            pct: 100,
-            risk: params.slice.risk,
-          },
-        ],
-        ...(livenessWarnings.length > 0 ? { warnings: livenessWarnings } : {}),
-        metadata: {
-          ...notApplicableFreshnessMetadata({
-            proofKind: "centrifuge-vault-total-supply-liveness",
-            totalAssetsUnavailable: true,
-          }),
-          chain: primaryInput.chain,
-          contractAddress,
-          ...(totalSupplyRaw != null ? { totalSupplyRaw: totalSupplyRaw.toString() } : {}),
-          ...(assetAddress != null ? { assetAddress } : {}),
-          ...(assetAddress != null ? { assetAddressMatchesExpected } : {}),
-          redemption: {
-            capacityKind: "documented-eventual" as const,
-            freshnessKind: "same-run-onchain" as const,
-            routeStatus: "unknown" as const,
-          },
-        },
-      };
+    }
+    if (totalSupplyRaw == null || totalSupplyRaw <= 0n) {
+      throw new Error(`ERC-7540 totalAssets() call failed for ${coin.id}`);
     }
 
     return {
@@ -127,24 +86,26 @@ export async function fetchCentrifugeVaultReserves(
         },
       ],
       warnings: [
-        ...livenessWarnings,
-        reserveInfoWarning(
+        reserveDegradedWarning(
           "centrifuge-vault-total-assets-unavailable",
-          "Centrifuge vault totalAssets() was unavailable; validated token liveness with ERC-20 totalSupply()",
+          "Centrifuge vault totalAssets() was unavailable; validated accounting asset and token liveness with ERC-20 totalSupply()",
         ),
-      ].filter((warning): warning is LiveReserveWarning => warning != null),
+      ],
       metadata: {
         ...notApplicableFreshnessMetadata({
           proofKind: "centrifuge-vault-total-supply-liveness",
           totalAssetsUnavailable: true,
+          assetAddressMatchesExpected: true,
         }),
         chain: primaryInput.chain,
         contractAddress,
+        assetAddress,
         totalSupplyRaw: totalSupplyRaw.toString(),
         redemption: {
           capacityKind: "documented-eventual" as const,
           freshnessKind: "same-run-onchain" as const,
-          routeStatus: "unknown" as const,
+          routeStatus: "degraded" as const,
+          routeStatusSource: "onchain" as const,
         },
       },
     };


### PR DESCRIPTION
### Motivation
- A previous fallback accepted ERC-7540 `totalAssets()` failures based only on a positive ERC-20 `totalSupply()` and emitted an info-only warning, allowing such snapshots to remain `ok` and scoring-eligible; this weakens proof integrity and can let upstream/RPC failures become authoritative-looking reserve evidence. 
- The intent of this change is to require the accounting `asset()` sanity-check before accepting a `totalSupply()` liveness fallback and to ensure any fallback produces degraded state (or fails closed) so score-grade evidence is not produced from partial reads. 

### Description
- Validate the ERC-7540 accounting asset before accepting the `totalSupply()` fallback in `worker/src/cron/reserve-adapters/centrifuge-vault.ts`, throwing if `asset()` is unreadable or does not match the configured `assetAddress`. 
- Fail closed when both `totalAssets()` and `totalSupply()` are unavailable instead of publishing the configured slice as a successful result. 
- Mark the `totalAssets()`-unavailable fallback as degraded by using `reserveDegradedWarning`, adding `assetAddress` and `assetAddressMatchesExpected` to metadata, and setting `redemption.routeStatus` to `degraded` with `routeStatusSource: "onchain"`, so such snapshots cannot be treated as `ok` score-grade evidence. 
- Update the focused Centrifuge adapter tests in `worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts` to expect degraded fallback behavior and to cover the closed-failure cases for unavailable `totalSupply()` and mismatched `asset()`. 

### Testing
- Ran the focused unit suite with `npx vitest run worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts --reporter=verbose` and all tests passed (`7 passed`). 
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b107208332b3ea0d7c0dd8d7ee)