### PR TITLE
fix(yield): harden MXN benchmark fallback (remove Etherfuse as global MXN proxy)

### DIFF
--- a/docs/worker-infrastructure.md
+++ b/docs/worker-infrastructure.md
@@ -112,7 +112,7 @@ Canonical binding ownership now lives in `shared/lib/env-contract.ts`; the worke
 | `MINT_BURN_STALE_CRIT_SEC` | `string` | optional | - | - | Mint/burn stale-critical threshold override (seconds). |
 | `MINT_BURN_ALERT_COOLDOWN_SEC` | `string` | optional | - | - | Mint/burn stale-alert dedupe cooldown override (seconds). |
 | `OPENEXCHANGERATES_API_KEY` | `string` | optional | - | - | Open Exchange Rates credential used for FX cross-validation. |
-| `BANXICO_TOKEN` | `string` | optional | - | - | Banxico SIE API token used for official MXN CETES 28-day benchmark rates; when absent/failing, the benchmark cron can use Etherfuse CETES current issuance as an explicit degraded proxy. |
+| `BANXICO_TOKEN` | `string` | optional | - | - | Banxico SIE API token used for official MXN CETES 28-day benchmark rates; when absent/failing, MXN retains the last market benchmark when available or remains unavailable for USD fallback. |
 | `CLOUDFLARE_ACCOUNT_ID` | `string` | optional | - | - | Cloudflare account scope used by admin D1 status metrics. |
 | `CLOUDFLARE_D1_STATUS_API_TOKEN` | `string` | optional | - | - | Cloudflare API token with D1 status/analytics read access for admin metrics. |
 | `CLOUDFLARE_D1_DATABASE_ID` | `string` | optional | - | - | Target D1 database ID used by admin D1 status metrics. |

--- a/docs/yield-intelligence-timeline.md
+++ b/docs/yield-intelligence-timeline.md
@@ -1,10 +1,19 @@
 # Yield Intelligence Methodology - Version Timeline
 
-Internal changelog reconstructed from git history. Runtime currently reports Yield Intelligence `v8.292`.
+Internal changelog reconstructed from git history. Runtime currently reports Yield Intelligence `v8.293`.
 
 ---
 
 > Older entries are archived in [yield-intelligence-timeline-archive.md](./yield-intelligence-timeline-archive.md); this file keeps the 10 most recent.
+
+## v8.293 - Banxico-Only MXN Benchmark Hardening (June 19, 2026)
+
+- MXN benchmark resolution still prefers Banxico SIE `SF43936` with `BANXICO_TOKEN`, but no longer queries Etherfuse CETES current issuance when Banxico is unavailable
+- Etherfuse CETES current issuance remains the `cetes-etherfuse` product APY source only; it is not written into the shared `risk_free_rates` benchmark cache as a global MXN proxy
+- Degraded benchmark resolutions no longer refresh `lastMarket*` fields, so fallback/proxy values cannot become durable retained market sources on later feed failures
+- When Banxico is unavailable and no prior market MXN benchmark is retained, MXN-pegged rows fall back through the normal USD benchmark-selection path
+
+---
 
 ## v8.292 - Yearn-Style 5-Category Venue Risk and Dependency Concentration (June 15, 2026)
 

