### PR TITLE
Harden DOLA reserve asset tracking

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts
@@ -167,6 +167,32 @@ describe("adaptFirmMarkets", () => {
     expect(riskByPrefix["BTC"]).toBe("medium");
     expect(riskByPrefix["Governance tokens"]).toBe("very-high");
   });
+
+  it("treats prototype-key symbols as unknown collateral instead of tracked stablecoins", () => {
+    const result = adaptFirmMarkets({
+      markets: [
+        makeMarket("toString", 1_000_000),
+        makeMarket("sUSDe", 1_000_000),
+      ],
+      timestamp: 1000,
+    });
+
+    expect(result.slices).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: "sUSDe collateral",
+        pct: 50,
+        risk: "high",
+        coinId: "susde-ethena",
+      }),
+      expect.objectContaining({
+        name: "Other collateral",
+        pct: 50,
+        risk: "high",
+      }),
+    ]));
+    expect(result.slices.find((slice) => slice.name === "toString collateral")).toBeUndefined();
+    expect(validateAdapterOutput(result, { adapter: getReserveAdapter("dola-inverse") ?? undefined }).valid).toBe(true);
+  });
 });
 
 describe("listUnexpectedDolaAssets", () => {

--- a/worker/src/cron/reserve-adapters/dola-inverse.ts
+++ b/worker/src/cron/reserve-adapters/dola-inverse.ts
@@ -43,6 +43,11 @@ const TRACKED_STABLECOIN_ASSETS: Partial<Record<string, { coinId: string; risk: 
   USR: { coinId: "usr-resolv", risk: "high" },
 };
 
+function getTrackedStablecoinAsset(symbol: string): { coinId: string; risk: ReserveSlice["risk"] } | undefined {
+  if (!Object.prototype.hasOwnProperty.call(TRACKED_STABLECOIN_ASSETS, symbol)) return undefined;
+  return TRACKED_STABLECOIN_ASSETS[symbol];
+}
+
 const KNOWN_ASSETS = new Set([...STABLECOIN_ASSETS, ...ETH_LST_ASSETS, ...BTC_ASSETS, ...GOVERNANCE_ASSETS]);
 
 export function bucketForAsset(symbol: string): DolaBucket {
@@ -86,7 +91,7 @@ export function adaptFirmMarkets(payload: FirmMarketsResponse): AdapterResult {
     getValue: (market) => market.totalDebt,
     getBucket: (market) => {
       const symbol = resolveBaseSymbol(market);
-      if (TRACKED_STABLECOIN_ASSETS[symbol]) return "stablecoin";
+      if (getTrackedStablecoinAsset(symbol)) return "stablecoin";
       return bucketForAsset(symbol);
     },
     isUnknown: (market) => !KNOWN_ASSETS.has(resolveBaseSymbol(market)),
@@ -96,14 +101,14 @@ export function adaptFirmMarkets(payload: FirmMarketsResponse): AdapterResult {
     const value = market.totalDebt;
     if (!Number.isFinite(value) || value <= 0) continue;
     const symbol = resolveBaseSymbol(market);
-    if (!TRACKED_STABLECOIN_ASSETS[symbol]) continue;
+    if (!getTrackedStablecoinAsset(symbol)) continue;
     trackedStableValues.set(symbol, (trackedStableValues.get(symbol) ?? 0) + value);
   }
   const trackedStableTotal = Array.from(trackedStableValues.values()).reduce((sum, value) => sum + value, 0);
 
   const slices = slicesFromValues([
     ...Array.from(trackedStableValues, ([symbol, value]) => {
-      const config = TRACKED_STABLECOIN_ASSETS[symbol]!;
+      const config = getTrackedStablecoinAsset(symbol)!;
       return {
         name: `${symbol} collateral`,
         value,


### PR DESCRIPTION
### Motivation

- The DOLA FiRM adapter previously used plain-object bracket lookups on upstream-provided symbols, which allowed inherited prototype keys (e.g. `toString`, `__proto__`) to be treated as tracked stablecoins and produce slices with undefined `risk`, causing live reserve validation failures. 
- The change prevents an untrusted provider response from causing adapter output to fail validation by requiring an own-property check for tracked-symbol membership.

### Description

- Add `getTrackedStablecoinAsset(symbol)` that uses `Object.prototype.hasOwnProperty.call(...)` to verify membership and return the tracked config only for own properties. 
- Replace direct `TRACKED_STABLECOIN_ASSETS[...]` membership checks and config reads in `adaptFirmMarkets` with `getTrackedStablecoinAsset(...)` to guard both bucket attribution and tracked-slice creation. 
- Add a regression test in `worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts` that ensures prototype-key symbols are treated as ordinary `Other collateral` and do not produce invalid tracked slices. 
- Modified files: `worker/src/cron/reserve-adapters/dola-inverse.ts`, `worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts`.

### Testing

- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/dola-inverse.test.ts` and the suite passed (`1` test file, `22` tests passed). 
- Ran `cd worker && npx tsc --noEmit` to ensure TypeScript builds and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350febd508833297504b1affc716c9)