### PR TITLE
Fix SEO live-smoke symlink entrypoint

### DIFF
--- a/scripts/__tests__/check-seo-live-smoke.test.ts
+++ b/scripts/__tests__/check-seo-live-smoke.test.ts
@@ -1,5 +1,9 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { checkSitemapUrls } from "../ci/check-seo-live-smoke.mjs";
+import { checkSitemapUrls, isMainEntrypoint } from "../ci/check-seo-live-smoke.mjs";
 
 function responseWithBody(status: number, contentType = "text/plain") {
   const cancel = vi.fn(async () => {});
@@ -47,5 +51,21 @@ describe("check-seo-live-smoke sitemap URL checks", () => {
       "https://pharos.watch/not-found/: sitemap URL returns 404",
       "https://pharos.watch/error/: sitemap URL returns 503",
     ]);
+  });
+});
+
+describe("check-seo-live-smoke entrypoint guard", () => {
+  it("matches symlinked invocation paths against the real module URL", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pharos-seo-smoke-"));
+    const realScript = join(tempDir, "check-seo-live-smoke.mjs");
+    const symlinkedScript = join(tempDir, "check-seo-live-smoke-link.mjs");
+    writeFileSync(realScript, "export {};\n");
+    symlinkSync(realScript, symlinkedScript);
+
+    try {
+      expect(isMainEntrypoint(pathToFileURL(realScript).href, symlinkedScript)).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/ci/check-seo-live-smoke.mjs
+++ b/scripts/ci/check-seo-live-smoke.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { parseSitemapLocs } from "../lib/seo-sitemap.mjs";
 import { parseCliOptions, parseNonNegativeInt, readEnvFirst } from "../lib/smoke-runtime.mjs";
@@ -253,7 +254,11 @@ async function main() {
   console.log(`OK: SEO live smoke passed for ${baseUrl.toString()} (${sitemapLabel})`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+export function isMainEntrypoint(importMetaUrl, argvPath = process.argv[1]) {
+  return Boolean(argvPath) && importMetaUrl === pathToFileURL(realpathSync(argvPath)).href;
+}
+
+if (isMainEntrypoint(import.meta.url)) {
   main().catch((error) => {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
### Motivation
- The entrypoint guard in `scripts/ci/check-seo-live-smoke.mjs` compared `import.meta.url` to `pathToFileURL(process.argv[1]).href`, which can fail when the script is invoked via a symlink and cause the smoke checks to be skipped.
- The change ensures symlinked invocations still run `main()` by resolving the real filesystem path before comparing to `import.meta.url`.

### Description
- Import `realpathSync` and add `export function isMainEntrypoint(importMetaUrl, argvPath = process.argv[1])` which resolves `argvPath` via `realpathSync()` and compares the resulting `pathToFileURL(...).href` to `import.meta.url`.
- Replace the previous direct `import.meta.url === pathToFileURL(process.argv[1]).href` guard with `if (isMainEntrypoint(import.meta.url)) { ... }` so symlinked invocation paths run `main()`.
- Add a focused Vitest unit test in `scripts/__tests__/check-seo-live-smoke.test.ts` that creates a real file and a symlink and asserts `isMainEntrypoint()` matches the real module URL, and cleanly removes temporary files.

### Testing
- Ran the unit tests with `npx vitest run scripts/__tests__/check-seo-live-smoke.test.ts` and the suite passed.
- Linted the touched files with `npx eslint scripts/ci/check-seo-live-smoke.mjs scripts/__tests__/check-seo-live-smoke.test.ts --max-warnings=0` and the lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3403d029288332b21526e794ab0891)