### PR TITLE
fix(security): cap selector snapshot writes per IP

### DIFF
--- a/docs/worker-infrastructure.md
+++ b/docs/worker-infrastructure.md
@@ -126,7 +126,7 @@ Canonical binding ownership now lives in `shared/lib/env-contract.ts`; the worke
 | `OPS_API_SERVICE_TOKEN_SECRET` | `string` | - | required | - | Pages-managed Access service-token client secret used on the server-to-server hop to `ops-api.pharos.watch`. |
 | `SITE_ORIGIN` | `string` | - | - | optional | Site origin override used by the Pages `/_site-data/*` proxy when classifying production hosts. |
 | `SITE_API_ORIGIN` | `string` | - | - | required | Site-data upstream origin; production Pages hosts require `https://site-api.pharos.watch`. |
-| `SELECTOR_SNAPSHOTS` | `KVNamespace` | - | - | required | KV namespace binding for the Pages-only Stablecoin Picker snapshot store at `functions/selector-snapshot/[[path]].ts`; 5-year TTL on content-addressed `s:{sid}` entries. |
+| `SELECTOR_SNAPSHOTS` | `KVNamespace` | - | - | required | KV namespace binding for the Pages-only Stablecoin Picker snapshot store at `functions/selector-snapshot/[[path]].ts`; stores content-addressed `s:{sid}` entries plus hashed-IP write-quota counters. |
 <!-- ENV-CONTRACT:WORKER-INFRASTRUCTURE:END -->
 
 ---

--- a/functions/AGENTS.md
+++ b/functions/AGENTS.md
@@ -21,11 +21,11 @@ See root AGENTS.md / CLAUDE.md § High-Value Gotchas for cross-cutting rules. Th
 
 ## Accepted residual risk — selector-snapshot write lane (S-062)
 
-`POST /selector-snapshot` (`functions/selector-snapshot/[[path]].ts`) is the only unauthenticated KV write path in this slice. Its gates are: a spoofable Origin/Referer check (`rejectIfNotSiteDataUiOrigin`), a 100 KiB payload cap, content-addressed dedupe of identical bodies, and a per-isolate hashed-IP throttle (10 writes / 60s window). The zone WAF rate limits only cover `api.pharos.watch/api/*`, and the isolate-local limiter resets on isolate recycle and is not shared across colos, so a single source rotating colos/isolates can exceed 10/min.
+`POST /selector-snapshot` (`functions/selector-snapshot/[[path]].ts`) is the only unauthenticated KV write path in this slice. Its gates are: a spoofable Origin/Referer check (`rejectIfNotSiteDataUiOrigin`), a 100 KiB payload cap, content-addressed dedupe of identical bodies, a per-isolate hashed-IP throttle (10 writes / 60s window), and a KV-backed hashed-IP daily quota (100 writes / UTC day). The zone WAF rate limits only cover `api.pharos.watch/api/*`; the isolate-local limiter still resets on isolate recycle and is not shared across colos, but the KV quota gives direct-client writes a durable per-IP ceiling.
 
-Accepted because the blast radius is bounded write-amplification / KV cost, not data integrity: read-side sid recomputation and shape validation reject tampered values, and abusive entries fall off the 90-day unread TTL (`SELECTOR_SNAPSHOT_UNREAD_TTL_SECONDS`) unless read. Worst-case per-attacker cost ceiling is roughly `100 KiB x 10 writes/min x (isolates reached) x 90 days` of KV storage before unread expiry, with each entry surviving only if it is also read at least once.
+Accepted because the blast radius is bounded write-amplification / KV cost, not data integrity: read-side sid recomputation and shape validation reject tampered values, and abusive entries fall off the 90-day unread TTL (`SELECTOR_SNAPSHOT_UNREAD_TTL_SECONDS`) unless read. Worst-case single-IP cost ceiling is roughly `100 KiB x 100 writes/day x 90 days` of KV storage before unread expiry, with each entry surviving longer only if it is also read at least once.
 