--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -8,11 +8,13 @@ Risk-adjusted yield tracking and ranking for yield-bearing stablecoins and curat
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v8.292`
+- **Current methodology version:** `v8.293`
 - **Public changelog page:** `/methodology/yield-changelog/`
 - **Canonical source:** `shared/lib/yield-methodology-version.ts`
 
 Yield versions are bumped when APY source resolution, source arbitration, history semantics, PYS scoring logic, or score-affecting publication rules change.
+
+Yield v8.293 hardens MXN benchmark integrity by removing the Etherfuse CETES issuer page from the shared benchmark fallback path. Etherfuse CETES current issuance remains the product APY source for `cetes-etherfuse`, but the global MXN benchmark now resolves from Banxico SIE `SF43936` or retained prior market data only. Fallback benchmark resolutions also stop refreshing `lastMarket*` metadata, so degraded proxy values cannot become the durable last-market source for later retained fallbacks. PYS formula shape, source-risk calibration, history semantics, and publication guards are otherwise unchanged.
 
 Yield v8.292 replaces the hand-set 3-bucket venue tier with Yearn's shipped 5-category weighted rubric (audits, centralization, funds management, liquidity, operational; each 1–5), derives `venueRiskTier` from the resulting 1–5 score, and moves the PYS venue penalty to a continuous, calibration-preserving curve `max(0, weighted - 2.0) * 0.15` (blue-chip `low` venues stay a 0 no-op; `3.0` reproduces the legacy `medium` +0.15). It scores 49 previously-unreviewed long-tail venues (the reviewed registry grows 12 → 61), lighting up uncollateralized/RWA credit, newer money markets, CDPs, app-chain lenders, and additional risky allowlist venues that were formerly `unknown` = neutral. It also adds a reviewer-set cross-venue `dependencyConcentration` sub-signal (seeded with `yvusdc-yearn` = Sky), anchored to Yearn's own published yvUSDC risk report. The newly-scored medium/high venues feed the DEWS structured-venue branch (DEWS v6.091) with no DEWS threshold change. The PYS formula shape, benchmark selection, history semantics, and publication guards are otherwise unchanged.
 
@@ -46,7 +48,7 @@ Yield v8.17 tracks `sdusd-dtrinity` as the first-class dTRINITY dStake yield wra
 
 Yield v8.16 fixes `fpi-frax`, `silk-shade-protocol`, and `isc-international-stable-currency` NAV-token metadata so they route through NAV-appreciation coverage, and adds rate-derived proxy coverage for `cgusd-cygnus-finance` and `usdn-noble`.
 
-Yield v8.15 gives `cetes-etherfuse` a curated `protocol-api:etherfuse-cetes-current-issuance` APY source from Etherfuse's current Stablebond issuance rate. This replaces the selected USD price-derived NAV fallback when Etherfuse is reachable, so MXN/USD FX movement is no longer interpreted as CETES yield. The MXN benchmark still prefers Banxico SIE `SF43936`, but when `BANXICO_TOKEN` is missing or Banxico fails, the daily benchmark cron can use the Etherfuse CETES current issuance rate as an explicit degraded proxy fallback (`isFallback: true`, `isProxy: true`).
+Yield v8.15 gives `cetes-etherfuse` a curated `protocol-api:etherfuse-cetes-current-issuance` APY source from Etherfuse's current Stablebond issuance rate. This replaces the selected USD price-derived NAV fallback when Etherfuse is reachable, so MXN/USD FX movement is no longer interpreted as CETES yield. The MXN benchmark uses Banxico SIE `SF43936`; Etherfuse CETES current issuance is not used as a shared MXN benchmark fallback.
 
 Yield v8.14 ships the public adapter manifest endpoint at `/api/yield-adapter-manifest` as the canonical machine-readable source list for every yield-bearing asset. Each entry carries `stablecoinId`, `coinSymbol`, `family` (`onchain` / `protocol-api` / `defillama` / `defillama-auto` / `rate-derived` / `price-derived` / `intentional-gap`), nullable `sourceKey`, optional `sourceKeyPattern`, `label`, optional `chain`/`project` hints, `lifecycle` (`active` / `quarantined` / `intentional-gap` / `experimental`), `quarantineReason` when lifecycle is `quarantined`, the current `methodologyVersion` label, and a methodology-snapshot `updatedAt`. `sourceKey` is populated only when the entry has an exact runtime key that can join to rankings, decision rows, or `/api/yield-history?sourceKey=...`; runtime-resolved DeFiLlama variant rows and disabled/quarantined readers use `sourceKey: null` plus `sourceKeyPattern` instead of publishing synthetic keys. Scoring, source resolution, history semantics, and publication rules are unchanged in v8.14; the bump tracks the new public contract only.
 
@@ -505,7 +507,7 @@ Yield Intelligence now uses a small benchmark registry instead of a single globa
 | `CHF` | CHF 3M compounded SARON | SIX delayed `SAR3MC` download | Public feed is delayed by one business day; not labeled as a proxy |
 | `GBP` | GBP 3M compounded SONIA | Bank of England IADB SONIA Compounded Index `IUDZOS2` CSV | Annualized from the trailing 90-day index change; metadata source `boe-sonia-compounded-index`, fallback mode `gbp-sonia-compounded-index-failed` |
 | `JPY` | JPY overnight call (TONA proxy) | Bank of Japan Time-Series Data Search `STRDCLUCON` | Used as a TONA-equivalent proxy |
-| `MXN` | MXN CETES 28d | Banxico SIE API (series `SF43936`), then Etherfuse CETES current issuance fallback | `BANXICO_TOKEN` enables the official Banxico feed; when missing/failing, Etherfuse is marked `isFallback` and `isProxy`. CETES (Etherfuse) is itself a 28d CETES tokenization, so the spread is ~0% — see "Self-reference caveat" below |
+| `MXN` | MXN CETES 28d | Banxico SIE API (series `SF43936`) | `BANXICO_TOKEN` enables the official Banxico feed; when missing/failing, MXN retains the last market source when available or remains unavailable so rows fall back to USD. Etherfuse CETES current issuance is deliberately limited to the CETES product APY source, not the shared MXN benchmark. |
 | `BRL` | BRL SELIC over | BCB SGS API (series `11`) | No auth required; daily |
 | `AUD` | AUD cash-rate target | Reserve Bank of Australia F1 money-market CSV | RBA cash-rate target used as the AUD local cash hurdle |
 | `CAD` | CAD overnight repo (CORRA proxy) | Bank of Canada Valet API (series `V122530`) | Overnight repo; CORRA-equivalent |
@@ -527,7 +529,6 @@ https://www.bankofengland.co.uk/boeapps/database/_iadb-fromshowcolumns.asp
 https://www.stat-search.boj.or.jp/api/v1/getDataCode
 https://www.rba.gov.au/statistics/tables/csv/f1-data.csv
 https://www.banxico.org.mx/SieAPIRest/service/v1/series/SF43936/datos/oportuno
-https://app.etherfuse.com/bonds/cetes
 https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados/ultimos/1?formato=json
 https://www.bankofcanada.ca/valet/observations/V122530/json?recent=1
 https://www.cbr.ru/DailyInfoWebServ/DailyInfo.asmx
@@ -537,7 +538,7 @@ https://evds3.tcmb.gov.tr/igmevdsms-dis/serieList/fe/type=json&code=bie_bisttlre
 
 **Stored as:** `cache` table, key `"risk_free_rates"`, with the legacy USD-only key `"risk_free_rate"` still written for compatibility.
 
-**Fallback:** `RISK_FREE_RATE_FALLBACK = 3.75%` applies to USD only. Other benchmarks prefer a retained last-known source-backed value when available; otherwise they remain unavailable and rows fall back to USD when selection requires it. MXN additionally tries Etherfuse CETES current issuance as a degraded proxy when Banxico is unavailable.
+**Fallback:** `RISK_FREE_RATE_FALLBACK = 3.75%` applies to USD only. Other benchmarks prefer a retained last-known source-backed value when available; otherwise they remain unavailable and rows fall back to USD when selection requires it. MXN does not use issuer-controlled product pages as benchmark fallbacks.
 
 **Tokenized-treasury benchmark overrides:** Some rate-derived treasury-like products tokenize the same instrument as their local benchmark, which can compress excess-yield and PYS context toward zero. `benchmarkOverrideKey` lets a rate-derived row compute APY from its configured product benchmark while comparing PYS/excess-yield against an explicit benchmark hurdle. USD T-bill/MMF-style proxies use `USD_EFFR` as the comparison hurdle; EUTBL and UKTBL carry explicit same-currency override keys. CETES still uses its protocol-native issuance adapter plus the MXN CETES benchmark path, so CETES-specific override policy remains a separate future decision.
 
@@ -753,7 +754,7 @@ Fetches the benchmark registry used by Yield Intelligence:
 - CHF 3M compounded SARON (`SAR3MC`) from SIX's delayed public download, fetched through the guest OAuth + report-download flow used by their public site
 - GBP 3M compounded SONIA from the Bank of England IADB SONIA Compounded Index `IUDZOS2`, annualized from the trailing 90-day index change (v8.28)
 - JPY call-rate proxy from Bank of Japan Time-Series Data Search `STRDCLUCON` (v8.22)
-- MXN CETES 28-day from Banxico SIE (`SF43936`), falling back to Etherfuse CETES current issuance as a degraded proxy when Banxico is unavailable (v8.15)
+- MXN CETES 28-day from Banxico SIE (`SF43936`), with retained-last-market fallback only when a prior market source exists (v8.293 removed the Etherfuse degraded benchmark proxy)
 - BRL SELIC overnight from BCB SGS series 11 (no auth) (v8.13)
 - AUD cash-rate target from the Reserve Bank of Australia F1 money-market CSV (v8.22)
 - CAD CORRA proxy from Bank of Canada Valet `V122530` (v8.13)
@@ -1133,7 +1134,7 @@ The control row exposes four fixed lookback presets (`7d`, `30d`, `90d`, `1y`) p
 | `worker/src/cron/yield-helpers.ts`                   | Pure functions: APY, PYS, stability, variance, warning signals, `matchAllDlPools`                                                            |
 | `worker/src/cron/yield-sync/pool-filter.ts`          | Pre-filter for wrapper-relevant DeFiLlama pools before matching                                                                               |
 | `worker/src/lib/yield-source-links.ts`               | Curated yield-source link registry plus metadata fallback resolver for rankings/history payloads                                               |
-| `worker/src/cron/fetch-tbill-rate.ts`                | Daily benchmark-registry cron (USD T-bill, USD EFFR, EUR 3M compounded €STR, CHF 3M compounded SARON, GBP 3M compounded SONIA, JPY call-rate proxy, MXN CETES 28d with Etherfuse fallback, BRL SELIC, AUD cash-rate target, CAD CORRA proxy, RUB CBR key rate, TRY BIST TLREF) |
+| `worker/src/cron/fetch-tbill-rate.ts`                | Daily benchmark-registry cron (USD T-bill, USD EFFR, EUR 3M compounded €STR, CHF 3M compounded SARON, GBP 3M compounded SONIA, JPY call-rate proxy, MXN CETES 28d, BRL SELIC, AUD cash-rate target, CAD CORRA proxy, RUB CBR key rate, TRY BIST TLREF) |
 | `worker/src/api/cache-handlers.ts`                   | Cache-backed `GET /api/yield-rankings` handler with live Safety Score hydration (`handleYieldRankings`)                                      |
 | `worker/src/api/yield-history.ts`                    | `GET /api/yield-history` handler                                                                                                             |
 | `shared/types/index.ts`                              | `YieldConfig`, `YieldType`, `YieldRanking` (`.altSources: AltYieldSource[]`), `AltYieldSource`, `YieldRankingsResponse`, `YieldHistoryPoint` |

--- a/shared/data/methodology-changelogs/yield-methodology/v8.ts
+++ b/shared/data/methodology-changelogs/yield-methodology/v8.ts
@@ -2,6 +2,22 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 
 export const YIELD_METHODOLOGY_V8: readonly MethodologyChangelogEntry[] = [
   {
+    version: "8.293",
+    title: "Banxico-Only MXN Benchmark Hardening",
+    date: "2026-06-19",
+    effectiveAt: 1781827200,
+    summary:
+      "Yield Intelligence removes the Etherfuse CETES issuer page from the shared MXN benchmark fallback path so MXN benchmarks are sourced from Banxico or retained prior market data only.",
+    impact: [
+      "MXN benchmark resolution still prefers Banxico SIE `SF43936` with `BANXICO_TOKEN`; when the token is missing or Banxico fails, the cron no longer fetches Etherfuse CETES current issuance as a global benchmark proxy",
+      "Etherfuse CETES current issuance remains available only as the CETES product's own `protocol-api:etherfuse-cetes-current-issuance` APY source",
+      "Fallback benchmark resolutions no longer refresh `lastMarket*` fields, preventing degraded proxy values from becoming retained last-market benchmarks on later source failures",
+      "If Banxico is unavailable and no prior Banxico-backed MXN benchmark is retained, MXN-pegged rows fall back to the normal USD benchmark-selection path",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
+  {
     version: "8.292",
     title: "Yearn-Style 5-Category Venue Risk and Dependency Concentration",
     date: "2026-06-15",

--- a/shared/lib/env-contract/registry.ts
+++ b/shared/lib/env-contract/registry.ts
@@ -464,7 +464,7 @@ export const ENV_BINDINGS = [
   {
     key: "BANXICO_TOKEN",
     valueType: "string",
-    description: "Banxico SIE API token used for official MXN CETES 28-day benchmark rates; when absent/failing, the benchmark cron can use Etherfuse CETES current issuance as an explicit degraded proxy.",
+    description: "Banxico SIE API token used for official MXN CETES 28-day benchmark rates; when absent/failing, MXN retains the last market benchmark when available or remains unavailable for USD fallback.",
     example: { section: "workerOptional", value: "" },
     runtimes: {
       worker: { order: 38, status: "optional" },

--- a/shared/lib/methodology-versions/yield-methodology.ts
+++ b/shared/lib/methodology-versions/yield-methodology.ts
@@ -9,7 +9,7 @@ import { YIELD_METHODOLOGY_V8 } from "../../data/methodology-changelogs/yield-me
 import { createMethodologyVersion } from "./base";
 
 const yieldMethodology = createMethodologyVersion({
-  currentVersion: "8.292",
+  currentVersion: "8.293",
   changelogPath: "/methodology/yield-changelog/",
   changelog: [
     ...YIELD_METHODOLOGY_V8,

--- a/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
+++ b/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
@@ -1088,10 +1088,6 @@ describe("fetchTbillRate — new currency fetchers", () => {
           + "02-Mar-2026,4.30,,4.31\n",
           { status: 200 },
         ),
-        "app.etherfuse.com/bonds/cetes": new Response(ETHERFUSE_CETES_HTML, {
-          status: 200,
-          headers: { "Content-Type": "text/html" },
-        }),
         "api.bcb.gov.br": new Response(JSON.stringify([{ data: "26/03/2026", valor: "12.75" }]), { status: 200 }),
         "bankofcanada.ca/valet": new Response(
           JSON.stringify({
@@ -1112,12 +1108,12 @@ describe("fetchTbillRate — new currency fetchers", () => {
     const metadata = JSON.parse(result.metadata ?? "{}") as Record<string, unknown>;
 
     expect(calls.some((u) => u.includes("banxico.org.mx"))).toBe(false);
-    expect(calls.some((u) => u.includes("app.etherfuse.com/bonds/cetes"))).toBe(true);
-    expect(metadata.mxnSource).toBe("etherfuse-cetes-current-issuance");
-    expect(metadata.mxnRate).toBe(5.58);
-    expect(metadata.mxnRecordDate).toBe("2026-05-14");
+    expect(calls.some((u) => u.includes("app.etherfuse.com/bonds/cetes"))).toBe(false);
+    expect(metadata.mxnSource).toBeNull();
+    expect(metadata.mxnRate).toBeNull();
+    expect(metadata.mxnRecordDate).toBeNull();
     expect(result.status).toBe("degraded");
-    expect(String(metadata.fallbackMode)).toContain("mxn:banxico-token-missing-etherfuse-stablebond");
+    expect(String(metadata.fallbackMode)).toContain("mxn:banxico-token-missing");
   });
 
   it("retains the last MXN benchmark when the Banxico fetch fails", async () => {

--- a/worker/src/cron/fetch-tbill-rate.ts
+++ b/worker/src/cron/fetch-tbill-rate.ts
@@ -40,10 +40,6 @@ import {
 } from "./yield-sync/benchmarks";
 import { rethrowIfAborted, throwIfAborted } from "../lib/abort";
 import { DAY_MS } from "@shared/lib/time-constants";
-import {
-  ETHERFUSE_CETES_BENCHMARK_SOURCE,
-  fetchEtherfuseCetesIssuance,
-} from "./yield-sync/etherfuse-cetes";
 import { loadRiskFreeRateRegistry } from "./yield-sync/sources-riskfree";
 import type { YieldBenchmarkKey } from "@shared/types/yield";
 import type { Env } from "../lib/env";
@@ -468,13 +464,24 @@ function buildResolvedBenchmark(params: {
     isFallback: params.isFallback ?? false,
     fallbackMode: params.fallbackMode ?? null,
   });
+  const marketFields = params.isFallback
+    ? {
+      lastMarketRate: null,
+      lastMarketRecordDate: null,
+      lastMarketFetchedAt: null,
+      lastMarketSource: null,
+    }
+    : {
+      lastMarketRate: params.rate,
+      lastMarketRecordDate: params.recordDate,
+      lastMarketFetchedAt: params.fetchedAt,
+      lastMarketSource: params.source,
+    };
+
   return {
     ...resolved,
     isProxy: params.isProxy ?? resolved.isProxy,
-    lastMarketRate: params.rate,
-    lastMarketRecordDate: params.recordDate,
-    lastMarketFetchedAt: params.fetchedAt,
-    lastMarketSource: params.source,
+    ...marketFields,
   };
 }
 
@@ -1113,35 +1120,6 @@ async function resolveMxnBenchmarkProvider(params: {
   }
 
   const baseFallbackMode = token ? "banxico-cetes-failed" : "banxico-token-missing";
-  const etherfuseIssuance = await fetchEtherfuseCetesIssuance({
-    signal,
-    timeoutMs: BENCHMARK_FETCH_TIMEOUT_MS,
-    retries: BENCHMARK_FETCH_MAX_RETRIES,
-  });
-
-  if (etherfuseIssuance && isValidBenchmarkRate(etherfuseIssuance.apyPercent)) {
-    const fallbackMode = `${baseFallbackMode}-etherfuse-stablebond`;
-    const parsed = {
-      rate: etherfuseIssuance.apyPercent,
-      recordDate: etherfuseIssuance.recordDate,
-    };
-    return {
-      key: "MXN",
-      parsed,
-      meta: buildResolvedBenchmark({
-        key: "MXN",
-        rate: parsed.rate,
-        recordDate: parsed.recordDate,
-        fetchedAt,
-        source: ETHERFUSE_CETES_BENCHMARK_SOURCE,
-        isFallback: true,
-        fallbackMode,
-        isProxy: true,
-      }),
-      failureMode: fallbackMode,
-    };
-  }
-
   const meta = buildRetainedBenchmark(previous.MXN, baseFallbackMode);
   return {
     key: "MXN",


### PR DESCRIPTION
### Motivation
- Prevent an issuer-controlled Etherfuse product page from being used as a global MXN risk-free benchmark fallback that could poison downstream yield analytics. 
- Avoid persisting degraded/proxy fallback observations into durable `lastMarket*` fields so a manipulated or stale proxy cannot become the retained market benchmark.

### Description
- Stop querying/wiring Etherfuse CETES issuance into the MXN benchmark path by removing Etherfuse fallback logic from `resolveMxnBenchmarkProvider` in `worker/src/cron/fetch-tbill-rate.ts` so MXN now comes from Banxico or retained prior-market data only.
- Change `buildResolvedBenchmark` to avoid writing `lastMarket*` fields when the resolved benchmark is a fallback (`isFallback === true`), so fallback/proxy values do not refresh durable last-market metadata.
- Update targeted unit tests in `worker/src/cron/__tests__/fetch-tbill-rate.test.ts` to assert that missing `BANXICO_TOKEN` skips both Banxico and Etherfuse fetches and leaves MXN unavailable for normal fallback handling.
- Bump and document the yield methodology to `v8.293` and update docs and env-contract descriptions to describe the Banxico-only MXN benchmark behavior (docs and `shared/*` metadata files).

### Testing
- Ran focused unit suites: `npx vitest run worker/src/cron/__tests__/fetch-tbill-rate.test.ts worker/src/cron/__tests__/yield-etherfuse-cetes-source.test.ts` and all tests passed (54 passed).
- Type-checked the Worker: `cd worker && npx tsc --noEmit` succeeded.
- Documentation sync: `npm run check:doc-sync` on the updated docs and changelog passed.
- Env contract check: `npm run check:env-contract` passed, ensuring manifest/docs remain in sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350fec97a48332968dcca8b40b4811)