### PR TITLE
Bound crvUSD LLAMMA band multicalls

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
@@ -664,6 +664,78 @@ describe("fetchCrvUsdReserves", () => {
     expect(fetchDefiLlamaPrices).not.toHaveBeenCalled();
   });
 
+  it("rejects unexpectedly wide LLAMMA band ranges before building multicall payloads", async () => {
+    vi.mocked(fetchDefiLlamaPrices).mockResolvedValue(new Map([[BTC_ASSET, 10]]));
+    vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (_chain, address, data) => {
+      const normalizedAddress = address.toLowerCase();
+      const callData = data as `0x${string}`;
+
+      if (normalizedAddress === CURVE_CONTROLLER_FACTORY.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_FACTORY_ABI, data: callData });
+        if (decoded.functionName === "n_collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "n_collaterals", result: 1n });
+        }
+        if (decoded.functionName === "collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "collaterals", result: BTC_ASSET });
+        }
+        if (decoded.functionName === "controllers") {
+          return encodeFunctionResult({
+            abi: CURVE_FACTORY_ABI,
+            functionName: "controllers",
+            result: LLAMMA_CONTROLLER,
+          });
+        }
+        if (decoded.functionName === "amms") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "amms", result: LLAMMA_AMM });
+        }
+      }
+
+      if (normalizedAddress === BTC_ASSET) {
+        const decoded = decodeFunctionData({ abi: ERC20_ABI, data: callData });
+        if (decoded.functionName === "symbol") {
+          return encodeFunctionResult({ abi: ERC20_ABI, functionName: "symbol", result: "WBTC" });
+        }
+      }
+
+      if (normalizedAddress === LLAMMA_AMM.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_AMM_ABI, data: callData });
+        if (decoded.functionName === "min_band") {
+          return encodeFunctionResult({ abi: CURVE_AMM_ABI, functionName: "min_band", result: 0n });
+        }
+        if (decoded.functionName === "max_band") {
+          return encodeFunctionResult({ abi: CURVE_AMM_ABI, functionName: "max_band", result: 2_048n });
+        }
+      }
+
+      if (normalizedAddress === YIELD_BASIS_FACTORY) {
+        const decoded = decodeFunctionData({ abi: FACTORY_ABI, data: callData });
+        if (decoded.functionName === "market_count") {
+          return encodeFunctionResult({ abi: FACTORY_ABI, functionName: "market_count", result: 0n });
+        }
+      }
+
+      return null;
+    });
+
+    const config: LiveReservesConfig = {
+      adapter: "crvusd",
+      version: 3,
+      semantics: "collateral-mix",
+      inputs: {
+        primary: {
+          kind: "onchain-evm",
+          chain: "ethereum",
+          rpcMode: "public-rpc",
+        },
+      },
+    };
+
+    await expect(fetchCrvUsdReserves({} as never, config, signal)).rejects.toThrow(
+      "band range too wide: 2049 bands exceeds 2048",
+    );
+    expect(fetchOnchainMulticall3).not.toHaveBeenCalled();
+  });
+
   it("loads direct LLAMMA bands onchain when configured for onchain input", async () => {
     vi.mocked(fetchDefiLlamaPrices).mockResolvedValue(new Map([[BTC_ASSET, 10]]));
     vi.mocked(fetchOnchainMulticall3).mockResolvedValue([

--- a/worker/src/cron/reserve-adapters/crvusd.ts
+++ b/worker/src/cron/reserve-adapters/crvusd.ts
@@ -108,6 +108,8 @@ const ETHEREUM_RPC_URLS = [getPublicRpcUrl(ETHEREUM_CHAIN), getSecondaryFallback
 );
 const CURVE_CONTROLLER_FACTORY = "0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC";
 const DIRECT_LLAMMA_MULTICALL_BATCH_SIZE = 500;
+const DIRECT_LLAMMA_MAX_BANDS_PER_MARKET = 2_048;
+const DIRECT_LLAMMA_MAX_MULTICALLS = 10_000;
 const CRVUSD_MARKET_READ_CONCURRENCY = 2;
 const YIELD_BASIS_FACTORY = "0x370a449febb9411c95bf897021377fe0b7d100c0";
 const YIELD_BASIS_VIEW_GAS = "0x5B8D80";
@@ -297,6 +299,19 @@ function safeInt256ToNumber(value: bigint, label: string): number {
   return asNumber;
 }
 
+function countLlammaBands(minBand: number, maxBand: number, marketId: number): number {
+  const bandCount = maxBand - minBand + 1;
+  if (!Number.isSafeInteger(bandCount) || bandCount < 1) {
+    throw new Error(`crvUSD LLAMMA market ${marketId} band range invalid: ${minBand}..${maxBand}`);
+  }
+  if (bandCount > DIRECT_LLAMMA_MAX_BANDS_PER_MARKET) {
+    throw new Error(
+      `crvUSD LLAMMA market ${marketId} band range too wide: ${bandCount} bands exceeds ${DIRECT_LLAMMA_MAX_BANDS_PER_MARKET}`,
+    );
+  }
+  return bandCount;
+}
+
 async function fetchLlammaMarketDescriptors(
   signal: AbortSignal,
   ctx?: AdapterContext,
@@ -340,6 +355,7 @@ async function fetchLlammaMarketDescriptors(
       const minBand = safeInt256ToNumber(minBandRaw as bigint, `market ${marketId} min_band`);
       const maxBand = safeInt256ToNumber(maxBandRaw as bigint, `market ${marketId} max_band`);
       if (maxBand < minBand) return null;
+      countLlammaBands(minBand, maxBand, marketId);
       return {
         marketId,
         collateralAddress,
@@ -375,6 +391,16 @@ async function fetchLlammaMarketExposures(signal: AbortSignal, ctx?: AdapterCont
     signal,
     ctx,
   );
+
+  const callCount = descriptors.reduce(
+    (total, market) => total + countLlammaBands(market.minBand, market.maxBand, market.marketId) * 2,
+    0,
+  );
+  if (callCount > DIRECT_LLAMMA_MAX_MULTICALLS) {
+    throw new Error(
+      `crvUSD LLAMMA band multicall too large: ${callCount} calls exceeds ${DIRECT_LLAMMA_MAX_MULTICALLS}`,
+    );
+  }
 
   const calls = descriptors.flatMap((market) => {
     const marketCalls = [];


### PR DESCRIPTION
### Motivation
- The crvUSD on-chain LLAMMA reader could accept attacker-influenced `min_band`/`max_band` ranges and synchronously expand them into two multicall entries per band, allowing a maliciously wide range to exhaust CPU or memory and stall the Worker cron.
- The change introduces conservative guardrails to fail early on invalid or excessively wide band ranges and prevent allocation of unbounded multicall payloads while preserving normal on-chain crvUSD reserve reads.

### Description
- Added constants `DIRECT_LLAMMA_MAX_BANDS_PER_MARKET` and `DIRECT_LLAMMA_MAX_MULTICALLS` and a helper `countLlammaBands()` in `worker/src/cron/reserve-adapters/crvusd.ts` to validate per-market band counts and cap the total multicall size.
- Called `countLlammaBands()` immediately after reading `min_band`/`max_band` so invalid or too-wide per-market ranges throw before descriptors are used.
- Added an aggregate `callCount` check that throws when the total number of multicall entries would exceed the configured maximum so the `calls` array is never built in that case.
- Added a focused test `rejects unexpectedly wide LLAMMA band ranges before building multicall payloads` in `worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts` that verifies a wide range is rejected and `fetchOnchainMulticall3` is not called.

### Testing
- Ran the adapter unit tests with `npx vitest run worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts --reporter=verbose` and all tests passed (12 passed).
- Type-checked the Worker with `cd worker && npx tsc --noEmit` and the build type-check completed successfully.
- Ran `npm run check:cron-connections` and the cron connection budget checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35080a07588332a0fe842874bcf540)