-If this lane sees real abuse, escalate to a Cloudflare WAF / rate-limiting rule on `pharos.watch/selector-snapshot*` or move the throttle to a Durable Object / KV-backed counter that survives isolate recycling.
+If this lane sees real abuse, escalate to a Cloudflare WAF / rate-limiting rule on `pharos.watch/selector-snapshot*` or move the throttle to a Durable Object-backed counter with stricter replay controls.
 
 ## Common Checks
 

--- a/functions/__tests__/selector-snapshot.test.ts
+++ b/functions/__tests__/selector-snapshot.test.ts
@@ -100,6 +100,7 @@ describe("selector-snapshot Pages Function", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -464,6 +465,36 @@ describe("selector-snapshot Pages Function", () => {
       });
       expect(otherIp.status).toBe(200);
     });
+  });
+
+  it("persists a per-IP daily quota across isolate rate-limit windows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-19T00:00:00Z"));
+    const env = makeEnv();
+    const output = buildSelectorSnapshotOutput();
+    const headers = {
+      ...POST_HEADERS,
+      "CF-Connecting-IP": "203.0.113.90",
+    };
+
+    for (let i = 0; i < 100; i++) {
+      vi.setSystemTime(new Date(Date.UTC(2026, 5, 19, 0, i + 1, 0)));
+      const response = await onRequest({
+        request: postRequest({ ...output, datasetHash: `quota-${i}` }, headers),
+        env,
+        params: {},
+      });
+      expect(response.status).toBe(200);
+    }
+
+    vi.setSystemTime(new Date(Date.UTC(2026, 5, 19, 1, 50, 0)));
+    const throttled = await onRequest({
+      request: postRequest({ ...output, datasetHash: "quota-over" }, headers),
+      env,
+      params: {},
+    });
+    expect(throttled.status).toBe(429);
+    expect(throttled.headers.get("Retry-After")).toBe("86400");
   });
 
   describe("GET failure modes", () => {

--- a/functions/selector-snapshot/[[path]].ts
+++ b/functions/selector-snapshot/[[path]].ts
@@ -43,6 +43,8 @@ const SNAPSHOT_BODY_ENCODER = new TextEncoder();
 const POST_RATE_LIMIT_WINDOW_MS = 60_000;
 const POST_RATE_LIMIT_MAX_PER_WINDOW = 10;
 const POST_RATE_LIMIT_MAX_TRACKED_IPS = 5_000;
+const POST_DAILY_QUOTA_MAX_PER_IP = 100;
+const POST_DAILY_QUOTA_TTL_SECONDS = 60 * 60 * 48;
 const postTimestampsByIpHash = new Map<string, number[]>();
 
 async function hashClientIp(ip: string): Promise<string> {
@@ -50,11 +52,19 @@ async function hashClientIp(ip: string): Promise<string> {
   return Array.from(new Uint8Array(digest).slice(0, 8), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-async function isPostRateLimited(request: Request): Promise<boolean> {
+async function getClientIpHash(request: Request): Promise<string | null> {
   const ip = request.headers.get("CF-Connecting-IP");
-  if (!ip) return false;
+  if (!ip) return null;
+  return hashClientIp(ip);
+}
 
-  const key = await hashClientIp(ip);
+function dailyQuotaKey(ipHash: string, now = new Date()): string {
+  return `q:${now.toISOString().slice(0, 10)}:${ipHash}`;
+}
+
+async function isPostRateLimited(request: Request): Promise<boolean> {
+  const key = await getClientIpHash(request);
+  if (!key) return false;
   const now = Date.now();
   const cutoff = now - POST_RATE_LIMIT_WINDOW_MS;
   const recent = (postTimestampsByIpHash.get(key) ?? []).filter((ts) => ts > cutoff);
@@ -70,6 +80,36 @@ async function isPostRateLimited(request: Request): Promise<boolean> {
   }
   postTimestampsByIpHash.set(key, recent);
   return false;
+}
+
+async function consumeDailyPostQuota(env: SelectorSnapshotEnv, request: Request): Promise<Response | null> {
+  const ipHash = await getClientIpHash(request);
+  if (!ipHash || !env.SELECTOR_SNAPSHOTS) return null;
+
+  const key = dailyQuotaKey(ipHash);
+  let count = 0;
+  try {
+    const stored = await env.SELECTOR_SNAPSHOTS.get(key, "text");
+    count = stored === null ? 0 : Number.parseInt(stored, 10);
+  } catch (error) {
+    console.warn("[selector-snapshot] quota read failure", error);
+    return jsonError(503, "Snapshot store temporarily unavailable");
+  }
+
+  if (Number.isFinite(count) && count >= POST_DAILY_QUOTA_MAX_PER_IP) {
+    return jsonError(429, "Daily snapshot write quota exceeded", { "Retry-After": "86400" });
+  }
+
+  try {
+    await env.SELECTOR_SNAPSHOTS.put(key, String((Number.isFinite(count) ? count : 0) + 1), {
+      expirationTtl: POST_DAILY_QUOTA_TTL_SECONDS,
+    });
+  } catch (error) {
+    console.warn("[selector-snapshot] quota write failure", error);
+    return jsonError(503, "Snapshot store temporarily unavailable");
+  }
+
+  return null;
 }
 
 interface SelectorSnapshotEnv {
@@ -174,6 +214,9 @@ async function handlePost(context: SelectorSnapshotContext): Promise<Response> {
   } catch {
     // Treat read failure as best-effort; proceed to write.
   }
+
+  const quotaRejected = await consumeDailyPostQuota(env, request);
+  if (quotaRejected) return quotaRejected;
 
   try {
     // Unread snapshots expire on the short TTL; the first successful read

--- a/shared/lib/env-contract/registry.ts
+++ b/shared/lib/env-contract/registry.ts
@@ -602,7 +602,7 @@ export const ENV_BINDINGS = [
   {
     key: "SELECTOR_SNAPSHOTS",
     valueType: "KVNamespace",
-    description: "KV namespace binding for the Pages-only Stablecoin Picker snapshot store at `functions/selector-snapshot/[[path]].ts`; 5-year TTL on content-addressed `s:{sid}` entries.",
+    description: "KV namespace binding for the Pages-only Stablecoin Picker snapshot store at `functions/selector-snapshot/[[path]].ts`; stores content-addressed `s:{sid}` entries plus hashed-IP write-quota counters.",
     example: { section: "pagesSiteDataRequired", value: "" },
     runtimes: {
       pagesSiteData: { order: 5, status: "required" },


### PR DESCRIPTION
### Motivation
- The public `POST /selector-snapshot` path allowed long-lived KV writes protected only by spoofable browser headers and an isolate-local burst limiter, enabling direct clients to create many persistent snapshots and exhaust KV storage. 
- The intent is to bound the storage/amplification blast radius for spoofed-origin writes without changing the snapshot read/replay contract.

### Description
- Add a KV-backed per-IP daily quota consumed under the `SELECTOR_SNAPSHOTS` binding using keys of the form `q:<YYYY-MM-DD>:<hashedIp>` with `POST_DAILY_QUOTA_MAX_PER_IP = 100` and a TTL, implemented in `functions/selector-snapshot/[[path]].ts`.
- The quota is checked and incremented only after payload validation and idempotent dedupe (existing-snapshot check), so re-POSTing the same snapshot does not consume the daily budget.
- Preserve the existing per-isolate sliding-window limiter and unread/retention semantics, and update tests and docs to reflect the durable quota counter and revised residual-risk ceiling by changing `functions/__tests__/selector-snapshot.test.ts`, `functions/AGENTS.md`, `shared/lib/env-contract/registry.ts`, and `docs/worker-infrastructure.md`.

### Testing
- Ran `npx vitest run functions/__tests__/selector-snapshot.test.ts` and the selector-snapshot test suite passed (`31` tests passed).
- Ran `npm run check:env-contract` and `npm run check:worker-boundary` and both checks succeeded.
- Ran `npx tsc --noEmit` as an additional safety check but it failed repo-wide on unrelated pre-existing type errors (these failures are not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350fec617c8332b177ef6a67042260)