### PR TITLE
Fix DDRR scoring: require coarse terminal evidence interval to settle before recovery

### DIFF
--- a/shared/lib/depeg-resolver-review/__tests__/depeg-resolver-review.test.ts
+++ b/shared/lib/depeg-resolver-review/__tests__/depeg-resolver-review.test.ts
@@ -287,6 +287,26 @@ describe("DDRR v2 scoring", () => {
     expect(row.durationReview).toBe("duration_unscored");
   });
 
+  it("does not treat overlapping coarse terminal evidence as settled before recovery", () => {
+    const row = reviewDepegResolverAssessment(
+      assessment({ resolutionTier: "recovery_likely" }),
+      actualEvent({
+        endedAt: LOCKED_AT + 4_000,
+        recoveryPrice: 1,
+        terminalObserved: true,
+        terminalEvidenceAt: LOCKED_AT + 3_000,
+        terminalEvidenceInterval: { start: LOCKED_AT + 3_000, end: LOCKED_AT + 5_000 },
+        terminalEvidencePrecision: "day",
+      }),
+      REVIEWED_AT,
+    );
+
+    expect(row.actual.kind).toBe("recovered");
+    expect(row.verdictReview).toBe("correct_recoverable");
+    expect(row.durationReview).not.toBe("duration_unscored");
+    expect(row.actualRemainingSec).toBe(4_000);
+  });
+
   it("reviews horizons as hit, miss, pending, or unscored from lock-time horizons", () => {
     const hit = reviewDepegResolverAssessment(
       assessment({ horizonCells: [horizonCell("6h")] }),

--- a/shared/lib/depeg-resolver-review/outcomes.ts
+++ b/shared/lib/depeg-resolver-review/outcomes.ts
@@ -69,6 +69,16 @@ function terminalOutcome(input: {
   };
 }
 
+function isTerminalEvidenceSettledBy(
+  terminalEvidenceAt: number | null,
+  terminalEvidenceInterval: { start: number; end: number } | null,
+  endedAt: number,
+): boolean {
+  if (terminalEvidenceAt == null || terminalEvidenceAt > endedAt) return false;
+  if (terminalEvidenceInterval == null) return true;
+  return terminalEvidenceInterval.end <= endedAt;
+}
+
 export function getAssessmentReviewAnchorSec(assessment: DdrrAssessmentInput): number {
   return assessment.lockedAt ?? assessment.assessedAt;
 }
@@ -121,8 +131,7 @@ export function deriveActualOutcome(
     terminalObserved &&
     event.endedAt != null &&
     event.recoveryPrice != null &&
-    terminalEvidenceAt != null &&
-    terminalEvidenceAt <= event.endedAt
+    isTerminalEvidenceSettledBy(terminalEvidenceAt, terminalEvidenceInterval, event.endedAt)
   ) {
     return terminalOutcome({
       actualEndedAt: event.endedAt,


### PR DESCRIPTION
### Motivation
- Prevent recovered events from being misclassified as `terminal` when terminal evidence comes from coarse (day/month) source dates whose uncertainty interval only overlaps the recovery timestamp. 
- The prior change propagated interval-anchored `terminalEvidenceAt` unconditionally which allowed `terminalEvidenceAt <= endedAt` to score overlaps as terminal even when the evidence interval extended past the event end. 

### Description
- Add `isTerminalEvidenceSettledBy()` to require that coarse evidence with a `terminalEvidenceInterval` has `interval.end <= endedAt` before treating it as settled for terminal scoring. 
- Replace the simple `terminalEvidenceAt <= event.endedAt` check in `deriveActualOutcome()` with `isTerminalEvidenceSettledBy(...)` so exact evidence (no interval) keeps previous behavior while interval-backed evidence must fully settle. 
- Add a regression test in `shared/lib/depeg-resolver-review/__tests__/depeg-resolver-review.test.ts` that verifies overlapping day-precision evidence does not flip a recovered event to terminal. 

### Testing
- Ran the focused Vitest suites with `npx vitest run shared/lib/depeg-resolver-review/__tests__/depeg-resolver-review.test.ts worker/src/cron/__tests__/compute-depeg-resolver-review.test.ts` and all tests passed (`2 files, 48 tests` passed). 
- Ran the single-test invocation `npx vitest run shared/lib/depeg-resolver-review/__tests__/depeg-resolver-review.test.ts --testNamePattern "overlapping coarse terminal evidence|terminal evidence at or before"` and it passed (`2 tests` matched and passed). 
- Ran repository sanity checks `npm run check:worker-boundary` and `npm run check:shared-cycles` which both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051f51c08332ba5cab28048288b2)