### PR TITLE
fix(worker): contain status stablecoins cache preload failures

### DIFF
--- a/worker/src/api/__tests__/status.test.ts
+++ b/worker/src/api/__tests__/status.test.ts
@@ -1469,6 +1469,37 @@ describe("handleStatus", () => {
     expect(body.datasetFreshness.discoveryCandidates).toBe(discoveryWriterAt);
   });
 
+  it("keeps status available when the shared stablecoins cache preload throws", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const db = mockD1([
+      {
+        match: "FROM cache WHERE key = ?",
+        matchBinds: [STATUS_RAW_SNAPSHOT_CACHE_KEY],
+        rows: [makeRawStatusSnapshotRow(now, 60)],
+      },
+      {
+        match: "FROM cache WHERE key = ?",
+        matchBinds: ["stablecoins"],
+        rows: [],
+        throwError: new Error("simulated stablecoins cache read failure"),
+      },
+      { match: "FROM discovery_candidates WHERE dismissed = 0", rows: [] },
+    ]);
+
+    const request = makeApiRequest("/api/status", { adminKey: "secret-key" });
+    const res = await handleStatus(db, true, request, "coingecko-key");
+    const body = (await res.json()) as {
+      sectionErrors: { coingeckoPriceDiff?: { code: string; message: string } };
+      coingeckoPriceDiff: unknown;
+      mintBurnReconciliation: unknown;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.coingeckoPriceDiff).toBeNull();
+    expect(body.mintBurnReconciliation).toBeNull();
+    expect(body.sectionErrors.coingeckoPriceDiff?.code).toBe("coingecko_price_diff_query_failed");
+  });
+
   it("marks data quality stale when the stablecoins cache is malformed", async () => {
     const db = mockD1([
       { match: "cache WHERE key IN", rows: [makeCacheRow("stablecoins")] },

--- a/worker/src/api/status-supplements.ts
+++ b/worker/src/api/status-supplements.ts
@@ -250,8 +250,21 @@ export async function loadStatusSupplements(
 
   // Load the large stablecoins cache blob once per request; loadCoinGeckoPriceDiff,
   // loadSourceDepthDistribution, and getMintBurnReconciliation all consume it, so a
-  // single read avoids three D1 round-trips for the same row (audit S-018).
-  const stablecoinsCache = await loadStablecoinsCache(db, { mode: "lenient", allowLegacyArray: true });
+  // single read avoids three D1 round-trips for the same row (audit S-018). Keep
+  // read/runtime failures contained so optional status supplements preserve the
+  // endpoint's partial-failure behavior.
+  let stablecoinsCache: StablecoinsCacheLoadResult;
+  try {
+    stablecoinsCache = await loadStablecoinsCache(db, { mode: "lenient", allowLegacyArray: true });
+  } catch (err) {
+    logStatusSupplementWarning(
+      "stablecoins_cache_preload_failed",
+      "Stablecoins cache preload failed",
+      err,
+      { source: "stablecoins-cache" },
+    );
+    stablecoinsCache = { kind: "error", reason: "cache-read-failed", updatedAt: null };
+  }
 
   let discoveryCandidates: DiscoveryCandidate[] | null = null;
   try {

--- a/worker/src/lib/stablecoins-cache.ts
+++ b/worker/src/lib/stablecoins-cache.ts
@@ -32,7 +32,8 @@ export type StablecoinsCacheFailureReason =
   | "legacy-array-not-allowed"
   | "legacy-array-payload"
   | "filtered-malformed-entries"
-  | "published-contract-invalid";
+  | "published-contract-invalid"
+  | "cache-read-failed";
 
 export interface StablecoinsCacheLoadOk {
   kind: "ok";


### PR DESCRIPTION
### Motivation

- The shared stablecoins cache was being preloaded at the top of `loadStatusSupplements` without local error containment, which caused a D1/read runtime exception to abort the whole admin `/api/status` response instead of degrading only the dependent subsections.
- The change restores the endpoint's intended partial-failure behavior so optional supplements can surface errors via `sectionErrors` rather than causing an internal 500.

### Description

- Wrap the shared preload call to `loadStablecoinsCache` in `loadStatusSupplements` with a `try/catch`, log a warning on thrown failures, and convert the exception into a structured `StablecoinsCacheLoadResult` error (`{ kind: "error", reason: "cache-read-failed", updatedAt: null }`).
- Add `"cache-read-failed"` to `StablecoinsCacheFailureReason` so thrown read/runtime failures are represented in the existing cache-load result shape.
- Add a regression test that simulates a thrown stablecoins cache read and verifies `/api/status` still returns HTTP 200 while the CoinGecko and mint/burn subsections degrade and emit `sectionErrors`.

### Testing

- Ran the focused status suite with `npx vitest run worker/src/api/__tests__/status.test.ts --reporter=verbose`, which passed (all tests in that file passed, including the new regression test).
- Ran the worker TypeScript check with `npm run typecheck:worker`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e6dd8833284d19c5f1f128021)