### PR TITLE
fix(telegram): throttle webhook auth warning logs

### DIFF
--- a/worker/src/api/__tests__/telegram-webhook-auth.test.ts
+++ b/worker/src/api/__tests__/telegram-webhook-auth.test.ts
@@ -50,6 +50,31 @@ describe("validateTelegramWebhookSecret", () => {
     warn.mockRestore();
   });
 
+  it("throttles repeated missing-secret warnings after the spike signal", async () => {
+    resetTelegramInvalidSecretLogStateForTests();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const request = new Request("https://x/api/telegram-webhook");
+
+    for (let index = 0; index < 7; index += 1) {
+      expect(await validateTelegramWebhookSecret(request, "current")).toBe("missing");
+    }
+
+    expect(warn).toHaveBeenCalledTimes(5);
+    const records = warn.mock.calls.map((call) => JSON.parse(String(call[0] ?? "{}")) as {
+      missingSecretWindowCount?: number;
+      missingSecretSpike?: boolean;
+    });
+    expect(records.map((record) => record.missingSecretWindowCount)).toEqual([1, 2, 3, 4, 5]);
+    expect(records.map((record) => record.missingSecretSpike)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      true,
+    ]);
+    warn.mockRestore();
+  });
+
   it("logs invalid secrets as a separate spike signal", async () => {
     resetTelegramInvalidSecretLogStateForTests();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/worker/src/lib/telegram-log.ts
+++ b/worker/src/lib/telegram-log.ts
@@ -50,6 +50,10 @@ function normalizeId(value: string | number | null | undefined): string | undefi
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function shouldEmitSecretAuthAttempt(windowCount: number): boolean {
+  return windowCount <= SECRET_AUTH_SPIKE_THRESHOLD;
+}
+
 export function logTelegramEvent(event: TelegramLogEvent): void {
   const { level, message, chatId, userId, action, ...rest } = event;
   const resolvedLevel: TelegramLogLevel = level ?? "error";
@@ -94,6 +98,7 @@ export function logTelegramInvalidSecretAttempt(
     invalidSecretWindowCount = 0;
   }
   invalidSecretWindowCount += 1;
+  if (!shouldEmitSecretAuthAttempt(invalidSecretWindowCount)) return;
 
   logTelegramEvent({
     level: "warn",
@@ -121,6 +126,7 @@ export function logTelegramMissingSecretAttempt(
     missingSecretWindowCount = 0;
   }
   missingSecretWindowCount += 1;
+  if (!shouldEmitSecretAuthAttempt(missingSecretWindowCount)) return;
 
   logTelegramEvent({
     level: "warn",


### PR DESCRIPTION
### Motivation

- The Telegram webhook path is public and missing-secret probes could create one `console.warn` per unauthenticated request, allowing log flooding and masking real signals.
- The intended spike/throttle behavior was implemented as counters but did not suppress log emission after the threshold, so a fix was needed to actually limit warn-level records.

### Description

- Add a small emission guard `shouldEmitSecretAuthAttempt()` and use it to suppress warn-level log emission once the per-isolate window count exceeds `SECRET_AUTH_SPIKE_THRESHOLD` in `worker/src/lib/telegram-log.ts`.
- Preserve existing spike labeling (the `missingSecretSpike` / `invalidSecretSpike` boolean) so the threshold event is still recorded when the count reaches the configured threshold.
- Early-return from `logTelegramInvalidSecretAttempt()` and `logTelegramMissingSecretAttempt()` after the threshold to prevent unbounded `console.warn` output while keeping the in-memory counters and windowing behavior intact.
- Add a regression test `throttles repeated missing-secret warnings after the spike signal` to `worker/src/api/__tests__/telegram-webhook-auth.test.ts` that verifies repeated missing-secret requests still return the same auth result but only emit warning logs up to the configured threshold.

### Testing

- Ran the targeted test suites with `npx vitest run worker/src/api/__tests__/telegram-webhook-auth.test.ts worker/src/api/__tests__/telegram-webhook.test.ts` and all tests passed (149 tests total in the run reported by Vitest).
- Type-checked the worker code with `cd worker && npx tsc --noEmit` which completed without type errors.

Files changed: `worker/src/lib/telegram-log.ts`, `worker/src/api/__tests__/telegram-webhook-auth.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051eb8fc833287c2932b1bebb261)