### PR TITLE
fix(report-card): use report-card snapshot freshness for Safety Score header

### DIFF
--- a/src/components/__tests__/report-card.test.tsx
+++ b/src/components/__tests__/report-card.test.tsx
@@ -60,7 +60,23 @@ function makeReportCard(): ReportCard {
 
 describe("ReportCardDetail", () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
+  });
+
+  it("marks the header freshness chip stale after the report-card freshness budget", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-19T12:16:00Z"));
+
+    render(
+      <ReportCardDetail
+        card={makeReportCard()}
+        liquidityComponents={null}
+        updatedAtMs={new Date("2026-06-19T12:00:00Z").getTime()}
+      />,
+    );
+
+    expect(screen.getByRole("status", { name: /Updated at/i }).getAttribute("data-stale")).toBe("true");
   });
 
   it("keeps dimension disclosure controls separate from methodology hint buttons", () => {

--- a/src/components/report-card.tsx
+++ b/src/components/report-card.tsx
@@ -22,7 +22,7 @@ import { parseDimensionDetail } from "@/lib/report-card-parsing";
 import { getSafetyGradeMetadata, gradeBandLabel } from "@/lib/report-card-ui";
 import { LIQUIDITY_SCORE_WEIGHTS } from "@shared/lib/liquidity-score-weights";
 import { FreshnessIndicator } from "@/components/status/freshness-indicator";
-import { CRON_24H } from "@/lib/cron-intervals";
+import { API_FRESHNESS_MAX_AGE_SEC } from "@shared/lib/api-freshness";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShowYourWorkPanel } from "@/components/show-your-work-panel";
 
@@ -530,7 +530,7 @@ export function ReportCardDetail({ card, liquidityComponents, updatedAtMs, right
             <span className="flex items-center justify-between gap-2">
               <MethodologyLabel topic="safetyScore">Safety Score</MethodologyLabel>
               {updatedAtMs != null ? (
-                <FreshnessIndicator updatedAtMs={updatedAtMs} staleAfterMs={CRON_24H} labelPrefix="Updated" />
+                <FreshnessIndicator updatedAtMs={updatedAtMs} staleAfterMs={API_FRESHNESS_MAX_AGE_SEC.reportCards * 1000} labelPrefix="Updated" />
               ) : null}
             </span>
           </CardTitle>

--- a/src/lib/__tests__/stablecoin-detail-view-model.test.ts
+++ b/src/lib/__tests__/stablecoin-detail-view-model.test.ts
@@ -112,6 +112,54 @@ function makeBuildStablecoinDetailViewModelParams(
 }
 
 describe("stablecoin detail view-model builder", () => {
+  it("uses report-card snapshot freshness instead of the browser fetch timestamp", () => {
+    const coin = TRACKED_META_BY_ID.get("usdt-tether");
+    expect(coin).toBeDefined();
+
+    const viewModel = buildStablecoinDetailViewModel(
+      makeBuildStablecoinDetailViewModelParams({
+        core: {
+          id: "usdt-tether",
+          coin: coin!,
+        },
+        queries: {
+          supplyHistory: { data: [{ date: 1_700_000_000, circulatingUsd: 100, price: 1 }] },
+          stablecoinList: {
+            data: {
+              peggedAssets: [
+                {
+                  id: "usdt-tether",
+                  name: "Tether",
+                  symbol: "USDT",
+                  pegType: "peggedUSD",
+                  price: 1,
+                  circulating: { peggedUSD: 100 },
+                },
+              ],
+              fxFallbackRates: {},
+            } as never,
+            dataUpdatedAt: 1,
+          },
+          reportCards: {
+            data: {
+              cards: [],
+              methodology: {},
+              dependencyGraph: { nodes: [], edges: [] },
+              updatedAt: 1_700_000_000,
+            } as never,
+            dataUpdatedAt: 1_800_000_000_000,
+            meta: { source: "test", updatedAt: 1_700_000_123 },
+          },
+        },
+      }),
+    );
+
+    expect(viewModel.status).toBe("ready");
+    if (viewModel.status !== "ready") return;
+
+    expect(viewModel.reportCardUpdatedAt).toBe(1_700_000_123_000);
+  });
+
   it("uses only compact mint-authority summaries for client detail presentation", () => {
     const fullCoin = TRACKED_META_BY_ID.get("usdc-circle");
     expect(fullCoin?.mintAuthority).toBeDefined();

--- a/src/lib/stablecoin-detail-view-model.ts
+++ b/src/lib/stablecoin-detail-view-model.ts
@@ -88,6 +88,11 @@ export interface DetailQueryResource<TData> {
   meta: ApiMeta | null;
 }
 
+function resolveReportCardSnapshotUpdatedAtMs(reportCards: DetailQueryResource<ReportCardsResponse>): number | null {
+  const updatedAtSeconds = reportCards.meta?.updatedAt ?? reportCards.data?.updatedAt ?? null;
+  return updatedAtSeconds != null && updatedAtSeconds > 0 ? updatedAtSeconds * 1000 : null;
+}
+
 export interface DetailSupplyHistoryInput {
   data?: SupplyHistoryPoint[];
   isLoading: boolean;
@@ -866,7 +871,7 @@ export function buildStablecoinDetailViewModel({
     summary,
     logoSrc,
     reportCard,
-    reportCardUpdatedAt: reportCards.dataUpdatedAt > 0 ? reportCards.dataUpdatedAt : null,
+    reportCardUpdatedAt: resolveReportCardSnapshotUpdatedAtMs(reportCards),
     variantParent,
     variantSiblings: variantRelationship?.siblings ?? [],
     childVariants,


### PR DESCRIPTION
### Motivation

- The Safety Score header was showing a freshness chip driven by TanStack Query's `dataUpdatedAt` and using a 24h stale window, which can mislead users when the API is serving an older report-card snapshot.  
- The report-card API emits authoritative freshness via `_meta.updatedAt`/`updatedAt` and the public freshness budget for report cards is 900 seconds, so the header must reflect the snapshot timestamp and budget.  

### Description

- Derive the view-model `reportCardUpdatedAt` from the report-card response metadata or payload `updatedAt` (seconds → milliseconds) via `resolveReportCardSnapshotUpdatedAtMs()` in `src/lib/stablecoin-detail-view-model.ts`.  
- Update `ReportCardDetail` to use the configured endpoint budget `API_FRESHNESS_MAX_AGE_SEC.reportCards * 1000` for the header `FreshnessIndicator` instead of `CRON_24H` in `src/components/report-card.tsx`.  
- Add a unit/regression test verifying the view model prefers the snapshot `updatedAt` metadata (`src/lib/__tests__/stablecoin-detail-view-model.test.ts`) and a component test asserting the header chip becomes stale per the report-card freshness budget (`src/components/__tests__/report-card.test.tsx`).  

### Testing

- Ran the focused Vitest suites with `npx vitest run src/lib/__tests__/stablecoin-detail-view-model.test.ts src/components/__tests__/report-card.test.tsx --config vitest.config.ts --reporter verbose` and all tests passed.  
- Ran static checks with `npm run typecheck` and `npm run lint`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350febf8948332bc12deaa10e662d1)