### PR TITLE
fix(worker): preserve partial DEWS latest fallback

### DIFF
--- a/worker/src/cron/__tests__/dispatch-telegram-state.test.ts
+++ b/worker/src/cron/__tests__/dispatch-telegram-state.test.ts
@@ -70,13 +70,20 @@ describe("loadDewsRows", () => {
     )).toBe(true);
   });
 
-  it("skips the legacy stress_signals query when latest rows are fresh", async () => {
+  it("preserves legacy-only rows when latest rows are fresh but partial", async () => {
     const latestRow = {
       stablecoin_id: "usdc-circle",
       score: 8,
       band: "CALM",
       signals_json: signalsJson,
       computed_at: completedDewsAt,
+    };
+    const legacyOnlyRow = {
+      stablecoin_id: "usdt-tether",
+      score: 13,
+      band: "WATCH",
+      signals_json: signalsJson,
+      computed_at: completedDewsAt - 30,
     };
     const db = mockD1([
       {
@@ -90,14 +97,19 @@ describe("loadDewsRows", () => {
         matchBinds: [completedDewsAt],
         rows: [latestRow],
       },
+      {
+        match: "pharos:telegram-dispatch:dews-legacy",
+        matchBinds: [completedDewsAt],
+        rows: [legacyOnlyRow],
+      },
     ]);
 
     const rows = await loadDewsRows(db, nowSec);
 
-    expect(rows).toEqual([latestRow]);
+    expect(rows).toEqual([legacyOnlyRow, latestRow]);
     const history = db.getHistory();
     expect(history.some((entry) =>
       entry.sql.includes("pharos:telegram-dispatch:dews-legacy")
-    )).toBe(false);
+    )).toBe(true);
   });
 });

--- a/worker/src/cron/dispatch-telegram-state.ts
+++ b/worker/src/cron/dispatch-telegram-state.ts
@@ -93,14 +93,9 @@ export async function loadDewsRows(db: D1Database, nowSec: number): Promise<Dews
     latestRows = [];
   }
 
-  // stress_signals_latest is the current primary source and is upserted as a
-  // complete snapshot each DEWS run. When it is present and fresh it already
-  // covers every current coin, so skip the legacy stress_signals query (and its
-  // correlated MAX(computed_at) sub-query) entirely rather than always paying
-  // for a redundant round-trip on every 5-minute dispatch.
-  if (latestRows.length > 0 && !areDewsLatestRowsStale(latestRows, nowSec)) {
-    return latestRows;
-  }
+  // Fallback keeps stale-materialization and partial latest-table deployments
+  // safe. stress_signals_latest is an optimization over the canonical history
+  // table, so Telegram dispatch merges both and keeps the newest row per coin.
 
   const legacyStmt = db.prepare(
     completedAt == null


### PR DESCRIPTION
### Motivation
- A recent change short-circuited `loadDewsRows` when `stress_signals_latest` returned any fresh row, which can drop legacy-only stablecoins during partial latest-table materializations. This breaks Telegram DEWS dispatch correctness during rollouts or partial writes.\

### Description
- Remove the early-return that skipped the canonical `stress_signals` query in `loadDewsRows` so the legacy fallback is always consulted.\
- Keep the merge logic that returns legacy rows when `stress_signals_latest` is stale and otherwise merges newest-per-coin rows via `mergeNewestDewsRows`.\
- Update the inline comment in `worker/src/cron/dispatch-telegram-state.ts` to document that `stress_signals_latest` is an optimization and that readers merge with the canonical history for safety.\
- Add/replace a focused regression test in `worker/src/cron/__tests__/dispatch-telegram-state.test.ts` that models a fresh but partial `stress_signals_latest` and asserts the legacy-only row is preserved and the legacy query is executed.\

### Testing
- Ran the focused unit test: `npx vitest run worker/src/cron/__tests__/dispatch-telegram-state.test.ts`, which passed.\
- Type-check: `cd worker && npx tsc --noEmit` completed without errors.\
- Cron connection budget check: `npm run check:cron-connections` completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051e0f7c83328db9e0fa49b02ade)