### PR TITLE
Restore direct Liquity V2 reserve reads

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/liquity-v2-branches.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/liquity-v2-branches.test.ts
@@ -343,8 +343,8 @@ describe("fetchLiquityV2BranchReserves Enosys branches", () => {
   });
 });
 
-describe("fetchLiquityV2BranchReserves multicall fast-path", () => {
-  it("uses multicall for branch balances and debt/shutdown reads when fully decodable", async () => {
+describe("fetchLiquityV2BranchReserves direct-call reads", () => {
+  it("does not trust sender-dependent Multicall3 balance or debt reads", async () => {
     const testConfig: LiveReservesConfig = {
       adapter: "liquity-v2-branches",
       version: 1,
@@ -370,15 +370,19 @@ describe("fetchLiquityV2BranchReserves multicall fast-path", () => {
 
     vi.mocked(probeOptionalRedemptionRateBps).mockResolvedValue(null);
     vi.mocked(fetchDefiLlamaPrices).mockResolvedValue(new Map([["WETH", 1_750]]));
-    vi.mocked(fetchOnchainMulticall3)
-      .mockResolvedValueOnce([
-        { label: "balance:0", success: true, returnData: encodeUint(2_000_000_000_000_000_000n) },
-      ])
-      .mockResolvedValueOnce([
-        { label: "debt:0", success: true, returnData: encodeUint(1_250_000_000_000_000_000_000n) },
-        { label: "shutdown:0", success: true, returnData: encodeUint(0) },
-      ]);
-    vi.mocked(fetchOnchainRawCall).mockResolvedValue(null);
+    vi.mocked(fetchOnchainMulticall3).mockResolvedValue([
+      { label: "balance:0", success: true, returnData: encodeUint(20_000_000_000_000_000_000n) },
+      { label: "debt:0", success: true, returnData: encodeUint(12_500_000_000_000_000_000_000n) },
+      { label: "shutdown:0", success: true, returnData: encodeUint(0) },
+    ]);
+    vi.mocked(fetchErc20Balance).mockResolvedValue(2_000_000_000_000_000_000n);
+    vi.mocked(fetchOnchainRawCall).mockImplementation(async ({ data }) => (
+      data === "0x06ff8dfb" ? encodeUint(1) : null
+    ));
+    vi.mocked(fetchOnchainUint256).mockImplementation(async ({ data }) => (
+      data === "0x45507998" ? 1_250_000_000_000_000_000_000n : null
+    ));
+    vi.mocked(fetchOnchainRateBps).mockResolvedValue(null);
 
     const result = await fetchLiquityV2BranchReserves(
       { id: "test-liquity-v2" } as StablecoinMeta,
@@ -386,17 +390,32 @@ describe("fetchLiquityV2BranchReserves multicall fast-path", () => {
       AbortSignal.timeout(5_000),
     );
 
+    expect(result.slices).toEqual([expect.objectContaining({ name: "WETH", pct: 100 })]);
     expect(result.metadata).toMatchObject({
       totalDebtUsd: 1250,
       immediateRedeemableUsd: 1250,
       redemption: {
-        routeStatus: "open",
+        routeStatus: "degraded",
+        routeStatusReason: "Collateral branch shutdown/sunset detected for: WETH",
       },
     });
-    expect(fetchOnchainMulticall3).toHaveBeenCalledTimes(2);
-    expect(fetchErc20Balance).not.toHaveBeenCalled();
-    expect(fetchOnchainUint256).not.toHaveBeenCalledWith(expect.objectContaining({
+    expect(fetchOnchainMulticall3).not.toHaveBeenCalled();
+    expect(fetchErc20Balance).toHaveBeenCalledWith(
+      expect.objectContaining({ chain: "ethereum" }),
+      "0x2222222222222222222222222222222222222222",
+      "0x1111111111111111111111111111111111111111",
+      expect.any(AbortSignal),
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(fetchOnchainUint256).toHaveBeenCalledWith(expect.objectContaining({
+      contract: "0x1111111111111111111111111111111111111111",
       data: "0x45507998",
+    }));
+    expect(fetchOnchainRawCall).toHaveBeenCalledWith(expect.objectContaining({
+      contract: "0x1111111111111111111111111111111111111111",
+      data: "0x06ff8dfb",
     }));
   });
 });

--- a/worker/src/cron/reserve-adapters/liquity-v2-branches.ts
+++ b/worker/src/cron/reserve-adapters/liquity-v2-branches.ts
@@ -1,13 +1,12 @@
 import type { StablecoinMeta } from "@shared/types/core";
 import type { LiveReservesConfig, LiveReserveWarning } from "@shared/types/live-reserves";
-import { DECIMALS_SELECTOR, encodeBalanceOfCallData, TOTAL_SUPPLY_SELECTOR } from "../../lib/evm-selectors";
+import { DECIMALS_SELECTOR, TOTAL_SUPPLY_SELECTOR } from "../../lib/evm-selectors";
 import type { AdapterContext, AdapterResult } from "./types";
 import { ERC4626_ASSET_SELECTOR, ERC4626_TOTAL_ASSETS_SELECTOR } from "./erc4626";
 import {
   buildRedemptionSnapshotMetadata,
   decimalNumberFromBigInt,
   fetchErc20Balance,
-  fetchOnchainMulticall3,
   fetchOnchainRateBps,
   fetchOnchainRawCall,
   fetchOnchainUint256,
@@ -27,7 +26,6 @@ import {
 import {
   decodeAddressWord,
   decodeBoolWord,
-  decodeUint256Word,
   decodeUint8Word,
 } from "./abi-decode";
 
@@ -167,38 +165,6 @@ async function fetchLiquityV2BranchBalances(
   ctx: AdapterContext | undefined,
   timeoutMs: number,
 ): Promise<BranchBalanceEntry[]> {
-  const balanceCalls = params.branches.map((branch, index) => ({
-    label: `balance:${index}`,
-    contract: branch.token.address,
-    data: encodeBalanceOfCallData(branch.holder),
-    allowFailure: true,
-  }));
-
-  const multicallResults = await fetchOnchainMulticall3({
-    calls: balanceCalls,
-    signal,
-    ctx,
-    chain: input.chain,
-    rpcUrl: params.rpcUrl,
-    fallbackRpcUrl: params.fallbackRpcUrl,
-    timeoutMs,
-  });
-
-  if (multicallResults && multicallResults.length === balanceCalls.length) {
-    const balances = multicallResults.map((result, index) => {
-      const branch = params.branches[index]!;
-      const balanceRaw = result.success ? decodeUint256Word(result.returnData) : null;
-      return { branch, balanceRaw };
-    });
-    const unreadable = balances.some((entry) => entry.balanceRaw == null);
-    if (!unreadable) {
-      const adapted = await Promise.all(
-        balances.map((entry) => tryAdaptErc4626ShareEntry(input, entry, signal, ctx, params, timeoutMs)),
-      );
-      return adapted;
-    }
-  }
-
   const shareEntries = await Promise.all(
     params.branches.map(async (branch) => {
       const raw = await fetchErc20Balance(
@@ -393,88 +359,43 @@ export async function fetchLiquityV2BranchReserves(
       params.fallbackRpcUrl,
     ),
   ]);
-  const debtCalls = balances.flatMap((entry, index) => [
-    {
-      label: `debt:${index}`,
-      contract: entry.branch.holder,
-      data: debtSelector,
-      allowFailure: true,
-    },
-    {
-      label: `shutdown:${index}`,
-      contract: entry.branch.holder,
-      data: shutdownSelector,
-      allowFailure: true,
-    },
-  ]);
-
-  const multicallDebts = await fetchOnchainMulticall3({
-    calls: debtCalls,
-    signal,
-    ctx,
-    chain: input.chain,
-    rpcUrl: params.rpcUrl,
-    fallbackRpcUrl: params.fallbackRpcUrl,
-    timeoutMs,
-  });
-
-  const multicallDebtReads = multicallDebts && multicallDebts.length === debtCalls.length
-    ? await Promise.all(
-      balances.map(async (entry, index) => {
-        const debtResult = multicallDebts[index * 2];
-        const shutdownResult = multicallDebts[index * 2 + 1];
-        const branchRedemptionFeeBps = params.redemptionRateProbe
-          ? null
-          : await probeBranchRedemptionFeeBps(input, entry.branch, signal, ctx, params);
-        return {
-          entry,
-          debtRaw: debtResult?.success ? decodeUint256Word(debtResult.returnData) : null,
-          shutDown: shutdownResult?.success ? decodeBoolWord(shutdownResult.returnData) : null,
-          redemptionFeeBps: branchRedemptionFeeBps,
-        };
-      }),
-    )
-    : null;
-
-  const debts = multicallDebtReads && multicallDebtReads.every((entry) => entry.debtRaw != null)
-    ? multicallDebtReads
-    : await Promise.all(
-      balances.map(async (entry) => {
-        const [debtRaw, shutDownRaw, branchRedemptionFeeBps] = await Promise.all([
-          fetchOnchainUint256({
-            contract: entry.branch.holder,
-            data: debtSelector,
-            signal,
-            ctx,
-            rpcUrl: params.rpcUrl,
-            fallbackRpcUrl: params.fallbackRpcUrl,
-            rpcMode: input.rpcMode,
-            chain: input.chain,
-            timeoutMs,
-          }),
-          fetchOnchainRawCall({
-            contract: entry.branch.holder,
-            data: shutdownSelector,
-            signal,
-            ctx,
-            rpcUrl: params.rpcUrl,
-            fallbackRpcUrl: params.fallbackRpcUrl,
-            rpcMode: input.rpcMode,
-            chain: input.chain,
-            timeoutMs,
-          }),
-          params.redemptionRateProbe
-            ? Promise.resolve(null)
-            : probeBranchRedemptionFeeBps(input, entry.branch, signal, ctx, params),
-        ]);
-        return {
-          entry,
-          debtRaw,
-          shutDown: decodeBoolWord(shutDownRaw),
-          redemptionFeeBps: branchRedemptionFeeBps,
-        };
-      }),
-    );
+  const debts = await Promise.all(
+    balances.map(async (entry) => {
+      const [debtRaw, shutDownRaw, branchRedemptionFeeBps] = await Promise.all([
+        fetchOnchainUint256({
+          contract: entry.branch.holder,
+          data: debtSelector,
+          signal,
+          ctx,
+          rpcUrl: params.rpcUrl,
+          fallbackRpcUrl: params.fallbackRpcUrl,
+          rpcMode: input.rpcMode,
+          chain: input.chain,
+          timeoutMs,
+        }),
+        fetchOnchainRawCall({
+          contract: entry.branch.holder,
+          data: shutdownSelector,
+          signal,
+          ctx,
+          rpcUrl: params.rpcUrl,
+          fallbackRpcUrl: params.fallbackRpcUrl,
+          rpcMode: input.rpcMode,
+          chain: input.chain,
+          timeoutMs,
+        }),
+        params.redemptionRateProbe
+          ? Promise.resolve(null)
+          : probeBranchRedemptionFeeBps(input, entry.branch, signal, ctx, params),
+      ]);
+      return {
+        entry,
+        debtRaw,
+        shutDown: decodeBoolWord(shutDownRaw),
+        redemptionFeeBps: branchRedemptionFeeBps,
+      };
+    }),
+  );
 
   const unreadableDebtBranches = debts
     .filter((entry) => entry.debtRaw == null)


### PR DESCRIPTION
### Motivation
- Fix a data-integrity vulnerability where a new Multicall3 fast path allowed sender-dependent contracts to return different balances/debt/shutdown values when invoked via Multicall3, which could corrupt published reserve and redemption metadata.
- Restore the original direct `eth_call` semantics so each branch/token is probed in the same caller context the adapter originally relied on, preventing malicious or non-standard contracts from poisoning results.

### Description
- Remove the Multicall3 fast paths for branch balances and for debt/shutdown reads in `worker/src/cron/reserve-adapters/liquity-v2-branches.ts` and always perform per-branch direct reads instead. 
- Replace batched multicall-derived parsing with direct calls using `fetchErc20Balance`, `fetchOnchainUint256`, and `fetchOnchainRawCall` and restore direct decoding semantics for debt and shutdown values. 
- Update the adapter tests in `worker/src/cron/reserve-adapters/__tests__/liquity-v2-branches.test.ts` to assert the adapter ignores mocked/inflated Multicall3 responses and uses the direct-call path; remove unused multicall-related imports and decoders.

### Testing
- TypeScript compile check run with `cd worker && npx tsc --noEmit` completed successfully. 
- Adapter unit tests run with `npm test -- --run worker/src/cron/reserve-adapters/__tests__/liquity-v2-branches.test.ts` and all tests passed (8 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350feca168833288cb79e0fd78d785)