### PR TITLE
fix(depegs): require DEX source-family corroboration

### DIFF
--- a/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
+++ b/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
@@ -537,8 +537,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 4,
             source_total_tvl: 5_000_000,
             price_sources_json: JSON.stringify([
-              { price: 0.96, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.955, tvl: 2_000_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 0.96, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.955, tvl: 2_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
           {
@@ -548,8 +548,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 4,
             source_total_tvl: 5_000_000,
             price_sources_json: JSON.stringify([
-              { price: 1.001, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 1, tvl: 2_000_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 1.001, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 1, tvl: 2_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
         ],
@@ -761,8 +761,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 4,
             source_total_tvl: 6_000_000,
             price_sources_json: JSON.stringify([
-              { price: 1.03, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 1.031, tvl: 3_000_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 1.03, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 1.031, tvl: 3_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
         ],
@@ -852,8 +852,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 3,
             source_total_tvl: 5_000_000,
             price_sources_json: JSON.stringify([
-              { price: 0.988, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.987, tvl: 2_000_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 0.988, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.987, tvl: 2_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
         ],
@@ -1037,8 +1037,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 4,
             source_total_tvl: 4_000_000,
             price_sources_json: JSON.stringify([
-              { price: 1.03, tvl: 1_500_000, protocol: "curve", chain: "ethereum" },
-              { price: 1.001, tvl: 900_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 1.03, tvl: 1_500_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 1.001, tvl: 900_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
         ],
@@ -1351,8 +1351,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 2,
             source_total_tvl: 5_000_000,
             price_sources_json: JSON.stringify([
-              { price: 0.96, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.959, tvl: 2_000_000, protocol: "curve", chain: "ethereum" },
+              { price: 0.96, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.959, tvl: 2_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
             ]),
           },
         ],
@@ -1692,9 +1692,9 @@ describe("confirmPendingDepegs", () => {
             source_total_tvl: 3_290_000,
             // Individual pools show real depeg via price_sources_json
             price_sources_json: JSON.stringify([
-              { price: 0.80, tvl: 500_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.95, tvl: 200_000, protocol: "uniswap", chain: "ethereum" },
-              { price: 1.00, tvl: 50_000, protocol: "balancer", chain: "ethereum" },
+              { price: 0.80, tvl: 500_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.95, tvl: 200_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
+              { price: 1.00, tvl: 50_000, protocol: "balancer", sourceFamily: "balancer", chain: "ethereum" },
             ]),
           },
         ],
@@ -1757,8 +1757,8 @@ describe("confirmPendingDepegs", () => {
             source_total_tvl: 50_000_000,
             // All pools near peg — should NOT confirm
             price_sources_json: JSON.stringify([
-              { price: 1.001, tvl: 20_000_000, protocol: "uniswap", chain: "ethereum" },
-              { price: 0.999, tvl: 15_000_000, protocol: "curve", chain: "ethereum" },
+              { price: 1.001, tvl: 20_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
+              { price: 0.999, tvl: 15_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
             ]),
           },
         ],
@@ -1806,8 +1806,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 5,
             source_total_tvl: 10_000_000,
             price_sources_json: JSON.stringify([
-              { price: 0.98, tvl: 1_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.979, tvl: 1_000_000, protocol: "curve", chain: "ethereum" },
+              { price: 0.98, tvl: 1_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.979, tvl: 1_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
             ]),
           },
         ],
@@ -1856,8 +1856,8 @@ describe("confirmPendingDepegs", () => {
           source_pool_count: 4,
           source_total_tvl: 4_000_000,
           price_sources_json: JSON.stringify([
-            { price: 0.997, tvl: 5_000_000, protocol: "curve", chain: "ethereum" },
-            { price: 1.012, tvl: 5_000_000, protocol: "uniswap", chain: "ethereum" },
+            { price: 0.997, tvl: 5_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+            { price: 1.012, tvl: 5_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
           ]),
         },
       ];
@@ -1899,7 +1899,7 @@ describe("confirmPendingDepegs", () => {
           source_pool_count: 1,
           source_total_tvl: 6_000_000,
           price_sources_json: JSON.stringify([
-            { price: 0.98, tvl: 6_000_000, protocol: "curve", chain: "ethereum" },
+            { price: 0.98, tvl: 6_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
           ]),
         },
       ];
@@ -1940,8 +1940,8 @@ describe("confirmPendingDepegs", () => {
           source_pool_count: 4,
           source_total_tvl: 4_000_000,
           price_sources_json: JSON.stringify([
-            { price: 0.998, tvl: 5_000_000, protocol: "curve", chain: "ethereum" },
-            { price: 0.999, tvl: 5_000_000, protocol: "uniswap", chain: "ethereum" },
+            { price: 0.998, tvl: 5_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+            { price: 0.999, tvl: 5_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
           ]),
         },
       ];
@@ -2024,8 +2024,8 @@ describe("confirmPendingDepegs", () => {
             source_pool_count: 3,
             source_total_tvl: 5_000_000,
             price_sources_json: JSON.stringify([
-              { price: 0.988, tvl: 3_000_000, protocol: "curve", chain: "ethereum" },
-              { price: 0.987, tvl: 2_000_000, protocol: "uniswap", chain: "ethereum" },
+              { price: 0.988, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.987, tvl: 2_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
             ]),
           },
         ],

--- a/worker/src/cron/__tests__/detect-depegs.test.ts
+++ b/worker/src/cron/__tests__/detect-depegs.test.ts
@@ -407,8 +407,8 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "curve", chain: "ethereum", price: 0.55, tvl: 3_000_000 },
-            { protocol: "uniswap", chain: "ethereum", price: 0.551, tvl: 2_000_000 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.55, tvl: 3_000_000 },
+            { protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum", price: 0.551, tvl: 2_000_000 },
           ]),
           updated_at: now - 60,
         }],
@@ -961,8 +961,8 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "curve", chain: "ethereum", price: 0.994, tvl: 2_000_000 },
-            { protocol: "uniswap", chain: "ethereum", price: 0.9945, tvl: 2_000_000 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.994, tvl: 2_000_000 },
+            { protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum", price: 0.9945, tvl: 2_000_000 },
           ]),
           updated_at: now - 60,
         }],
@@ -1058,9 +1058,9 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "bunni-ethereum", chain: "ethereum", price: 0.9993, tvl: 1_451_774 },
-            { protocol: "uniswap-v4-ethereum", chain: "ethereum", price: 0.31388474, tvl: 627_528 },
-            { protocol: "curve", chain: "ethereum", price: 0.111775, tvl: 64_711 },
+            { protocol: "bunni-ethereum", sourceFamily: "bunni-ethereum", chain: "ethereum", price: 0.9993, tvl: 1_451_774 },
+            { protocol: "uniswap-v4-ethereum", sourceFamily: "uniswap-v4-ethereum", chain: "ethereum", price: 0.31388474, tvl: 627_528 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.111775, tvl: 64_711 },
           ]),
           updated_at: now - 60,
         }],
@@ -1118,9 +1118,9 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "fluid", chain: "ethereum", price: 0.9997, tvl: 900_000 },
-            { protocol: "balancer", chain: "ethereum", price: 1.0001, tvl: 700_000 },
-            { protocol: "curve", chain: "ethereum", price: 0.9999, tvl: 300_000 },
+            { protocol: "fluid", sourceFamily: "fluid", chain: "ethereum", price: 0.9997, tvl: 900_000 },
+            { protocol: "balancer", sourceFamily: "balancer", chain: "ethereum", price: 1.0001, tvl: 700_000 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.9999, tvl: 300_000 },
           ]),
           updated_at: now - 60,
         }],
@@ -1178,9 +1178,9 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "curve", chain: "ethereum", price: 0.9438, tvl: 11_000_000 },
-            { protocol: "pancakeswap", chain: "bsc", price: 0.9461, tvl: 5_000_000 },
-            { protocol: "uniswap-v4", chain: "ethereum", price: 0.9442, tvl: 3_000_000 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.9438, tvl: 11_000_000 },
+            { protocol: "pancakeswap", sourceFamily: "pancakeswap", chain: "bsc", price: 0.9461, tvl: 5_000_000 },
+            { protocol: "uniswap-v4", sourceFamily: "uniswap-v4", chain: "ethereum", price: 0.9442, tvl: 3_000_000 },
           ]),
           updated_at: now - 60,
         }],
