### PR TITLE
fix(worker): preserve immutable row presence on malformed backstop rows

### DIFF
--- a/worker/src/lib/__tests__/redemption-backstops-store.test.ts
+++ b/worker/src/lib/__tests__/redemption-backstops-store.test.ts
@@ -410,6 +410,52 @@ describe("loadLegacyRedemptionBackstopCurrentMap", () => {
     assertAllD1MatchesUsed(db);
   });
 
+  it("does not use legacy current rows when immutable run rows are present but all malformed", async () => {
+    const db = mockD1Strict([
+      {
+        match: COMPLETED_RUNS_SQL,
+        matchBinds: [5],
+        rows: [
+          {
+            run_id: "run-corrupt",
+            completed_at: 1_700_000_010,
+            expected_count: 1,
+            written_count: 1,
+            min_updated_at: 1_700_000_000,
+            max_updated_at: 1_700_000_000,
+            methodology_version: "1.1",
+          },
+          {
+            run_id: "run-valid",
+            completed_at: 1_700_000_000,
+            expected_count: 1,
+            written_count: 1,
+            min_updated_at: 1_699_999_990,
+            max_updated_at: 1_699_999_990,
+            methodology_version: "1.1",
+          },
+        ],
+      },
+      {
+        match: RUN_ROWS_BY_RUN_ID_SQL,
+        matchBinds: ["run-corrupt"],
+        rows: [makeRealisticRow({ snapshot_run_id: "run-corrupt", score: 101 })],
+      },
+      {
+        match: RUN_ROWS_BY_RUN_ID_SQL,
+        matchBinds: ["run-valid"],
+        rows: [makeRealisticRow({ snapshot_run_id: "run-valid", updated_at: 1_699_999_990 })],
+      },
+    ]);
+
+    const result = await loadRedemptionBackstopSnapshot(db);
+
+    expect(result.runId).toBe("run-valid");
+    expect(result.snapshotSource).toBe("run-rows");
+    expect(result.latestUpdatedAt).toBe(1_699_999_990);
+    assertAllD1MatchesUsed(db);
+  });
+
   it("serves legacy current rows scoped to the completed run when immutable run rows are empty", async () => {
     const db = mockD1Strict([
       {

--- a/worker/src/lib/redemption-backstops-store.ts
+++ b/worker/src/lib/redemption-backstops-store.ts
@@ -451,7 +451,10 @@ async function queryRedemptionBackstopMap(db: D1Database, runId?: string | null)
   return decodeBackstopRows(rows.results ?? [], "Failed to decode redemption backstop snapshot rows");
 }
 
-async function queryRedemptionBackstopMapFromRunRows(db: D1Database, runId: string): Promise<RedemptionBackstopMap> {
+async function queryRedemptionBackstopMapFromRunRows(
+  db: D1Database,
+  runId: string,
+): Promise<{ map: RedemptionBackstopMap; rawRowCount: number }> {
   let rows: D1Result<RedemptionBackstopRow>;
   try {
     rows = await db
@@ -471,7 +474,11 @@ async function queryRedemptionBackstopMapFromRunRows(db: D1Database, runId: stri
     });
   }
 
-  return decodeBackstopRows(rows.results ?? [], "Failed to decode immutable redemption backstop run rows");
+  const resultRows = rows.results ?? [];
+  return {
+    map: decodeBackstopRows(resultRows, "Failed to decode immutable redemption backstop run rows"),
+    rawRowCount: resultRows.length,
+  };
 }
 
 async function queryCompletedRedemptionBackstopRunMap(
@@ -479,8 +486,8 @@ async function queryCompletedRedemptionBackstopRunMap(
   runId: string,
 ): Promise<{ map: RedemptionBackstopMap; source: RedemptionSnapshotSource }> {
   try {
-    const map = await queryRedemptionBackstopMapFromRunRows(db, runId);
-    if (Object.keys(map).length > 0) {
+    const { map, rawRowCount } = await queryRedemptionBackstopMapFromRunRows(db, runId);
+    if (rawRowCount > 0) {
       return { map, source: "run-rows" };
     }
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent a data-integrity regression where all-malformed immutable `redemption_backstop_run_rows` could be treated as absent and trigger a legacy `redemption_backstop` fallback for a completed run.
- Ensure completed-run selection treats a populated-but-malformed immutable run as present (and therefore rejected if decoding fails), instead of indistinguishable from an empty migration-era run.

### Description
- Change `queryRedemptionBackstopMapFromRunRows` to return both the decoded `map` and the `rawRowCount` of rows returned by the `redemption_backstop_run_rows` query so presence is preserved even when decoding skips malformed rows (`worker/src/lib/redemption-backstops-store.ts`).
- Update completed-run source selection logic to use `rawRowCount > 0` to decide that immutable `run-rows` were present, avoiding accidental `legacy-current` fallback when all immutable rows decode to nothing (`worker/src/lib/redemption-backstops-store.ts`).
- Add a regression test `does not use legacy current rows when immutable run rows are present but all malformed` that asserts a corrupt latest immutable run is rejected in favor of an older valid immutable run instead of falling back to legacy rows (`worker/src/lib/__tests__/redemption-backstops-store.test.ts`).

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/redemption-backstops-store.test.ts` and the test suite passed.
- Ran `cd worker && npx tsc --noEmit` to verify TypeScript checks and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051de7348332af7ab0723951be17)