### PR TITLE
fix(yield): guard data-source metadata lookups

### DIFF
--- a/src/app/yield/source-board-model.test.ts
+++ b/src/app/yield/source-board-model.test.ts
@@ -164,6 +164,30 @@ describe("buildYieldSourceBoardModel", () => {
     expect(model.benchmarkLabels).toEqual([{ label: "USD 3M T-Bill", count: 1 }]);
   });
 
+  it("formats prototype-property dataSource values as unknown labels", () => {
+    const model = buildYieldSourceBoardModel([
+      makeYieldRanking({
+        id: "unknown-source-row",
+        dataSource: "unknown-source",
+        yieldSource: "Unknown Source",
+        apy30d: 5,
+        provenance: null,
+      }),
+      makeYieldRanking({
+        id: "constructor-source-row",
+        dataSource: "constructor",
+        yieldSource: "Constructor Source",
+        apy30d: 6,
+        provenance: null,
+      }),
+    ]);
+
+    expect(model.groups.map((group) => group.dataSourceLabel)).toEqual([
+      "Constructor",
+      "Unknown Source",
+    ]);
+  });
+
   it("infers lane confidence tier from known dataSource values and returns null for unknown", () => {
     expect(inferLaneConfidenceTier("onchain")).toBe("deterministic");
     expect(inferLaneConfidenceTier("rate-derived")).toBe("deterministic");

--- a/src/lib/yield-data-source.ts
+++ b/src/lib/yield-data-source.ts
@@ -35,12 +35,18 @@ export const YIELD_DATA_SOURCE_META: Record<string, YieldDataSourceMeta> = {
   },
 };
 
+function getKnownYieldDataSourceMeta(dataSource: string): YieldDataSourceMeta | null {
+  return Object.prototype.hasOwnProperty.call(YIELD_DATA_SOURCE_META, dataSource)
+    ? YIELD_DATA_SOURCE_META[dataSource]
+    : null;
+}
+
 export function getYieldDataSourceMeta(dataSource: string): YieldDataSourceMeta {
-  return YIELD_DATA_SOURCE_META[dataSource] ?? YIELD_DATA_SOURCE_META.defillama;
+  return getKnownYieldDataSourceMeta(dataSource) ?? YIELD_DATA_SOURCE_META.defillama;
 }
 
 export function getYieldDataSourceLabel(dataSource: string): string {
-  const known = YIELD_DATA_SOURCE_META[dataSource];
+  const known = getKnownYieldDataSourceMeta(dataSource);
   if (known) return known.label;
   return (
     dataSource


### PR DESCRIPTION
### Motivation
- Prevent prototype-property strings like `constructor`, `toString`, or `__proto__` from being treated as valid entries in the shared yield data-source metadata table which could produce undefined labels and crash client-side sorting. 
- Preserve existing user-facing labels and badge fallbacks while making the metadata lookup robust against untrusted or malformed `dataSource` values. 

### Description
- Add a helper `getKnownYieldDataSourceMeta(dataSource: string): YieldDataSourceMeta | null` that uses `Object.prototype.hasOwnProperty.call(...)` to ensure only own properties on `YIELD_DATA_SOURCE_META` are returned. (file: `src/lib/yield-data-source.ts`).
- Update `getYieldDataSourceMeta` to use the new helper and preserve the existing fallback to `YIELD_DATA_SOURCE_META.defillama` for unknown keys. (file: `src/lib/yield-data-source.ts`).
- Update `getYieldDataSourceLabel` to use the helper so prototype keys fall through to the formatted label fallback instead of returning an inherited non-string value. (file: `src/lib/yield-data-source.ts`).
- Add a regression test that builds the source-board model with a `constructor` `dataSource` and an unknown `dataSource` to assert both produce string labels and remain sortable. (file: `src/app/yield/source-board-model.test.ts`).

### Testing
- Ran the focused Vitest suite with `npx vitest run src/app/yield/source-board-model.test.ts`, and the tests passed (`1 file, 6 tests` passed). 
- Ran static type checking with `npm run typecheck` (`tsc --noEmit`), and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051edb3c8332a95016766fef2b6c)