### PR TITLE
Avoid exposing anonymous Telegram admins

### DIFF
--- a/worker/src/lib/__tests__/telegram-chat-member.test.ts
+++ b/worker/src/lib/__tests__/telegram-chat-member.test.ts
@@ -5,7 +5,8 @@ import { jsonResponse } from "../../test-helpers/__shared/mock-fetch";
 const fetchSpy = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
 vi.stubGlobal("fetch", fetchSpy);
 
-const { getCachedChatMember, getCachedChatAdministrators } = await import("../telegram-chat-member");
+const { getCachedChatMember, getCachedChatAdministrators, formatAdministratorMentions } =
+  await import("../telegram-chat-member");
 
 const NOW_SEC = Math.floor(Date.now() / 1000);
 
@@ -20,6 +21,7 @@ describe("getCachedChatMember", () => {
       userId: "42",
       username: "alice",
       firstName: "Alice",
+      isAnonymous: false,
     });
     const db = mockD1([
       {
@@ -37,6 +39,7 @@ describe("getCachedChatMember", () => {
       userId: "42",
       username: "alice",
       firstName: "Alice",
+      isAnonymous: false,
     });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -71,6 +74,7 @@ describe("getCachedChatMember", () => {
       userId: "42",
       username: "bob",
       firstName: "Bob",
+      isAnonymous: false,
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
@@ -134,14 +138,16 @@ describe("getCachedChatAdministrators", () => {
     const result = await getCachedChatAdministrators(db, "bot-token", "-100");
 
     expect(result).toEqual([
-      { status: "creator", userId: "1", username: "alice", firstName: "Alice" },
-      { status: "administrator", userId: "2", username: null, firstName: "Bob" },
+      { status: "creator", userId: "1", username: "alice", firstName: "Alice", isAnonymous: false },
+      { status: "administrator", userId: "2", username: null, firstName: "Bob", isAnonymous: false },
     ]);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns the cached value without calling Telegram when fresh", async () => {
-    const cached = JSON.stringify([{ status: "creator", userId: "1", username: "alice", firstName: "Alice" }]);
+    const cached = JSON.stringify([
+      { status: "creator", userId: "1", username: "alice", firstName: "Alice", isAnonymous: false },
+    ]);
     const db = mockD1([
       {
         match: "SELECT value, updated_at FROM cache WHERE key = ?",
@@ -153,7 +159,21 @@ describe("getCachedChatAdministrators", () => {
 
     const result = await getCachedChatAdministrators(db, "bot-token", "-100");
 
-    expect(result).toEqual([{ status: "creator", userId: "1", username: "alice", firstName: "Alice" }]);
+    expect(result).toEqual([
+      { status: "creator", userId: "1", username: "alice", firstName: "Alice", isAnonymous: false },
+    ]);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatAdministratorMentions", () => {
+  it("omits anonymous administrators from group-visible hints", () => {
+    expect(
+      formatAdministratorMentions([
+        { status: "creator", userId: "1", username: "alice", firstName: "Alice", isAnonymous: false },
+        { status: "administrator", userId: "2", username: "hidden", firstName: "Hidden", isAnonymous: true },
+        { status: "administrator", userId: "3", username: null, firstName: "Bob", isAnonymous: false },
+      ]),
+    ).toBe("@alice, Bob");
   });
 });

--- a/worker/src/lib/telegram-chat-member.ts
+++ b/worker/src/lib/telegram-chat-member.ts
@@ -5,19 +5,14 @@ import { toErrorMessage } from "./error-utils";
 
 const CHAT_MEMBER_CACHE_TTL_SEC = 5 * 60;
 
-export type TelegramChatMemberStatus =
-  | "creator"
-  | "administrator"
-  | "member"
-  | "restricted"
-  | "left"
-  | "kicked";
+export type TelegramChatMemberStatus = "creator" | "administrator" | "member" | "restricted" | "left" | "kicked";
 
 export interface TelegramChatMember {
   status: TelegramChatMemberStatus;
   userId: string;
   username: string | null;
   firstName: string | null;
+  isAnonymous: boolean;
 }
 
 interface TelegramApiUser {
@@ -29,6 +24,7 @@ interface TelegramApiUser {
 interface TelegramChatMemberResult {
   status?: string;
   user?: TelegramApiUser;
+  is_anonymous?: boolean;
 }
 
 interface TelegramApiResponse<T> {
@@ -71,6 +67,7 @@ function normalizeMember(raw: TelegramChatMemberResult, fallbackUserId: string):
     userId,
     username: raw.user?.username ?? null,
     firstName: raw.user?.first_name ?? null,
+    isAnonymous: raw.is_anonymous === true,
   };
 }
 
@@ -109,9 +106,7 @@ export async function getCachedChatMember(
 
   if (!response.ok) {
     await drainResponseBody(response);
-    console.warn(
-      `[telegram-chat-member] getChatMember returned ${response.status} for chat ${chatId} user ${userId}`,
-    );
+    console.warn(`[telegram-chat-member] getChatMember returned ${response.status} for chat ${chatId} user ${userId}`);
     return null;
   }
 
@@ -140,7 +135,9 @@ export async function getCachedChatAdministrators(
   if (cached && isFresh(cached.updatedAt)) {
     try {
       const parsed = JSON.parse(cached.value) as TelegramChatMember[];
-      if (Array.isArray(parsed)) return parsed;
+      if (Array.isArray(parsed) && parsed.every((entry) => typeof entry?.isAnonymous === "boolean")) {
+        return parsed;
+      }
     } catch {
       /* fall through to refresh */
     }
@@ -150,18 +147,13 @@ export async function getCachedChatAdministrators(
   try {
     response = await postTelegramBotApi(botToken, "getChatAdministrators", { chat_id: chatId });
   } catch (err) {
-    console.warn(
-      `[telegram-chat-member] getChatAdministrators fetch failed for chat ${chatId}:`,
-      toErrorMessage(err),
-    );
+    console.warn(`[telegram-chat-member] getChatAdministrators fetch failed for chat ${chatId}:`, toErrorMessage(err));
     return null;
   }
 
   if (!response.ok) {
     await drainResponseBody(response);
-    console.warn(
-      `[telegram-chat-member] getChatAdministrators returned ${response.status} for chat ${chatId}`,
-    );
+    console.warn(`[telegram-chat-member] getChatAdministrators returned ${response.status} for chat ${chatId}`);
     return null;
   }
 
@@ -186,6 +178,7 @@ export function formatAdministratorMentions(admins: TelegramChatMember[]): strin
   const labels: string[] = [];
   for (const admin of admins) {
     if (admin.status !== "creator" && admin.status !== "administrator") continue;
+    if (admin.isAnonymous) continue;
     if (admin.username) {
       labels.push(`@${admin.username}`);
     } else if (admin.firstName) {


### PR DESCRIPTION
### Motivation
- Prevent the bot from revealing identities of Telegram admins who have enabled anonymous admin mode when non-admins trigger gated group commands. 
- The existing normalization dropped Telegram's `is_anonymous` flag so the hint text could include anonymous admins.

### Description
- Preserve Telegram anonymity metadata by adding `isAnonymous` to `TelegramChatMember` and mapping it from the API `is_anonymous` field in `worker/src/lib/telegram-chat-member.ts`.
- Require cached admin-list entries to include explicit `isAnonymous` metadata before reusing them so old caches without anonymity data are refreshed.
- Omit administrators with `isAnonymous === true` in `formatAdministratorMentions` so group-visible hints do not list anonymous admins.
- Add regression coverage and update tests in `worker/src/lib/__tests__/telegram-chat-member.test.ts` to validate caching, normalization, and anonymous-admin filtering.

### Testing
- Ran the focused unit tests with `npm run test -- worker/src/api/__tests__/telegram-webhook.test.ts worker/src/lib/__tests__/telegram-chat-member.test.ts` and both suites passed (all tests green).
- Verified TypeScript build for the worker with `cd worker && npx tsc --noEmit` which completed without errors.
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350febd4cc8332a4e392f2c9f87ea7)