### PR TITLE
Bound crvUSD LLAMMA on-chain reads

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts
@@ -443,6 +443,116 @@ describe("fetchCrvUsdReserves", () => {
     });
   });
 
+  it("rejects malicious LLAMMA market counts before descriptor allocation", async () => {
+    vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (_chain, address, data) => {
+      const normalizedAddress = address.toLowerCase();
+      const callData = data as `0x${string}`;
+
+      if (normalizedAddress === CURVE_CONTROLLER_FACTORY.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_FACTORY_ABI, data: callData });
+        if (decoded.functionName === "n_collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "n_collaterals", result: 65n });
+        }
+      }
+
+      if (normalizedAddress === YIELD_BASIS_FACTORY) {
+        const decoded = decodeFunctionData({ abi: FACTORY_ABI, data: callData });
+        if (decoded.functionName === "market_count") {
+          return encodeFunctionResult({ abi: FACTORY_ABI, functionName: "market_count", result: 0n });
+        }
+      }
+
+      return null;
+    });
+
+    const config: LiveReservesConfig = {
+      adapter: "crvusd",
+      version: 3,
+      semantics: "collateral-mix",
+      inputs: {
+        primary: {
+          kind: "onchain-evm",
+          chain: "ethereum",
+          rpcMode: "public-rpc",
+        },
+      },
+    };
+
+    await expect(fetchCrvUsdReserves({} as never, config, signal)).rejects.toThrow(
+      "n_collaterals exceeds operational cap",
+    );
+    expect(fetchOnchainMulticall3).not.toHaveBeenCalled();
+  });
+
+  it("rejects malicious LLAMMA band spans before building multicall entries", async () => {
+    vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (_chain, address, data) => {
+      const normalizedAddress = address.toLowerCase();
+      const callData = data as `0x${string}`;
+
+      if (normalizedAddress === CURVE_CONTROLLER_FACTORY.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_FACTORY_ABI, data: callData });
+        if (decoded.functionName === "n_collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "n_collaterals", result: 1n });
+        }
+        if (decoded.functionName === "collaterals") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "collaterals", result: BTC_ASSET });
+        }
+        if (decoded.functionName === "controllers") {
+          return encodeFunctionResult({
+            abi: CURVE_FACTORY_ABI,
+            functionName: "controllers",
+            result: LLAMMA_CONTROLLER,
+          });
+        }
+        if (decoded.functionName === "amms") {
+          return encodeFunctionResult({ abi: CURVE_FACTORY_ABI, functionName: "amms", result: LLAMMA_AMM });
+        }
+      }
+
+      if (normalizedAddress === BTC_ASSET) {
+        const decoded = decodeFunctionData({ abi: ERC20_ABI, data: callData });
+        if (decoded.functionName === "symbol") {
+          return encodeFunctionResult({ abi: ERC20_ABI, functionName: "symbol", result: "WBTC" });
+        }
+      }
+
+      if (normalizedAddress === LLAMMA_AMM.toLowerCase()) {
+        const decoded = decodeFunctionData({ abi: CURVE_AMM_ABI, data: callData });
+        if (decoded.functionName === "min_band") {
+          return encodeFunctionResult({ abi: CURVE_AMM_ABI, functionName: "min_band", result: 0n });
+        }
+        if (decoded.functionName === "max_band") {
+          return encodeFunctionResult({ abi: CURVE_AMM_ABI, functionName: "max_band", result: 2048n });
+        }
+      }
+
+      if (normalizedAddress === YIELD_BASIS_FACTORY) {
+        const decoded = decodeFunctionData({ abi: FACTORY_ABI, data: callData });
+        if (decoded.functionName === "market_count") {
+          return encodeFunctionResult({ abi: FACTORY_ABI, functionName: "market_count", result: 0n });
+        }
+      }
+
+      return null;
+    });
+
+    const config: LiveReservesConfig = {
+      adapter: "crvusd",
+      version: 3,
+      semantics: "collateral-mix",
+      inputs: {
+        primary: {
+          kind: "onchain-evm",
+          chain: "ethereum",
+          rpcMode: "public-rpc",
+        },
+      },
+    };
+
+    await expect(fetchCrvUsdReserves({} as never, config, signal)).rejects.toThrow("band span exceeds operational cap");
+    expect(fetchOnchainMulticall3).not.toHaveBeenCalled();
+  });
+
   it("loads Yield Basis markets onchain and merges them with direct Curve collateral", async () => {
     vi.mocked(fetchJsonWithRetry).mockResolvedValue({
       chains: {

--- a/worker/src/cron/reserve-adapters/crvusd.ts
+++ b/worker/src/cron/reserve-adapters/crvusd.ts
@@ -108,6 +108,9 @@ const ETHEREUM_RPC_URLS = [getPublicRpcUrl(ETHEREUM_CHAIN), getSecondaryFallback
 );
 const CURVE_CONTROLLER_FACTORY = "0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC";
 const DIRECT_LLAMMA_MULTICALL_BATCH_SIZE = 500;
+const DIRECT_LLAMMA_MAX_MARKETS = 64;
+const DIRECT_LLAMMA_MAX_BANDS_PER_MARKET = 2_048;
+const DIRECT_LLAMMA_MAX_MULTICALL_ENTRIES = 8_192;
 const CRVUSD_MARKET_READ_CONCURRENCY = 2;
 const YIELD_BASIS_FACTORY = "0x370a449febb9411c95bf897021377fe0b7d100c0";
 const YIELD_BASIS_VIEW_GAS = "0x5B8D80";
@@ -312,6 +315,11 @@ async function fetchLlammaMarketDescriptors(
   if (!Number.isSafeInteger(marketCount) || marketCount < 0) {
     throw new Error(`crvUSD ControllerFactory n_collaterals invalid: ${String(countRaw)}`);
   }
+  if (marketCount > DIRECT_LLAMMA_MAX_MARKETS) {
+    throw new Error(
+      `crvUSD ControllerFactory n_collaterals exceeds operational cap: ${marketCount} > ${DIRECT_LLAMMA_MAX_MARKETS}`,
+    );
+  }
 
   const descriptors = await mapWithConcurrency(
     Array.from({ length: marketCount }, (_, marketId) => marketId),
@@ -340,6 +348,12 @@ async function fetchLlammaMarketDescriptors(
       const minBand = safeInt256ToNumber(minBandRaw as bigint, `market ${marketId} min_band`);
       const maxBand = safeInt256ToNumber(maxBandRaw as bigint, `market ${marketId} max_band`);
       if (maxBand < minBand) return null;
+      const bandCount = maxBand - minBand + 1;
+      if (!Number.isSafeInteger(bandCount) || bandCount > DIRECT_LLAMMA_MAX_BANDS_PER_MARKET) {
+        throw new Error(
+          `crvUSD LLAMMA band span exceeds operational cap for market ${marketId}: ${bandCount} > ${DIRECT_LLAMMA_MAX_BANDS_PER_MARKET}`,
+        );
+      }
       return {
         marketId,
         collateralAddress,
@@ -376,9 +390,17 @@ async function fetchLlammaMarketExposures(signal: AbortSignal, ctx?: AdapterCont
     ctx,
   );
 
+  const totalMulticallEntries = descriptors.reduce((sum, market) => sum + (market.maxBand - market.minBand + 1) * 2, 0);
+  if (totalMulticallEntries > DIRECT_LLAMMA_MAX_MULTICALL_ENTRIES) {
+    throw new Error(
+      `crvUSD LLAMMA band multicall exceeds operational cap: ${totalMulticallEntries} > ${DIRECT_LLAMMA_MAX_MULTICALL_ENTRIES}`,
+    );
+  }
+
   const calls = descriptors.flatMap((market) => {
     const marketCalls = [];
     for (let band = market.minBand; band <= market.maxBand; band += 1) {
+      throwIfAborted(signal);
       marketCalls.push({
         label: `${market.marketId}:y:${band}`,
         contract: market.ammAddress,


### PR DESCRIPTION
### Motivation
- The LLAMMA on-chain reader accepted RPC-returned `n_collaterals`, `min_band`, and `max_band` without operational caps, allowing a malicious or faulty RPC to cause huge synchronous call-array construction and exhaust Worker CPU/memory before timeouts/abort handling applied. 
- The change prevents availability DoS by enforcing sane upper bounds and early rejection of obviously-malicious ranges while preserving normal on-chain behavior.

### Description
- Add operational caps and constants in `worker/src/cron/reserve-adapters/crvusd.ts`: `DIRECT_LLAMMA_MAX_MARKETS`, `DIRECT_LLAMMA_MAX_BANDS_PER_MARKET`, and `DIRECT_LLAMMA_MAX_MULTICALL_ENTRIES`. 
- Validate `n_collaterals` against `DIRECT_LLAMMA_MAX_MARKETS` before allocating descriptors and validate per-market `bandCount` against `DIRECT_LLAMMA_MAX_BANDS_PER_MARKET` when reading `min_band`/`max_band`. 
- Compute the total planned multicall entry count and reject if it exceeds `DIRECT_LLAMMA_MAX_MULTICALL_ENTRIES` before building the call array, and add `throwIfAborted(signal)` inside the band loop to respect already-signalled aborts. 
- Add regression tests in `worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts` that assert oversized `n_collaterals` and oversized band spans are rejected and that `fetchOnchainMulticall3` is not invoked for those cases.

### Testing
- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/crvusd.test.ts`, which passed all tests (13 passed). 
- Ran `cd worker && npx tsc --noEmit` with no TypeScript errors. 
- Ran `npm run check:cron-connections` and confirmed cron connection budgets remain within limits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35099c14f883329b511ea7c4871eee)