### PR TITLE
fix(admin): support idempotency keys without randomUUID

### DIFF
--- a/src/lib/__tests__/api-key-request-admin-view-model.test.ts
+++ b/src/lib/__tests__/api-key-request-admin-view-model.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApiKeyRequestIdempotencyKey } from "../api-key-request-admin-view-model";
+
+const originalCrypto = globalThis.crypto;
+
+function setCrypto(value: Crypto | undefined) {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("createApiKeyRequestIdempotencyKey", () => {
+  afterEach(() => {
+    setCrypto(originalCrypto);
+  });
+
+  it("uses crypto.randomUUID when available", () => {
+    setCrypto({
+      randomUUID: vi.fn(() => "uuid-from-runtime"),
+    } as unknown as Crypto);
+
+    expect(createApiKeyRequestIdempotencyKey("reject", "akr_demo")).toBe(
+      "api-key-request:reject:akr_demo:uuid-from-runtime",
+    );
+  });
+
+  it("falls back to getRandomValues for supported browsers without randomUUID", () => {
+    setCrypto({
+      getRandomValues: vi.fn((array: Uint8Array) => {
+        array.set([
+          0x00,
+          0x11,
+          0x22,
+          0x33,
+          0x44,
+          0x55,
+          0x66,
+          0x77,
+          0x88,
+          0x99,
+          0xaa,
+          0xbb,
+          0xcc,
+          0xdd,
+          0xee,
+          0xff,
+        ]);
+        return array;
+      }),
+    } as unknown as Crypto);
+
+    expect(createApiKeyRequestIdempotencyKey("release-claim", "akr_demo")).toBe(
+      "api-key-request:release-claim:akr_demo:00112233-4455-4677-8899-aabbccddeeff",
+    );
+  });
+
+  it("throws when Web Crypto is unavailable", () => {
+    setCrypto(undefined);
+
+    expect(() => createApiKeyRequestIdempotencyKey("reject", "akr_demo")).toThrow(
+      "Web Crypto is required to generate a collision-resistant idempotency key",
+    );
+  });
+});

--- a/src/lib/api-key-request-admin-view-model.ts
+++ b/src/lib/api-key-request-admin-view-model.ts
@@ -89,10 +89,20 @@ export function describeRequester(request: ApiKeySelfServeRequestAdminSummary): 
 }
 
 export function createApiKeyRequestIdempotencyKey(action: ApiKeyRequestAction, requestId: string): string {
-  if (typeof crypto === "undefined" || typeof crypto.randomUUID !== "function") {
-    throw new Error("crypto.randomUUID is required to generate a collision-resistant idempotency key");
+  const runtimeCrypto = globalThis.crypto;
+  if (typeof runtimeCrypto?.randomUUID === "function") {
+    return `api-key-request:${action}:${requestId}:${runtimeCrypto.randomUUID()}`;
   }
-  return `api-key-request:${action}:${requestId}:${crypto.randomUUID()}`;
+  if (typeof runtimeCrypto?.getRandomValues !== "function") {
+    throw new Error("Web Crypto is required to generate a collision-resistant idempotency key");
+  }
+
+  const bytes = runtimeCrypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  const uuid = `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+  return `api-key-request:${action}:${requestId}:${uuid}`;
 }
 
 function hasActiveUnexpiredLinkedKey(


### PR DESCRIPTION
### Motivation
- The admin idempotency-key helper previously threw when `crypto.randomUUID` was not available, preventing admin API-key mutation requests from being sent in supported browsers that lack `randomUUID` (notably some Firefox versions in the declared browserslist).
- Provide a compatibility-safe, collision-resistant fallback that preserves availability without reintroducing weak `Math.random`-based keys.

### Description
- Keep the existing `crypto.randomUUID()` path and add a Web Crypto `getRandomValues` UUIDv4 fallback implemented in `src/lib/api-key-request-admin-view-model.ts` to generate an `api-key-request:<action>:<requestId>:<uuid>` idempotency key when `randomUUID` is absent.
- The fallback uses `globalThis.crypto.getRandomValues(new Uint8Array(16))` and sets the UUID v4 variant/version bits to produce an RFC4122 v4-style UUID string.
- Add focused unit tests at `src/lib/__tests__/api-key-request-admin-view-model.test.ts` that exercise the `randomUUID` path, the `getRandomValues` fallback, and the error case when Web Crypto is unavailable.

### Testing
- Ran the new tests with `npx vitest run src/lib/__tests__/api-key-request-admin-view-model.test.ts` and all tests passed.
- Type checking with `npm run typecheck` succeeded.
- Lint check with `npx eslint src/lib/api-key-request-admin-view-model.ts src/lib/__tests__/api-key-request-admin-view-model.test.ts --max-warnings=0` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e41ec8332b6f40c5360566f11)