### PR TITLE
Fix FX fallback resilience for malformed secondary mirrors

### DIFF
--- a/worker/src/cron/__tests__/sync-fx-rates.test.ts
+++ b/worker/src/cron/__tests__/sync-fx-rates.test.ts
@@ -501,6 +501,10 @@ describe("syncFxRates", () => {
         status: 503,
       },
       {
+        match: "@2025.6.15/",
+        body: "definitely not json",
+      },
+      {
         match: "cdn.jsdelivr.net/npm/@fawazahmed0/currency-api",
         body: { error: "Service unavailable" },
         status: 503,
@@ -1760,6 +1764,34 @@ describe("syncFxRates", () => {
     expect(candidate?.payload.date).toBe("2026-05-20");
     expect(candidate?.payload.usd.cnh).toBe(7.18);
     expect(fetchSpy.mock.calls.some(([url]) => String(url).includes("@2026.5.20/"))).toBe(true);
+  });
+
+  it("ignores malformed optional date-pinned secondary FX payloads when other mirrors are healthy", async () => {
+    vi.setSystemTime(new Date("2026-05-20T07:30:00Z"));
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url.includes("@2026.5.20/")) {
+        return new Response("definitely not json", { status: 200 });
+      }
+      if (url.includes("cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest")) {
+        return new Response(
+          JSON.stringify({ date: "2026-05-19", usd: { cnh: 7.28 } }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("latest.currency-api.pages.dev")) {
+        return new Response(
+          JSON.stringify({ date: "2026-05-18", usd: { cnh: 7.29 } }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }));
+
+    const candidate = await loadSecondaryCurrencyCandidate();
+
+    expect(candidate?.endpoint).toBe("jsdelivr");
+    expect(candidate?.payload.date).toBe("2026-05-19");
+    expect(candidate?.payload.usd.cnh).toBe(7.28);
   });
 
   it("returns cooldown_active and skips all outbound fetches when last-write marker is <30 min old", async () => {

--- a/worker/src/cron/sync-fx-rates-sources.ts
+++ b/worker/src/cron/sync-fx-rates-sources.ts
@@ -68,21 +68,26 @@ async function fetchSecondaryCurrencyCandidate(
     return null;
   }
 
-  const payload = await res.json();
-  const validation = validatePayloadWithSchema(
-    SecondaryCurrencyResponseSchema,
-    payload,
-    `sync-fx-rates:secondary:${endpoint}`,
-  );
-  if (!validation.ok) {
-    console.warn(`[sync-fx-rates] Secondary FX payload invalid (${endpoint}): ${validation.issues}`);
+  try {
+    const payload = await res.json();
+    const validation = validatePayloadWithSchema(
+      SecondaryCurrencyResponseSchema,
+      payload,
+      `sync-fx-rates:secondary:${endpoint}`,
+    );
+    if (!validation.ok) {
+      console.warn(`[sync-fx-rates] Secondary FX payload invalid (${endpoint}): ${validation.issues}`);
+      return null;
+    }
+
+    return {
+      endpoint,
+      payload: validation.data,
+    };
+  } catch (error) {
+    console.warn(`[sync-fx-rates] Secondary FX payload unreadable (${endpoint}):`, error);
     return null;
   }
-
-  return {
-    endpoint,
-    payload: validation.data,
-  };
 }
 
 function chooseSecondaryCurrencyCandidate(


### PR DESCRIPTION
### Motivation
- A newly added date-pinned jsDelivr secondary FX candidate could return a 200 with invalid JSON and that parsing error would reject the entire `Promise.all` for secondary mirror loading, aborting the live full-set fallback path and preventing tertiary fallbacks from running.

### Description
- Wrap parsing/validation inside `fetchSecondaryCurrencyCandidate()` with a `try/catch` so unreadable or malformed secondary payloads are treated as candidate-local failures and return `null` instead of throwing. 
- Preserve the existing `Promise.all` concurrency for mirror fetches but ensure one malformed candidate cannot reject the whole mirror-selection flow. 
- Add regression coverage in `worker/src/cron/__tests__/sync-fx-rates.test.ts` that proves a malformed date-pinned jsDelivr response is ignored when other secondary mirrors are healthy. 
- Extend the ExchangeRate-API live-fallback test scenario to include a malformed versioned secondary payload to ensure tertiary fallback still executes.

### Testing
- Ran the focused test command `npx vitest run worker/src/cron/__tests__/sync-fx-rates.test.ts -t "secondary FX|ExchangeRate-API as a live full-set fallback" --reporter=dot`, which passed. 
- Verified TypeScript build with `cd worker && npx tsc --noEmit`, which succeeded. 
- Verified cron trigger connection budgets with `npm run check:cron-connections`, which reported all triggers within budget. 
- Ran the full file test run `npx vitest run worker/src/cron/__tests__/sync-fx-rates.test.ts --reporter=dot` and all tests in that suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350feba410833287ab069820129c76)