### PR TITLE
fix(digest): keep open depegs authoritative and stop using cached price as recovery filter

### DIFF
--- a/docs/digest-pipeline.md
+++ b/docs/digest-pipeline.md
@@ -41,7 +41,7 @@ The cron assembles a `DigestInputData` object from the collector set below befor
 |----------|--------|-------------|
 | Market metrics | stablecoins cache | Total mcap, 7d delta, biggest supply mover (>$1M), cache age |
 | Editorial candidates | derived from all collected signals | Pre-ranked lead candidates with impact, novelty, confidence, artifact risk, and suppression reasons |
-| Depeg events | `depeg_events` table + current `stablecoins` cache price | Active count, top 8 by critical severity then absolute current impact (\|live bps\| × mcap), active age/chronic suppression with critical-depeg override, historical peak context, resolved depegs by absolute impact |
+| Depeg events | `depeg_events` table + current `stablecoins` cache price as display context | Active count and active depeg inclusion follow open `depeg_events` rows (the canonical detector closes recovered events); top 8 are ranked by critical severity then recorded event impact (\|event bps\| × mcap), with cache price shown only as supplemental context, active age/chronic suppression with critical-depeg override, historical peak context, and resolved depegs by absolute impact |
 | Stability Index | `stability_index_samples` + `stability_index` | Current PSI from latest 15-min sample, yesterday's from daily table |
 | Blacklist activity | `blacklist_events` (rolling last 24h) | Event count, total USD affected; threshold: ≥2 events OR ≥$10M single; zero-value bursts are artifact-risk candidates |
 | Supply velocity | top 10 coins by mcap | 1d vs 7d changes; signals: "reversed", "accelerating", "decelerating" with material daily/weekly thresholds |

--- a/worker/src/cron/__tests__/daily-digest.test.ts
+++ b/worker/src/cron/__tests__/daily-digest.test.ts
@@ -1760,7 +1760,7 @@ describe("collectActiveDepegs", () => {
     expect(result.value.topDepegs[0].suppressReason).toBeUndefined();
   });
 
-  it("uses the live stablecoins-cache price instead of the open event peak", async () => {
+  it("keeps the open event peak as authoritative while showing cache price as context", async () => {
     const nowSec = Math.floor(Date.now() / 1000);
     const db = mockD1([
       {
@@ -1785,7 +1785,7 @@ describe("collectActiveDepegs", () => {
     expect(result.value.activeDepegCount).toBe(1);
     expect(result.value.topDepegs[0]).toMatchObject({
       symbol: "USDC",
-      bps: -100,
+      bps: -5568,
       peakBps: -5568,
       currentPriceUsd: 0.99,
       peakPriceUsd: 0.443,
@@ -1833,7 +1833,7 @@ describe("collectActiveDepegs", () => {
     expect(result.value.topDepegs.some((depeg) => depeg.stablecoinId === "usr-resolv")).toBe(false);
   });
 
-  it("does not keep an active depeg candidate when fresh cache price recovered", async () => {
+  it("keeps an open depeg event even when the cache price appears recovered", async () => {
     const nowSec = Math.floor(Date.now() / 1000);
     const db = mockD1([
       {
@@ -1855,8 +1855,16 @@ describe("collectActiveDepegs", () => {
 
     const result = await collectActiveDepegs(makeCollectorCtx(db));
 
-    expect(result.value.activeDepegCount).toBe(0);
-    expect(result.value.topDepegs).toEqual([]);
+    expect(result.value.activeDepegCount).toBe(1);
+    expect(result.value.topDepegs[0]).toMatchObject({
+      stablecoinId: "usdt-tether",
+      symbol: "USDT",
+      bps: -500,
+      direction: "below",
+      peakBps: -500,
+      peakPriceUsd: 0.95,
+      currentPriceUsd: 0.9975,
+    });
   });
 });
 

--- a/worker/src/cron/daily-digest/collectors-market.ts
+++ b/worker/src/cron/daily-digest/collectors-market.ts
@@ -6,9 +6,7 @@ import {
   getDepegMarketImpactScore,
   isCriticalDepegRisk,
 } from "@shared/lib/digest-risk";
-import { getDepegThresholdBps } from "../../lib/constants";
 import { buildInClause } from "../../lib/db";
-import { deriveDepegSignal } from "../../lib/depeg-signals";
 import { computeFlowIntensity, computeGaugeScore, getGaugeBand, detectFlightToQuality } from "../../lib/mint-burn-scoring";
 import { isCanonicalMintBurnPair } from "../../lib/mint-burn-canonical-chain";
 import { SECONDS } from "../../lib/time-constants";
@@ -76,16 +74,10 @@ export async function collectActiveDepegs(
       const livePrice = typeof asset?.price === "number" && Number.isFinite(asset.price) && asset.price > 0
         ? asset.price
         : null;
-      const pegReference = typeof row.peg_reference === "number" && Number.isFinite(row.peg_reference) && row.peg_reference > 0
-        ? row.peg_reference
-        : 1;
-      const liveSignal = livePrice != null ? deriveDepegSignal(livePrice, pegReference) : null;
-      const threshold = getDepegThresholdBps(row.peg_type ?? asset?.pegType);
-      if (liveSignal && (liveSignal.absBps < threshold || liveSignal.direction !== row.direction)) {
-        return [];
-      }
-      const bps = liveSignal?.bps ?? row.peak_deviation_bps;
-      const direction = liveSignal?.direction ?? row.direction;
+      const direction = row.direction;
+      const bps = direction === "below"
+        ? -Math.abs(row.peak_deviation_bps)
+        : Math.abs(row.peak_deviation_bps);
       const impactScore = getDepegMarketImpactScore(bps, mcapUsd);
       return {
         stablecoinId: row.stablecoin_id,


### PR DESCRIPTION
### Motivation
- The active-depeg collector was using a lenient `stablecoins` cache price as a live signal to filter open `depeg_events`, allowing stale or poisoned cached prices to hide otherwise-open critical depegs. 
- The safe behavior is to treat the canonical detector (`depeg_events` rows) as authoritative for active inclusion and severity, and use cached provider prices only as supplemental display context.

### Description
- Stop deriving a `liveSignal` from the cached asset price and remove the threshold/direction gating that returned `[]` for open `depeg_events` when the cache looked recovered, by restoring event `peak_deviation_bps`/`direction` as the authoritative values in `collectActiveDepegs` (`worker/src/cron/daily-digest/collectors-market.ts`).
- Keep the stablecoins-cache `price` available as `currentPriceUsd` in the returned depeg entries so the digest can display the cache price as context without using it to suppress or rewrite event severity.
- Update focused unit tests in `worker/src/cron/__tests__/daily-digest.test.ts` to assert that open `depeg_events` remain counted and that the cache price is shown only as contextual `currentPriceUsd`.
- Clarify the digest pipeline doc in `docs/digest-pipeline.md` to state that active depeg inclusion/counting follows open `depeg_events` and cache price is display context only.

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/daily-digest.test.ts` and all tests passed after the changes. 
- Compiled the worker types with `cd worker && npx tsc --noEmit` with no errors. 
- Ran cron validations `npm run check:cron-sync` and `npm run check:cron-connections`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35377bc48c8332bcaacd66cca21da5)