### PR TITLE
fix(yield-health): reject non-object cache payloads

### DIFF
--- a/worker/src/lib/status/__tests__/yield-health.test.ts
+++ b/worker/src/lib/status/__tests__/yield-health.test.ts
@@ -495,6 +495,38 @@ describe("loadYieldHealthSummary", () => {
     });
   });
 
+  it("rejects fresh non-object ranking cache payloads as missing rankings", async () => {
+    for (const value of ["[]", "0", "true", JSON.stringify("text")]) {
+      const summary = await loadYieldHealthSummary(
+        makeDb([
+          {
+            key: "yield-rankings",
+            updated_at: NOW - 60,
+            value,
+          },
+          {
+            key: "yield:supplemental-sources:v1:morpho",
+            updated_at: NOW - 60,
+            value: "[]",
+          },
+          {
+            key: "yield-coverage-audit",
+            updated_at: NOW - 60,
+            value: "true",
+          },
+        ]),
+        NOW,
+        { "sync-yield-data": cron() },
+      );
+
+      expect(summary.rankingStatus).toBe("stale");
+      expect(summary.statusImpact).toBe("public-critical");
+      expect(summary.rankingCount).toBeNull();
+      expect(summary.supplemental.families?.morpho?.sourceCount).toBeNull();
+      expect(summary.coverageAudit.manifestMissingCount).toBeNull();
+    }
+  });
+
   it("keeps sparse non-ranking signals as admin watch and marks missing rankings public critical", async () => {
     const summary = await loadYieldHealthSummary(makeDb([]), NOW, { "sync-yield-data": cron("error") });
 

--- a/worker/src/lib/status/yield-health.ts
+++ b/worker/src/lib/status/yield-health.ts
@@ -61,6 +61,12 @@ interface CacheRow {
   updated_at: number | null;
 }
 
+function safeJsonObjectParse(json: string | null | undefined, context: string): Record<string, unknown> | null {
+  const parsed = safeJsonParse<unknown>(json, null, context);
+  return parsed != null && typeof parsed === "object" && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : null;
+}
 
 function ageSeconds(now: number, updatedAt: number | null | undefined): number | null {
   return typeof updatedAt === "number" && Number.isFinite(updatedAt)
@@ -524,9 +530,8 @@ function buildSupplementalHealth(
   const familyRows = SUPPLEMENTAL_SOURCE_FAMILY_KEYS.map((family) => {
     const row = byKey.get(getYieldSupplementalFamilyCacheKey(family)) ?? null;
     const ageSec = ageSeconds(now, row?.updated_at);
-    const payload = safeJsonParse<Record<string, unknown> | null>(
+    const payload = safeJsonObjectParse(
       row?.value ?? null,
-      null,
       `yield-health:supplemental:${family}`,
     );
     const sourceCount = getNumber(payload?.sourceCount);
@@ -613,9 +618,8 @@ export async function loadYieldHealthSummary(
   const byKey = new Map((rows.results ?? []).map((row) => [row.key, row]));
 
   const rankingsRow = byKey.get(YIELD_RANKINGS_CACHE_KEY) ?? null;
-  const rankingsPayload = safeJsonParse<Record<string, unknown> | null>(
+  const rankingsPayload = safeJsonObjectParse(
     rankingsRow?.value ?? null,
-    null,
     `yield-health:cache:${YIELD_RANKINGS_CACHE_KEY}`,
   );
   const rankingUpdatedAt = rankingsRow?.updated_at ?? getNumber(rankingsPayload?.updatedAt);
@@ -652,9 +656,8 @@ export async function loadYieldHealthSummary(
     : benchmarkStaleness;
 
   const coverageAuditUpdatedAt = byKey.get(YIELD_COVERAGE_AUDIT_CACHE_KEY)?.updated_at ?? null;
-  const coverageAuditPayload = safeJsonParse<Record<string, unknown> | null>(
+  const coverageAuditPayload = safeJsonObjectParse(
     byKey.get(YIELD_COVERAGE_AUDIT_CACHE_KEY)?.value ?? null,
-    null,
     `yield-health:cache:${YIELD_COVERAGE_AUDIT_CACHE_KEY}`,
   );
   const coverageAuditAgeSec = ageSeconds(now, coverageAuditUpdatedAt);


### PR DESCRIPTION
### Motivation
- Restore the previous object/non-array validation for persisted yield cache reads because the generic `safeJsonParse` accepts syntactically-valid arrays/primitives and caused fresh-but-invalid cache values to be treated as present payloads, misclassifying yield health.

### Description
- Add a small local guard `safeJsonObjectParse(json, context)` in `worker/src/lib/status/yield-health.ts` that returns a non-array object or `null` and uses `safeJsonParse` internally for syntax errors.
- Replace direct `safeJsonParse` usage with `safeJsonObjectParse` for yield rankings, supplemental family cache reads, and coverage-audit cache reads so arrays/primitives are treated as missing/malformed.
- Add a regression test in `worker/src/lib/status/__tests__/yield-health.test.ts` that asserts `[]`, `0`, `true`, and `"text"` ranking payloads (and matching supplemental/coverage-audit values) are rejected and cause the ranking path to be treated as missing/stale.

### Testing
- Ran the focused suite `npx vitest run worker/src/lib/status/__tests__/yield-health.test.ts` and the tests passed (`Test Files 1 passed`, `Tests 10 passed`).
- Ran TypeScript compile check `cd worker && npx tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e7de8833290c553b5d7b1b6d4)