### PR TITLE
fix(worker): fail daily digest on Telegram marker write errors

### DIFF
--- a/worker/src/cron/__tests__/daily-digest.test.ts
+++ b/worker/src/cron/__tests__/daily-digest.test.ts
@@ -1020,6 +1020,28 @@ describe("generateDailyDigest", () => {
     expect(markerDeletes).toHaveLength(0);
   });
 
+  it("fails the cron run when the Telegram sent marker cannot be written before delivery", async () => {
+    const db = mockD1([
+      ...makeBaseTables(),
+      {
+        match: "INSERT OR REPLACE INTO cache",
+        rows: [],
+        throwError: new Error("D1 marker write failed"),
+      },
+    ]);
+
+    await expect(generateDailyDigest(
+      db,
+      "anthropic-key",
+      null,
+      false,
+      { botToken: "tg-token", chatId: "tg-chat" },
+    )).rejects.toThrow("Telegram digest marker write failed; delivery skipped");
+
+    expect(postDigestToTelegram).not.toHaveBeenCalled();
+    expect(getInsertDigestBinds(db as MockD1Database)).toBeDefined();
+  });
+
   it("rolls back the Telegram sent marker when delivery fails so the next run can resend", async () => {
     vi.mocked(postDigestToTelegram).mockRejectedValueOnce(new Error("telegram down"));
 

--- a/worker/src/cron/daily-digest.ts
+++ b/worker/src/cron/daily-digest.ts
@@ -285,14 +285,19 @@ export async function generateDailyDigest(
       if (!sentMarker) {
         // Write the idempotency marker BEFORE sending so a marker-write
         // failure leaves the send unattempted (and surfaces as a hard cron
-        // failure via the channel-delivery wrapper) rather than risking a
-        // duplicate send on the next run. If the send itself fails, roll the
+        // failure after the channel wrapper records the failed attempt)
+        // rather than risking a duplicate send on the next run. If the send itself fails, roll the
         // marker back so a genuine delivery failure can be retried.
-        await setCache(
-          db,
-          markerKey,
-          JSON.stringify({ sentAt: now, editionNumber }),
-        );
+        try {
+          await setCache(
+            db,
+            markerKey,
+            JSON.stringify({ sentAt: now, editionNumber }),
+          );
+        } catch (err) {
+          degradedReasons.push("telegram-send-marker-write");
+          throw err;
+        }
         try {
           await postDigestToTelegram(
             digestCopy.digestTitle,
@@ -330,6 +335,10 @@ export async function generateDailyDigest(
       return `ok${appendixSuffix}`;
     },
   });
+
+  if (degradedReasons.includes("telegram-send-marker-write")) {
+    throw new Error(`Telegram digest marker write failed; delivery skipped: ${telegramStatus}`);
+  }
 
   const qualityMetadata = formatQualityMetadata(digestCopy.qualityIssues);
 


### PR DESCRIPTION
### Motivation
- The daily digest flow writes a Telegram idempotency marker before sending to avoid duplicate posts, but a marker-write failure could skip delivery while the channel wrapper returned a non-throwing `failed:` status, leaving the cron run recorded as OK.
- The intent is to ensure a marker-write failure is treated as a hard cron failure so skipped delivery is visible and the run is not reported as successful.

### Description
- In `worker/src/cron/daily-digest.ts` wrap the `setCache` marker write in a `try/catch`, push a `telegram-send-marker-write` degradation marker, and rethrow the error to surface the failure immediately.
- After `runDigestChannelDelivery` returns, escalate marker-write failures by checking for `telegram-send-marker-write` in `degradedReasons` and throwing an error to ensure the cron run fails instead of being logged OK.
- Add a regression test in `worker/src/cron/__tests__/daily-digest.test.ts` that injects a D1 `INSERT OR REPLACE INTO cache` write failure, asserts that `generateDailyDigest` rejects with the expected message, confirms `postDigestToTelegram` was not called, and verifies digest persistence still occurred before the hard failure.

### Testing
- Ran the targeted test file with `npx vitest run worker/src/cron/__tests__/daily-digest.test.ts` and all tests passed (`72 passed`).
- Ran TypeScript check with `cd worker && npx tsc --noEmit` and the compile succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051f7c78833294ecbdda1273ef40)