@@ -1230,9 +1230,9 @@ describe("detectDepegEvents", () => {
         rows: [{
           stablecoin_id: "usdt-tether",
           price_sources_json: JSON.stringify([
-            { protocol: "bunni-ethereum", chain: "ethereum", price: 0.9993, tvl: 1_451_774 },
-            { protocol: "uniswap-v4-ethereum", chain: "ethereum", price: 0.31388474, tvl: 627_528 },
-            { protocol: "curve", chain: "ethereum", price: 0.111775, tvl: 64_711 },
+            { protocol: "bunni-ethereum", sourceFamily: "bunni-ethereum", chain: "ethereum", price: 0.9993, tvl: 1_451_774 },
+            { protocol: "uniswap-v4-ethereum", sourceFamily: "uniswap-v4-ethereum", chain: "ethereum", price: 0.31388474, tvl: 627_528 },
+            { protocol: "curve", sourceFamily: "curve", chain: "ethereum", price: 0.111775, tvl: 64_711 },
           ]),
           updated_at: now - 60,
         }],

--- a/worker/src/cron/__tests__/dex-liquidity-price-bridge.test.ts
+++ b/worker/src/cron/__tests__/dex-liquidity-price-bridge.test.ts
@@ -11,8 +11,8 @@ describe("loadDexPriceSources", () => {
             {
               stablecoin_id: "usdc",
               price_sources_json: JSON.stringify([
-                { protocol: "fluid", chain: "ethereum", price: 0.9998, tvl: 500000 },
-                { protocol: "balancer", chain: "ethereum", price: 1.0001, tvl: 800000 },
+                { protocol: "fluid", sourceFamily: "fluid", chain: "ethereum", price: 0.9998, tvl: 500000 },
+                { protocol: "balancer", sourceFamily: "balancer", chain: "ethereum", price: 1.0001, tvl: 800000 },
               ]),
               updated_at: Math.floor(Date.now() / 1000),
             },
@@ -88,7 +88,7 @@ describe("loadDexPriceSources", () => {
             {
               stablecoin_id: "usdc",
               price_sources_json: JSON.stringify([
-                { protocol: "fluid", chain: "ethereum", price: 0.9998, tvl: 500000 },
+                { protocol: "fluid", sourceFamily: "fluid", chain: "ethereum", price: 0.9998, tvl: 500000 },
               ]),
               updated_at: updatedAt,
             },

--- a/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   accumulateGlobalAggregate,
+  aggregateProtocolSources,
   classifyCoverage,
   collapseDuplicateObservations,
   filterRetainedPools,
@@ -184,6 +185,22 @@ describe("classifyCoverage", () => {
 
     expect(coverageClass).toBe("mixed");
     expect(coverageConfidence).toBeCloseTo(0.61, 6);
+  });
+});
+
+describe("aggregateProtocolSources", () => {
+  it("preserves source family on protocol-source rows for depeg corroboration", () => {
+    const aggregated = aggregateProtocolSources([
+      makeObs({ protocol: "curve", price: 0.99, tvl: 1_000_000, sourceFamily: "dl" }),
+      makeObs({ protocol: "curve", price: 0.98, tvl: 2_000_000, sourceFamily: "gecko_terminal" }),
+      makeObs({ protocol: "uniswap", price: 0.97, tvl: 3_000_000, sourceFamily: "gecko_terminal" }),
+    ]);
+
+    expect(aggregated).toEqual([
+      expect.objectContaining({ protocol: "uniswap", sourceFamily: "gecko_terminal", tvl: 3_000_000 }),
+      expect.objectContaining({ protocol: "curve", sourceFamily: "gecko_terminal", tvl: 2_000_000 }),
+      expect.objectContaining({ protocol: "curve", sourceFamily: "dl", tvl: 1_000_000 }),
+    ]);
   });
 });
 

--- a/worker/src/cron/dex-liquidity/scoring-helpers.ts
+++ b/worker/src/cron/dex-liquidity/scoring-helpers.ts
@@ -32,6 +32,11 @@ const POOL_VOL_TO_TVL_RATIO_MAX = 50;
 const LARGE_POOL_TVL_MIN_USD = 100_000_000;
 const LARGE_POOL_MIN_VOLUME_USD = 50_000;
 
+function normalizeSourceFamily(value: string | null | undefined): string | undefined {
+  const normalized = (value ?? "").trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 export function rebuildMetricsFromPools(pools: LiquidityMetrics["topPools"]) {
   const protocolTvl: Record<string, number> = {};
   const chainTvl: Record<string, number> = {};
@@ -472,15 +477,19 @@ export function collapseDuplicateObservations(
 
 export function aggregateProtocolSources(
   observations: DexPriceObs[],
-): Array<{ protocol: string; chain: string; price: number; tvl: number }> {
-  const byProtocol = new Map<string, DexPriceObs[]>();
+): Array<{ protocol: string; chain: string; price: number; tvl: number; sourceFamily?: string }> {
+  const byProtocolFamily = new Map<string, DexPriceObs[]>();
   for (const observation of observations) {
-    const existing = byProtocol.get(observation.protocol) ?? [];
+    const sourceFamily = normalizeSourceFamily(observation.sourceFamily);
+    const key = `${observation.protocol}:${sourceFamily ?? "unknown"}`;
+    const existing = byProtocolFamily.get(key) ?? [];
     existing.push(observation);
-    byProtocol.set(observation.protocol, existing);
+    byProtocolFamily.set(key, existing);
   }
 
-  const aggregated = Array.from(byProtocol.entries(), ([protocol, protocolObs]) => {
+  const aggregated = Array.from(byProtocolFamily.values(), (protocolObs) => {
+    const protocol = protocolObs[0]?.protocol ?? "unknown";
+    const sourceFamily = normalizeSourceFamily(protocolObs[0]?.sourceFamily);
     const totalTvl = protocolObs.reduce((sum, observation) => sum + observation.tvl, 0);
 
     const chains = [...new Set(protocolObs.map((observation) => observation.chain))];
@@ -489,6 +498,7 @@ export function aggregateProtocolSources(
       chain: chains.length === 1 ? chains[0] : "multi",
       price: tvlWeightedMedian(protocolObs),
       tvl: Math.round(totalTvl),
+      ...(sourceFamily != null ? { sourceFamily } : {}),
     };
   });
 

--- a/worker/src/lib/__tests__/depeg-helpers.test.ts
+++ b/worker/src/lib/__tests__/depeg-helpers.test.ts
@@ -4,7 +4,12 @@ import {
   hasFreshMultiSourcePrimaryAgreement,
   isAuthoritativeDepegPegReference,
 } from "../depeg-trust-policy";
-import { buildInsertDepegEventStmt, rowToDepegEvent, type DepegRow } from "../depeg-helpers";
+import {
+  buildInsertDepegEventStmt,
+  collectDexProtocolCorroborations,
+  rowToDepegEvent,
+  type DepegRow,
+} from "../depeg-helpers";
 
 describe("classifyPrimaryDepegTrust", () => {
   const nowSec = 1_700_000_000;
@@ -252,5 +257,39 @@ describe("buildInsertDepegEventStmt + rowToDepegEvent provenance", () => {
     expect(() => rowToDepegEvent({ ...baseDepegRow, source: "manual" })).toThrow(
       '[depeg-helpers] Invalid source "manual" for event 1',
     );
+  });
+});
+
+describe("collectDexProtocolCorroborations", () => {
+  it("counts DEX corroboration by source family instead of protocol labels", () => {
+    const groups = collectDexProtocolCorroborations(
+      [
+        { protocol: "curve", chain: "ethereum", price: 0.96, tvl: 2_000_000, updatedAt: 1, sourceFamily: "poisoned-provider" },
+        { protocol: "uniswap", chain: "ethereum", price: 0.955, tvl: 2_000_000, updatedAt: 1, sourceFamily: "poisoned-provider" },
+        { protocol: "balancer", chain: "ethereum", price: 0.958, tvl: 2_000_000, updatedAt: 1, sourceFamily: "independent-provider" },
+      ],
+      1,
+      200,
+      "below",
+      "confirm",
+    );
+
+    expect(groups.map((group) => group.key).sort()).toEqual(["independent-provider", "poisoned-provider"]);
+  });
+
+  it("does not treat source-family-free legacy protocol rows as independent", () => {
+    const groups = collectDexProtocolCorroborations(
+      [
+        { protocol: "curve", chain: "ethereum", price: 0.96, tvl: 2_000_000, updatedAt: 1 },
+        { protocol: "uniswap", chain: "ethereum", price: 0.955, tvl: 2_000_000, updatedAt: 1 },
+      ],
+      1,
+      200,
+      "below",
+      "confirm",
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.key).toBe("unknown");
   });
 });

--- a/worker/src/lib/depeg-helpers.ts
+++ b/worker/src/lib/depeg-helpers.ts
@@ -188,8 +188,8 @@ function normalizeDexGroupPart(value: string | null | undefined, fallback: strin
   return normalized.length > 0 ? normalized : fallback;
 }
 
-export function dexProtocolGroupKey(source: Pick<DexPoolSource, "protocol" | "chain">): string {
-  return normalizeDexGroupPart(source.protocol, normalizeDexGroupPart(source.chain, "unknown"));
+export function dexProtocolGroupKey(source: Pick<DexPoolSource, "protocol" | "chain" | "sourceFamily">): string {
+  return normalizeDexGroupPart(source.sourceFamily, "unknown");
 }
 
 export function dexPoolIndependentGroupKey(


### PR DESCRIPTION
### Motivation
- Prevent a single/poisoned DEX data family from satisfying the independent-DEX corroboration gate by ensuring corroboration is counted by provider family, not by protocol label.

### Description
- Change DEX corroboration grouping to use `sourceFamily` as the group key by updating `dexProtocolGroupKey()` to prefer `sourceFamily` over protocol/chain. (`worker/src/lib/depeg-helpers.ts`).
- Make protocol-source aggregation preserve and emit `sourceFamily` and group by protocol+sourceFamily so `price_sources_json` retains provider provenance for later corroboration decisions. (`worker/src/cron/dex-liquidity/scoring-helpers.ts`).
- Add regression tests that (a) verify `collectDexProtocolCorroborations()` counts independent confirmations by `sourceFamily` and collapses legacy/no-family rows into `unknown`, and (b) assert `aggregateProtocolSources()` preserves `sourceFamily` in aggregated rows. (tests updated/added in `worker/src/lib/__tests__/depeg-helpers.test.ts` and `worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts`).
- Update multiple depeg/cron tests fixtures to include explicit `sourceFamily` in `price_sources_json` inputs so behavior remains deterministic.

### Testing
- TypeScript compile check: `cd worker && npx tsc --noEmit` — succeeded.
- Targeted unit test runs with `vitest` were executed: `worker/src/lib/__tests__/depeg-helpers.test.ts`, `worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts`, `worker/src/cron/__tests__/dex-liquidity-price-bridge.test.ts`, `worker/src/cron/__tests__/detect-depegs.test.ts`, and `worker/src/cron/__tests__/confirm-pending-depegs.test.ts` were run in various combinations during development and all targeted suites passed after the change. (Final verification runs reported the updated suites passing.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35205f871c8332a28dbb5bab4caf6d)