### PR TITLE
Fix DDR assessment warning serialization

### DIFF
--- a/worker/src/lib/__tests__/depeg-resolver-assessment-store.test.ts
+++ b/worker/src/lib/__tests__/depeg-resolver-assessment-store.test.ts
@@ -65,7 +65,7 @@ const baseRow: DdrDiagnosticAssessmentRow = {
 } as DdrDiagnosticAssessmentRow;
 
 function snapshot(
-  rows: DdrDiagnosticAssessmentRow[],
+  rows: unknown[],
   overrides: Partial<DdrDiagnosticAssessmentSnapshot["_meta"]> = {},
 ): DdrDiagnosticAssessmentSnapshot {
   return {
@@ -143,6 +143,21 @@ describe("writeDepegResolverAssessments", () => {
       expect(changes).toBe(5);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toContain("Dropped 1/2 non-conforming assessment rows");
+    });
+
+    it("does not let unserializable dropped row samples abort valid writes", async () => {
+      const db = mockD1([{ match: "depeg_resolver_assessments", rows: [] }]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const malformedRow = { stablecoinId: "bad", symbol: "BAD", value: 1n };
+
+      const changes = await writeDepegResolverAssessments(db, snapshot([malformedRow, baseRow]));
+      const writes = db.getHistory().filter((entry) => entry.sql.includes("depeg_resolver_assessments"));
+
+      expect(changes).toBe(5);
+      expect(writes).toHaveLength(5);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("Dropped 1/2 non-conforming assessment rows");
+      expect(warnSpy.mock.calls[0][0]).toContain("[unserializable [object Object] keys=stablecoinId,symbol,value;");
     });
   });
 });

--- a/worker/src/lib/depeg-resolver-assessment-store.ts
+++ b/worker/src/lib/depeg-resolver-assessment-store.ts
@@ -139,6 +139,25 @@ function checkpointsForAge(ageSec: number): DdrAssessmentCheckpoint[] {
   return checkpoints;
 }
 
+function formatNonConformingAssessmentSample(row: unknown): string {
+  try {
+    return JSON.stringify(row);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    try {
+      if (row != null && typeof row === "object") {
+        const allKeys = Object.keys(row);
+        const keys = allKeys.slice(0, 10);
+        const suffix = allKeys.length > keys.length ? ",…" : "";
+        return `[unserializable ${Object.prototype.toString.call(row)} keys=${keys.join(",")}${suffix}; ${errorMessage}]`;
+      }
+    } catch {
+      // Fall through to the generic formatter when even object introspection is unsafe.
+    }
+    return `[unserializable ${typeof row}; ${errorMessage}]`;
+  }
+}
+
 function isDiagnosticAssessmentRow(row: unknown): row is DdrDiagnosticAssessmentRow {
   if (!row || typeof row !== "object") return false;
   const candidate = row as Partial<DdrDiagnosticAssessmentRow>;
@@ -291,7 +310,7 @@ export async function writeDepegResolverAssessments(
     const droppedCount = snapshot.rows.length - diagnosticRows.length;
     const sampleRow = snapshot.rows.find((row) => !isDiagnosticAssessmentRow(row));
     console.warn(
-      `[ddr-assessment-store] Dropped ${droppedCount}/${snapshot.rows.length} non-conforming assessment rows (failed isDiagnosticAssessmentRow); sample shape: ${JSON.stringify(sampleRow)}`,
+      `[ddr-assessment-store] Dropped ${droppedCount}/${snapshot.rows.length} non-conforming assessment rows (failed isDiagnosticAssessmentRow); sample shape: ${formatNonConformingAssessmentSample(sampleRow)}`,
     );
   }
   if (diagnosticRows.length === 0) return 0;


### PR DESCRIPTION
### Motivation
- A dropped-row warning in the DDR assessment writer interpolated `JSON.stringify(sampleRow)` where `snapshot.rows` is typed `unknown[]`, which can throw for values like `BigInt`, circular references, or objects with throwing `toJSON`, aborting the persistence path and preventing valid rows from being written.

### Description
- Add a safe formatter `formatNonConformingAssessmentSample(row: unknown)` that calls `JSON.stringify` but falls back to a compact, non-throwing summary (inspecting up to 10 keys) when serialization fails. 
- Use the safe formatter in the dropped-row warning instead of calling `JSON.stringify(sampleRow)` directly. 
- Broaden the test fixture snapshot to accept `unknown[]` and add a regression test that verifies a non-JSON-serializable dropped sample (contains a `BigInt`) does not abort persistence and still emits the expected warning.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/lib/__tests__/depeg-resolver-assessment-store.test.ts` and all tests passed. 
- Verified TypeScript build for the worker: `cd worker && npx tsc --noEmit` succeeded.
- The new regression test confirms that a dropped `BigInt` sample logs a safe summary and valid DDR assessment writes still occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051ec1648332b8e223df8fd958b0)