### PR TITLE
Fix invalid lifecycle status fallback

### DIFF
--- a/shared/lib/stablecoins/__tests__/by-mechanism.test.ts
+++ b/shared/lib/stablecoins/__tests__/by-mechanism.test.ts
@@ -143,7 +143,16 @@ describe("getCoinsByLifecycleStatus", () => {
     expect(coins.length).toBeGreaterThan(0);
   });
 
+  it("returns frozen coins only for an explicit frozen status", () => {
+    const frozenCoins = getCoinsByLifecycleStatus("fiat-cash", "frozen");
+    const invalidCoins = getCoinsByLifecycleStatus(
+      "fiat-cash",
+      "dead" as "active" | "pre-launch" | "frozen",
+    );
 
+    expect(frozenCoins.length).toBeGreaterThan(0);
+    expect(invalidCoins).toEqual([]);
+  });
 });
 
 describe("nestVariants", () => {

--- a/shared/lib/stablecoins/by-mechanism.ts
+++ b/shared/lib/stablecoins/by-mechanism.ts
@@ -86,9 +86,11 @@ export function getCoinsByLifecycleStatus(
   } else if (status === "pre-launch") {
     pool = PRE_LAUNCH_STABLECOINS;
     registryForPool = PRE_LAUNCH_META_MAP;
-  } else {
+  } else if (status === "frozen") {
     pool = FROZEN_STABLECOINS;
     registryForPool = FROZEN_META_MAP;
+  } else {
+    return [];
   }
 
   return pool.filter(


### PR DESCRIPTION
### Motivation

- Restore correct runtime behaviour so that only an explicit `"frozen"` lifecycle status reads the frozen registry and unexpected status values return an empty array. 
- Prevent the prior regression where invalid runtime statuses such as `"dead"` would fall through to the frozen path despite the narrowed TypeScript union.

### Description

- Change control flow in `getCoinsByLifecycleStatus` (`shared/lib/stablecoins/by-mechanism.ts`) to use `else if (status === "frozen")` and return `[]` for any other unexpected status at runtime. 
- Add a regression test in `shared/lib/stablecoins/__tests__/by-mechanism.test.ts` asserting that an explicit `"frozen"` status returns frozen coins and a runtime `"dead"` value (cast to the union) yields an empty array. 
- Preserve the TypeScript signature (`"active" | "pre-launch" | "frozen"`) while tightening the runtime guard to match intended behaviour.

### Testing

- Ran unit tests: `npx vitest run shared/lib/stablecoins/__tests__/by-mechanism.test.ts` and the modified suite passed (all tests succeeded). 
- Ran typecheck: `npm run typecheck -- --pretty false` and it completed without errors. 
- Ran repository checks: `npm run check:worker-boundary` and `npm run check:shared-cycles`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051ead5c8332a559d580b37d4bc6)