### PR TITLE
fix(og): anchor 24h price delta to latest snapshot

### DIFF
--- a/worker/src/api/__tests__/og.test.tsx
+++ b/worker/src/api/__tests__/og.test.tsx
@@ -154,6 +154,39 @@ describe("stablecoin OG card data", () => {
       const data = await renderedCardData(db, "/api/og/stablecoin/usdt-tether");
       expect(data.pegScore).toBe(99);
     });
+
+    it("anchors 24h price change to the latest snapshot instead of wall-clock time", async () => {
+      const db = mockD1([
+        {
+          match: "cache",
+          rows: [
+            {
+              key: "stablecoins",
+              value: JSON.stringify({ peggedAssets: [makeAsset({ id: "usdt-tether", symbol: "USDT" })] }),
+              updated_at: nowSec,
+            },
+            {
+              key: "peg-analytics",
+              value: JSON.stringify({ computedAtSec: nowSec, pegData: [{ id: "usdt-tether", pegScore: 99 }] }),
+              updated_at: nowSec,
+            },
+          ],
+        },
+        { match: "dex_liquidity", rows: [] },
+        { match: "stress_signals", rows: [] },
+        { match: "current_snapshot", rows: [], first: { current_price: 1.02, prev_day_price: 0.99 } },
+        { match: "supply_history", rows: [{ price: 1.02 }, { price: 0.99 }] },
+        { match: "depeg_events", rows: [] },
+        { match: "mint_burn_hourly", rows: [] },
+      ]);
+
+      const data = await renderedCardData(db, "/api/og/stablecoin/usdt-tether");
+
+      expect(data.change24h).toBeCloseTo(3.0303, 4);
+      const priceQuery = db.getHistory().find((entry) => entry.sql.includes("current_snapshot"));
+      expect(priceQuery?.binds).toEqual(["usdt-tether", "usdt-tether", 86_400]);
+      expect(priceQuery?.sql).toContain("snapshot_date <= current_snapshot.snapshot_date - ?");
+    });
   });
 
   it("renders variant context when provided", () => {

--- a/worker/src/api/og.tsx
+++ b/worker/src/api/og.tsx
@@ -235,12 +235,28 @@ async function handleStablecoinOg(db: D1Database, coinId: string): Promise<Respo
       .first<{ net_flow: number | null }>(),
     db
       .prepare(
-        `SELECT
-          (SELECT price FROM supply_history WHERE stablecoin_id = ? AND price IS NOT NULL ORDER BY snapshot_date DESC LIMIT 1) as current_price,
-          (SELECT price FROM supply_history WHERE stablecoin_id = ? AND price IS NOT NULL AND snapshot_date <= ? ORDER BY snapshot_date DESC LIMIT 1) as prev_day_price`,
+        `WITH current_snapshot AS (
+          SELECT price, snapshot_date
+          FROM supply_history
+          WHERE stablecoin_id = ? AND price IS NOT NULL
+          ORDER BY snapshot_date DESC
+          LIMIT 1
+        )
+        SELECT
+          current_snapshot.price as current_price,
+          (
+            SELECT price
+            FROM supply_history
+            WHERE stablecoin_id = ?
+              AND price IS NOT NULL
+              AND snapshot_date <= current_snapshot.snapshot_date - ?
+            ORDER BY snapshot_date DESC
+            LIMIT 1
+          ) as prev_day_price
+        FROM current_snapshot`,
       )
-      .bind(id, id, Math.floor(Date.now() / 1000) - DAY_SECONDS)
-      .first<{ current_price: number; prev_day_price: number }>(),
+      .bind(id, id, DAY_SECONDS)
+      .first<{ current_price: number; prev_day_price: number | null }>(),
   ]);
 
   if (!hasUsableStablecoinsPayload(stablecoinsPayload)) {


### PR DESCRIPTION
### Motivation

- The OG stablecoin 24h price-change query could select the same `supply_history` row for both "current" and "previous" when the latest daily snapshot is older than 24 wall-clock hours, yielding a misleading `0%` change.
- The intent is to compute a true ~24h delta anchored to the latest available snapshot, not to wall-clock now, so the previous observation must be chosen relative to the current snapshot timestamp.

### Description

- Replace the two independent subqueries in `worker/src/api/og.tsx` with a CTE `current_snapshot` that selects the latest `supply_history` row and then compute `prev_day_price` using `snapshot_date <= current_snapshot.snapshot_date - ?` so the cutoff is relative to the chosen current snapshot.
- Bind the cutoff as `DAY_SECONDS` (instead of a wall-clock timestamp) and make `prev_day_price` nullable in the query result type to reflect missing prior snapshots.
- Add a focused regression test in `worker/src/api/__tests__/og.test.tsx` that verifies the rendered `change24h` uses distinct snapshot prices and asserts the query contains the `snapshot_date <= current_snapshot.snapshot_date - ?` predicate and the expected binds.

### Testing

- Ran the worker typecheck with `npm run typecheck:worker`, which completed successfully.
- Added and attempted to run the focused test with `npx vitest run worker/src/api/__tests__/og.test.tsx`, but the test run was blocked before execution by a local environment mismatch: `react` (`19.2.7`) and `react-dom` (`19.2.6`) versions differ, causing the test process to fail; the new test is present and will run once the environment mismatch is resolved.
- The change is limited to `worker/src/api/og.tsx` and its OG handler test and preserves existing behavior while correcting the 24h-anchor correctness issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e62e08332b014f3198a18871b)