### PR TITLE
Fix discovery candidate upsert failure isolation

### DIFF
--- a/worker/src/cron/__tests__/discovery-scan.test.ts
+++ b/worker/src/cron/__tests__/discovery-scan.test.ts
@@ -83,6 +83,41 @@ describe("upsertDiscoveryCandidates", () => {
     expect(history[0].sql).toContain("ON CONFLICT (gecko_id)");
     expect(history[1].sql).toContain("ON CONFLICT (llama_id)");
   });
+
+  it("falls back to per-candidate upserts when a discovery batch fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const db = mockD1([
+      {
+        match: "INSERT INTO discovery_candidates",
+        matchBinds: ["bad-stable", null, null, "BAD", 9_000_000, "coingecko", 1771934400, 1771934400],
+        rows: [],
+        throwError: new Error("NOT NULL constraint failed: discovery_candidates.name"),
+      },
+    ]);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-24T12:00:00Z"));
+    try {
+      const upserted = await upsertDiscoveryCandidates(db, [
+        { geckoId: "good-one", name: "GoodOne", symbol: "GOOD", marketCap: 10_000_000, source: "coingecko" },
+        { geckoId: "bad-stable", name: null as unknown as string, symbol: "BAD", marketCap: 9_000_000, source: "coingecko" },
+        { llamaId: 42, name: "LlamaStable", symbol: "LST", marketCap: 8_000_000, source: "defillama" },
+      ]);
+
+      expect(upserted).toBe(2);
+      expect(warn).toHaveBeenCalledWith(
+        "[discovery] Upsert batch failed; retrying candidates individually:",
+        expect.any(Error),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        "[discovery] Skipping discovery candidate after upsert failure:",
+        expect.any(Error),
+      );
+    } finally {
+      vi.useRealTimers();
+      warn.mockRestore();
+    }
+  });
 });
 
 describe("runDiscoveryScan", () => {

--- a/worker/src/cron/discovery-scan.ts
+++ b/worker/src/cron/discovery-scan.ts
@@ -1,5 +1,4 @@
 import { CIRCUIT_SOURCE, D1_BATCH_SIZE, USER_AGENT } from "../lib/constants";
-import { batchExecute } from "../lib/db";
 import { DAY_SECONDS } from "@shared/lib/time-constants";
 import { cgUrl, cgHeaders } from "../lib/coingecko";
 import { fetchWithRetry } from "../lib/fetch-retry";
@@ -106,12 +105,27 @@ export async function upsertDiscoveryCandidates(
     }
   }
 
-  try {
-    return await batchExecute(db, stmts, D1_BATCH_SIZE);
-  } catch (err) {
-    console.warn("[discovery] Upsert batch failed:", err);
-    return 0;
+  let changes = 0;
+  for (let i = 0; i < stmts.length; i += D1_BATCH_SIZE) {
+    const chunk = stmts.slice(i, i + D1_BATCH_SIZE);
+    try {
+      const result = await db.batch(chunk);
+      for (const row of result) {
+        changes += Number(row?.meta?.changes ?? 0);
+      }
+    } catch (err) {
+      console.warn("[discovery] Upsert batch failed; retrying candidates individually:", err);
+      for (const stmt of chunk) {
+        try {
+          const result = await stmt.run();
+          changes += Number(result?.meta?.changes ?? 0);
+        } catch (candidateErr) {
+          console.warn("[discovery] Skipping discovery candidate after upsert failure:", candidateErr);
+        }
+      }
+    }
   }
+  return changes;
 }
 
 async function cleanupOldDismissed(db: D1Database): Promise<number> {


### PR DESCRIPTION
### Motivation
- A recent change switched discovery candidate upserts to a single batched `batchExecute`, which allowed one malformed statement to cause a chunk failure and abort remaining candidates, reducing data availability. 
- Because discovery candidates come from scheduled external ingestion (CoinGecko / DefiLlama residuals), a single bad row should not prevent other valid candidates from being persisted. 

### Description
- Keep batched execution for the happy path but process statements in chunked `db.batch(...)` and, on a chunk failure, retry that chunk one statement at a time via `stmt.run()` to preserve per-candidate isolation. 
- Add warning logs for the batch-failure fallback and for individual candidate skips so operators can investigate malformed external residuals. 
- Add a focused unit test covering the fallback path to ensure a single bad candidate no longer suppresses valid candidates in the same upsert call. 

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/discovery-scan.test.ts --reporter=dot` and observed all tests pass (`9 passed`).
- Ran TypeScript check with `cd worker && npx tsc --noEmit` which completed successfully. 
- The new test verifies that when one candidate causes a `NOT NULL` constraint error the other valid candidates are still upserted and the failure is logged as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e9aa8833288aed1be4fb8e3e5)