### PR TITLE
fix(tape): keep DEWS watermarks monotonic

### DIFF
--- a/worker/src/lib/tape-projectors/__tests__/dews.test.ts
+++ b/worker/src/lib/tape-projectors/__tests__/dews.test.ts
@@ -232,6 +232,42 @@ describe("dews projector", () => {
     expect(deescalated[0]![2]).toBe("info");
   });
 
+  it("single-pass projector preserves already-advanced divergent watermarks", async () => {
+    const db = mockD1([
+      {
+        match: "FROM cache WHERE key",
+        rows: [
+          { key: "tape-projector:cursor:dews.escalated", value: String(SEC + 900) },
+          { key: "tape-projector:cursor:dews.deescalated", value: String(SEC) },
+        ],
+      },
+      {
+        match: MATCH_FETCH_SAMPLES,
+        rows: [
+          {
+            stablecoin_id: "usdt-tether",
+            computed_at: SEC + 100,
+            score: 50,
+            band: "ALERT",
+          },
+        ],
+      },
+      { match: MATCH_PRIOR_BAND, rows: [] },
+    ]) as MockD1Database;
+
+    const result = await projectDewsBandTransitions(db);
+
+    expect(result.advanced).toBe(SEC + 100);
+    const watermarkWrites = db
+      .getHistory()
+      .filter((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"))
+      .map((entry) => entry.binds);
+    expect(watermarkWrites).toEqual([
+      ["tape-projector:cursor:dews.escalated", String(SEC + 900), expect.any(Number)],
+      ["tape-projector:cursor:dews.deescalated", String(SEC + 100), expect.any(Number)],
+    ]);
+  });
+
   it("single-pass projector emits nothing for an empty batch", async () => {
     const db = mockD1(baseTables([])) as MockD1Database;
     const result = await projectDewsBandTransitions(db);

--- a/worker/src/lib/tape-projectors/dews.ts
+++ b/worker/src/lib/tape-projectors/dews.ts
@@ -257,7 +257,8 @@ export function projectDewsDeescalated(
  * otherwise re-fetch the same snapshot window and prior-band lookups).
  *
  * Both per-variant cursors (`dews.escalated` / `dews.deescalated`) are advanced
- * together so persisted watermarks stay valid and the single-variant exports
+ * monotonically so persisted watermarks stay valid even if one cursor was
+ * already ahead while the older cursor catches up. The single-variant exports
  * (used by the backfill admin endpoint and tests) remain interchangeable.
  */
 export async function projectDewsBandTransitions(
@@ -294,8 +295,8 @@ export async function projectDewsBandTransitions(
   if (!dryRun) {
     if (events.length > 0) await insertTapeEvents(db, events);
     if (options?.since == null && options?.until == null) {
-      await setProjectorWatermark(db, "dews.escalated", maxCursor);
-      await setProjectorWatermark(db, "dews.deescalated", maxCursor);
+      await setProjectorWatermark(db, "dews.escalated", Math.max(escWatermark, maxCursor));
+      await setProjectorWatermark(db, "dews.deescalated", Math.max(deescWatermark, maxCursor));
     }
   }
   return { projected: events.length, advanced: dryRun ? null : maxCursor };


### PR DESCRIPTION
### Motivation
- The combined DEWS single-pass projector seeded scans from the older of two persisted cursors but then wrote the batch `maxCursor` to both `dews.escalated` and `dews.deescalated`, which could rewind an already-advanced cursor and force duplicate backfills.

### Description
- Preserve each per-variant watermark by writing `Math.max(existingWatermark, batchMaxCursor)` for `dews.escalated` and `dews.deescalated` so cursor updates are monotonic (`worker/src/lib/tape-projectors/dews.ts`).
- Clarify the projector comment to document the monotonic cursor behavior (`worker/src/lib/tape-projectors/dews.ts`).
- Add a regression unit test that seeds divergent watermarks and verifies the advanced cursor is preserved while the lagging cursor advances (`worker/src/lib/tape-projectors/__tests__/dews.test.ts`).

### Testing
- Ran the DEWS projector unit suite with `npx vitest run worker/src/lib/tape-projectors/__tests__/dews.test.ts` and all tests passed (10 passed, 0 failed).
- Type-checked the worker with `cd worker && npx tsc --noEmit` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e7ac4833285227067a59534bf)