### PR TITLE
Harden Morpho yield asset matching

### DIFF
--- a/worker/src/cron/__tests__/yield-morpho-source.test.ts
+++ b/worker/src/cron/__tests__/yield-morpho-source.test.ts
@@ -19,7 +19,10 @@ describe("fetchMorphoVaultSources", () => {
             items: [{
               address: "0x9eF4cb75FeD5b3913219E881E0FF0b10a6761CF3",
               name: "Gauntlet USDC Prime",
-              asset: { symbol: "USDC" },
+              asset: {
+                symbol: "USDC",
+                address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+              },
               chain: { id: 1 },
               state: { netApy: 0.02968, totalAssetsUsd: 142_917_322, fee: 0 },
             }],
@@ -83,14 +86,20 @@ describe("fetchMorphoVaultSources", () => {
             items: [
               {
                 name: "Missing address",
-                asset: { symbol: "USDC" },
+                asset: {
+                  symbol: "USDC",
+                  address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                },
                 chain: { id: 1 },
                 state: { netApy: 0.03, totalAssetsUsd: 1_000_000, fee: 0 },
               },
               {
                 address: "0x9eF4cb75FeD5b3913219E881E0FF0b10a6761CF3",
                 name: "Gauntlet USDC Prime",
-                asset: { symbol: "USDC" },
+                asset: {
+                  symbol: "USDC",
+                  address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                },
                 chain: { id: 1 },
                 state: { netApy: 0.03, totalAssetsUsd: 1_000_000, fee: 0 },
               },
@@ -103,6 +112,40 @@ describe("fetchMorphoVaultSources", () => {
     const results = await fetchMorphoVaultSources();
     expect(results).toHaveLength(1);
     expect(results[0].symbol).toBe("USDC");
+  });
+
+  it("skips vaults whose asset address is missing or not tracked", async () => {
+    mockFetch([{
+      match: "api.morpho.org",
+      body: {
+        data: {
+          vaults: {
+            items: [
+              {
+                address: "0xabc",
+                name: "Missing Asset Address",
+                asset: { symbol: "USDC" },
+                chain: { id: 1 },
+                state: { netApy: 0.03, totalAssetsUsd: 1_000_000, fee: 0 },
+              },
+              {
+                address: "0xdef",
+                name: "Spoofed Asset Address",
+                asset: {
+                  symbol: "USDC",
+                  address: "0xdead000000000000000000000000000000000000",
+                },
+                chain: { id: 1 },
+                state: { netApy: 0.42, totalAssetsUsd: 1_000_000, fee: 0 },
+              },
+            ],
+          },
+        },
+      },
+    }]);
+
+    const results = await fetchMorphoVaultSources();
+    expect(results).toEqual([]);
   });
 
   it("uses tracked chain/address identity before returned symbols", async () => {

--- a/worker/src/cron/yield-sync/sources-optional-protocols-supplemental.ts
+++ b/worker/src/cron/yield-sync/sources-optional-protocols-supplemental.ts
@@ -103,9 +103,7 @@ function resolveMorphoTrackedAsset(
     if (byAddress) return byAddress;
   }
 
-  const symbol = asset.symbol.trim();
-  const meta = ACTIVE_STABLECOINS.find((entry) => entry.symbol.toLowerCase() === symbol.toLowerCase());
-  return meta ? { stablecoinId: meta.id, symbol: meta.symbol } : null;
+  return null;
 }
 
 function isSanePendleExpiry(expiry: string, nowMs: number): boolean {


### PR DESCRIPTION
### Motivation
- Prevent provider-derived symbol-only resolution that could pre-resolve spoofed or ambiguous Morpho vault assets and bypass central identity checks. 
- Ensure supplemental Morpho yield rows are only assigned a `stablecoinId` when the asset resolves to a tracked chain/address mapping. 
- Keep valid tracked-address matching intact while removing the unsafe fallback path. 

### Description
- Remove the symbol-only fallback from `resolveMorphoTrackedAsset` so it returns a tracked `stablecoinId` only when `assetsByChainAddress` matches the vault asset address (file: `worker/src/cron/yield-sync/sources-optional-protocols-supplemental.ts`).
- Update the Morpho unit fixture to include a tracked `asset.address` for the valid case and add a new regression test that asserts vaults with missing or untracked asset addresses are skipped (file: `worker/src/cron/__tests__/yield-morpho-source.test.ts`).
- Preserve the existing address-based matching path used by `fetchMorphoVaultSources` so legitimate Morpho candidates continue to be emitted when the chain/address identity is known. 

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/yield-morpho-source.test.ts` and the suite passed. 
- Ran TypeScript check with `cd worker && npx tsc --noEmit` and the compile check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351ec6f11c8332b169bbf78d4fb04c)