### PR TITLE
fix(blacklist): guard duplicate repair against releases

### DIFF
--- a/worker/src/cron/blacklist/__tests__/post-fetch.test.ts
+++ b/worker/src/cron/blacklist/__tests__/post-fetch.test.ts
@@ -77,6 +77,10 @@ describe("processFetchedBlacklistRows", () => {
         match: "SELECT id FROM blacklist_events WHERE id IN",
         rows: [{ id: duplicateRow.id }],
       },
+      {
+        match: "SELECT * FROM blacklist_events",
+        rows: [duplicateRow as unknown as Record<string, unknown>],
+      },
     ], { requireMatch: true });
     vi.mocked(syncCurrentBalanceCacheForRows).mockResolvedValue({
       updated: 1,
@@ -110,6 +114,74 @@ describe("processFetchedBlacklistRows", () => {
       expect.objectContaining({
         assetPriceUsd: null,
         latestRows: [duplicateRow],
+      }),
+    );
+  });
+
+  it("uses duplicate unblacklist rows when selecting repair latest state", async () => {
+    const blacklistRow = makeBlacklistRow({
+      id: "ethereum-0xduplicate-release-0",
+      stablecoin: "USDT",
+      chain_id: "ethereum",
+      chain_name: "Ethereum",
+      event_type: "blacklist",
+      address: "0x0000000000000000000000000000000000000789",
+      amount_native: null,
+      amount_usd_at_event: null,
+      amount_source: "unavailable",
+      amount_status: "recoverable_pending",
+      timestamp: 100,
+    }) as BlacklistRow;
+    const unblacklistRow = makeBlacklistRow({
+      id: "ethereum-0xduplicate-release-1",
+      stablecoin: "USDT",
+      chain_id: "ethereum",
+      chain_name: "Ethereum",
+      event_type: "unblacklist",
+      address: blacklistRow.address,
+      amount_native: null,
+      amount_usd_at_event: null,
+      amount_source: "unavailable",
+      amount_status: "recoverable_pending",
+      timestamp: 200,
+    }) as BlacklistRow;
+    const db = mockD1([
+      {
+        match: "SELECT id FROM blacklist_events WHERE id IN",
+        rows: [{ id: blacklistRow.id }, { id: unblacklistRow.id }],
+      },
+      {
+        match: "SELECT * FROM blacklist_events",
+        rows: [unblacklistRow as unknown as Record<string, unknown>],
+      },
+    ], { requireMatch: true });
+    vi.mocked(syncCurrentBalanceCacheForRows).mockResolvedValue({
+      updated: 0,
+      failed: 0,
+      skippedDueBudget: 0,
+      budgetExhausted: false,
+    });
+
+    const result = await processFetchedBlacklistRows({
+      db,
+      config,
+      rows: [blacklistRow, unblacklistRow],
+      chainLabel: "evm",
+      etherscanApiKey: null,
+      drpcApiKey: null,
+      trongridApiKey: null,
+      etherscanLimiter: async <T>(fn: () => Promise<T>) => fn(),
+      tronLimiter: async <T>(fn: () => Promise<T>) => fn(),
+      runBudget: makeRunBudget(),
+    });
+
+    expect(result.insertedRows).toBe(0);
+    expect(syncCurrentBalanceCacheForRows).toHaveBeenCalledWith(
+      db,
+      config,
+      [blacklistRow, unblacklistRow],
+      expect.objectContaining({
+        latestRows: [unblacklistRow],
       }),
     );
   });

--- a/worker/src/cron/blacklist/__tests__/row-preparation.test.ts
+++ b/worker/src/cron/blacklist/__tests__/row-preparation.test.ts
@@ -3,6 +3,7 @@ import { makeBlacklistRow } from "../../../test-helpers/__shared/fixtures";
 import type { BlacklistRow } from "../shared";
 import {
   buildCurrentBalanceSnapshotRows,
+  buildLatestBlacklistRows,
 } from "../row-preparation";
 
 describe("blacklist row preparation", () => {
@@ -22,6 +23,25 @@ describe("blacklist row preparation", () => {
 
     expect(buildCurrentBalanceSnapshotRows([unblacklistRow, blacklistRow])).toEqual([
       blacklistRow,
+      unblacklistRow,
+    ]);
+  });
+
+  it("selects only the latest row per address for active-state repair", () => {
+    const blacklistRow = makeBlacklistRow({
+      id: "ethereum-0xduplicate-0",
+      event_type: "blacklist",
+      address: "0x0000000000000000000000000000000000000333",
+      timestamp: 10,
+    }) as BlacklistRow;
+    const unblacklistRow = makeBlacklistRow({
+      id: "ethereum-0xduplicate-1",
+      event_type: "unblacklist",
+      address: blacklistRow.address,
+      timestamp: 11,
+    }) as BlacklistRow;
+
+    expect(buildLatestBlacklistRows([unblacklistRow, blacklistRow])).toEqual([
       unblacklistRow,
     ]);
   });

--- a/worker/src/cron/blacklist/post-fetch.ts
+++ b/worker/src/cron/blacklist/post-fetch.ts
@@ -10,6 +10,7 @@ import { insertBlacklistRows } from "./persistence";
 import { type BlacklistRunBudget } from "./run-budget";
 import {
   buildCurrentBalanceSnapshotRows,
+  buildLatestBlacklistRows,
   fetchBlacklistAssetPriceFromCache,
 } from "./row-preparation";
 
@@ -69,9 +70,47 @@ function filterCacheRepairLedgerRows(rows: BlacklistRow[]): BlacklistRow[] {
   return rows.filter(
     (row) =>
       row.suppression_reason == null
-      && (row.event_type === "blacklist" || row.event_type === "destroy")
-      && !shouldSuppressAsMirrorZero(row.stablecoin, row.event_type, row.amount_native),
+      && (row.event_type === "unblacklist"
+        || !shouldSuppressAsMirrorZero(row.stablecoin, row.event_type, row.amount_native)),
   );
+}
+
+async function fetchLatestKnownRepairRows(
+  db: D1Database,
+  rows: BlacklistRow[],
+): Promise<BlacklistRow[]> {
+  if (rows.length === 0) return [];
+
+  const seenKeys = new Set<string>();
+  const statements: D1PreparedStatement[] = [];
+  for (const row of rows) {
+    const key = `${row.stablecoin}:${row.chain_id}:${row.config_key}:${(row.contract_address ?? "").toLowerCase()}:${row.address.toLowerCase()}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    statements.push(
+      db.prepare(`
+        SELECT * FROM blacklist_events
+        WHERE stablecoin = ?
+          AND chain_id = ?
+          AND config_key = ?
+          AND lower(contract_address) = lower(?)
+          AND lower(address) = lower(?)
+        ORDER BY timestamp DESC, id DESC
+        LIMIT 1
+      `).bind(
+        row.stablecoin,
+        row.chain_id,
+        row.config_key,
+        row.contract_address,
+        row.address,
+      ),
+    );
+  }
+
+  const results = await db.batch(statements);
+  return results
+    .map((result) => (result as { results?: BlacklistRow[] }).results?.[0])
+    .filter((row): row is BlacklistRow => row != null && row.suppression_reason == null);
 }
 
 export async function processFetchedBlacklistRows(
@@ -94,6 +133,7 @@ export async function processFetchedBlacklistRows(
   if (newRows.length === 0) {
     const duplicateLedgerRows = filterCacheRepairLedgerRows(duplicateRows);
     if (duplicateLedgerRows.length > 0) {
+      const latestKnownRepairRows = await fetchLatestKnownRepairRows(options.db, duplicateLedgerRows);
       const assetPriceUsd = getBlacklistPriceAssetId(options.config.stablecoin)
         ? await fetchBlacklistAssetPriceFromCache(options.db, options.config.stablecoin)
         : null;
@@ -111,7 +151,7 @@ export async function processFetchedBlacklistRows(
           signal: options.signal,
           chainRpcs: options.chainRpcs,
           assetPriceUsd,
-          latestRows: buildCurrentBalanceSnapshotRows(duplicateLedgerRows),
+          latestRows: buildLatestBlacklistRows([...duplicateLedgerRows, ...latestKnownRepairRows]),
         },
       );
       return {
@@ -156,8 +196,12 @@ export async function processFetchedBlacklistRows(
   const insertedRows = await insertBlacklistRows(options.db, newRows);
   const ledgerRows = newRows.filter((row) => row.suppression_reason == null);
   const duplicateLedgerRows = filterCacheRepairLedgerRows(duplicateRows);
+  const latestKnownRepairRows = await fetchLatestKnownRepairRows(options.db, duplicateLedgerRows);
   const cacheSyncRows = [...ledgerRows, ...duplicateLedgerRows];
-  const latestLedgerRows = buildCurrentBalanceSnapshotRows(cacheSyncRows);
+  const latestLedgerRows = [
+    ...buildCurrentBalanceSnapshotRows(ledgerRows),
+    ...buildLatestBlacklistRows([...duplicateLedgerRows, ...latestKnownRepairRows]),
+  ];
   const currentBalanceCacheCounters = await syncCurrentBalanceCacheForRows(
     options.db,
     options.config,

--- a/worker/src/cron/blacklist/row-preparation.ts
+++ b/worker/src/cron/blacklist/row-preparation.ts
@@ -11,6 +11,17 @@ function compareBlacklistRows(left: BlacklistRow, right: BlacklistRow): number {
   return left.timestamp === right.timestamp ? left.id.localeCompare(right.id) : left.timestamp - right.timestamp;
 }
 
+export function buildLatestBlacklistRows(rows: readonly BlacklistRow[]): BlacklistRow[] {
+  const latestByAddress = new Map<string, BlacklistRow>();
+  const orderedRows = [...rows].sort(compareBlacklistRows);
+
+  for (const row of orderedRows) {
+    latestByAddress.set(buildCurrentBalanceKey(row), row);
+  }
+
+  return [...latestByAddress.values()].sort(compareBlacklistRows);
+}
+
 function buildCurrentBalanceKey(row: BlacklistRow): string {
   return buildBlacklistContractBalanceKey(
     row.stablecoin,


### PR DESCRIPTION
### Motivation
- Repair/duplicate-only cache sync previously dropped `unblacklist` events before selecting the latest event per identity, allowing stale duplicate `blacklist`/`destroy` rows to refresh `blacklist_current_balances` and corrupt frozen-balance analytics.
- The change aims to ensure repair lanes respect later releases already persisted in D1 or present among duplicate rows so public metrics cannot be poisoned by replayed historical blacklist logs.

### Description
- Include `unblacklist` rows when filtering duplicate repair candidates so releases are considered during latest-state selection by changing `filterCacheRepairLedgerRows` to retain `unblacklist` rows where appropriate.
- Add `buildLatestBlacklistRows(rows)` (in `worker/src/cron/blacklist/row-preparation.ts`) to compute the single latest row per address for active-state repair (distinct from the snapshot-preserving `buildCurrentBalanceSnapshotRows`).
- Add `fetchLatestKnownRepairRows(db, rows)` in `worker/src/cron/blacklist/post-fetch.ts` to query the DB for the latest persisted event per repair identity and include those results when choosing repair `latestRows` so newer persisted releases suppress stale duplicates.
- Use `buildLatestBlacklistRows([...duplicateLedgerRows, ...latestKnownRepairRows])` for duplicate-only repair and combine snapshot rows for newly ingested rows with latest-rows from duplicates + DB-lookups in the mixed path so same-batch snapshot behavior for new inserts is preserved.
- Add regression tests covering the duplicate-unblacklist repair selection and the `buildLatestBlacklistRows` helper (updates to `worker/src/cron/blacklist/__tests__/post-fetch.test.ts` and `worker/src/cron/blacklist/__tests__/row-preparation.test.ts`).

### Testing
- Ran the focused Vitest suites with `npx vitest run worker/src/cron/blacklist/__tests__/post-fetch.test.ts worker/src/cron/blacklist/__tests__/row-preparation.test.ts --reporter=verbose` and all tests passed (2 files, 5 tests total).
- Verified TypeScript checks with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b0ddbc8332a4c61af4b8333f97)