### PR TITLE
fix(pricing): enforce low-volume CoinGecko freshness

### DIFF
--- a/worker/src/cron/__tests__/supplemental-assets.test.ts
+++ b/worker/src/cron/__tests__/supplemental-assets.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StablecoinMeta } from "@shared/types/core";
 import {
   computeExcludedBalanceAdjustedSupplyRaw,
+  resolveLowVolumeCoinGeckoPrice,
   resolveSupplementalPrice,
   selectSingleOnChainSupplyContract,
   selectSupplementalOnChainSupplyContract,
@@ -149,6 +150,53 @@ describe("resolveSupplementalPrice", () => {
       observedAt: nowSec - 60,
       observedAtMode: "upstream",
     });
+  });
+
+  it("accepts low-volume CoinGecko rows inside the relaxed freshness window", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    expect(resolveLowVolumeCoinGeckoPrice(
+      {
+        vcred: {
+          usd: 0.42,
+          usd_market_cap: 1_000_000,
+          last_updated_at: nowSec - 6 * 24 * 60 * 60,
+        },
+      },
+      "vcred",
+    )).toEqual({
+      price: 0.42,
+      source: "coingecko-low-volume",
+      observedAt: nowSec - 6 * 24 * 60 * 60,
+      observedAtMode: "upstream",
+    });
+  });
+
+  it("rejects low-volume CoinGecko rows outside the relaxed freshness window", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    expect(resolveLowVolumeCoinGeckoPrice(
+      {
+        vcred: {
+          usd: 0.42,
+          usd_market_cap: 1_000_000,
+          last_updated_at: nowSec - 8 * 24 * 60 * 60,
+        },
+      },
+      "vcred",
+    )).toBeNull();
+  });
+
+  it("rejects low-volume CoinGecko rows without upstream timestamps", () => {
+    expect(resolveLowVolumeCoinGeckoPrice(
+      {
+        vcred: {
+          usd: 0.42,
+          usd_market_cap: 1_000_000,
+        },
+      },
+      "vcred",
+    )).toBeNull();
   });
 });
 

--- a/worker/src/cron/sync-stablecoins/supplemental-assets.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets.ts
@@ -12,7 +12,7 @@ import { fetchGoldTokens } from "./supplemental-assets/gold";
 import { fetchSilverTokens } from "./supplemental-assets/silver";
 
 export type { CoinGeckoMcapData } from "./supplemental-assets/shared";
-export { resolveSupplementalPrice } from "./supplemental-assets/shared";
+export { resolveLowVolumeCoinGeckoPrice, resolveSupplementalPrice } from "./supplemental-assets/shared";
 export {
   computeExcludedBalanceAdjustedSupplyRaw,
   selectSingleOnChainSupplyContract,

--- a/worker/src/cron/sync-stablecoins/supplemental-assets/fiat-cg.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets/fiat-cg.ts
@@ -9,6 +9,7 @@ import {
   fetchSupplementalPriceData,
   getSupplementalChainLabels,
   pegTypeKey,
+  resolveLowVolumeCoinGeckoPrice,
   resolveSupplementalPrice,
   toPositiveFiniteNumber,
   type CoinGeckoMcapData,
@@ -53,18 +54,8 @@ export async function fetchFiatCoinGeckoTokens(
         // `priceSource: missing`. Diagnosis pattern: detailProvider="coingecko"
         // with llamaId=null + low volume → upstream last_updated_at exceeds 15min.
         let priceResolution = resolveSupplementalPrice(priceData, cgData, meta.geckoId);
-        if (!priceResolution && meta.geckoId) {
-          const cgEntry = cgData[meta.geckoId];
-          const cgPrice = toPositiveFiniteNumber(cgEntry?.usd);
-          if (cgPrice != null) {
-            const observedAt = toPositiveFiniteNumber(cgEntry?.last_updated_at) ?? null;
-            priceResolution = {
-              price: cgPrice,
-              source: "coingecko-low-volume",
-              observedAt,
-              observedAtMode: observedAt != null ? "upstream" : "local_fetch",
-            };
-          }
+        if (!priceResolution) {
+          priceResolution = resolveLowVolumeCoinGeckoPrice(cgData, meta.geckoId);
         }
         const pegReferencePrice = toPositiveFiniteNumber(fxFallbackRates?.[pKey]);
         // USD is the base currency; fxFallbackRates omits peggedUSD. Default to 1.0 for

--- a/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
@@ -5,6 +5,7 @@ import { fetchWithRetry } from "../../../lib/fetch-retry";
 import { cancelResponseBodyQuietly } from "../../../lib/response-body";
 import { CIRCUIT_SOURCE, DEFILLAMA_COINS } from "../../../lib/constants";
 import { recordOutcomeSafe, shouldAttemptFetch } from "../../../lib/circuit-breaker";
+import { validatePricingSourceFreshness } from "../../../lib/pricing-source-freshness";
 import { DefiLlamaCoinsPriceSchema, type DefiLlamaCoinsPriceResponse } from "../../../lib/upstream-schemas";
 import type { PeggedAsset } from "../enrich-prices";
 
@@ -36,6 +37,33 @@ function isFreshSupplementalPrice(source: SupplementalPriceResolution["source"],
   const maxTrustedAgeSec = getPricingSourceRegistryEntry(source)?.maxTrustedAgeSec ?? 15 * 60;
   const nowSec = Math.floor(Date.now() / 1000);
   return nowSec - observedAt <= maxTrustedAgeSec;
+}
+
+export function resolveLowVolumeCoinGeckoPrice(
+  cgData: CoinGeckoMcapData,
+  geckoId?: string,
+): SupplementalPriceResolution | null {
+  if (!geckoId) return null;
+
+  const cgEntry = cgData[geckoId];
+  const cgPrice = toPositiveFiniteNumber(cgEntry?.usd);
+  if (cgPrice == null) return null;
+
+  const observedAt = toPositiveFiniteNumber(cgEntry?.last_updated_at) ?? null;
+  const freshness = validatePricingSourceFreshness({
+    source: "coingecko-low-volume",
+    observedAt,
+    observedAtMode: observedAt != null ? "upstream" : "local_fetch",
+    requireObservedAt: true,
+  });
+  if (!freshness.accepted) return null;
+
+  return {
+    price: cgPrice,
+    source: "coingecko-low-volume",
+    observedAt: freshness.observedAt,
+    observedAtMode: freshness.observedAtMode,
+  };
 }
 
 export function resolveSupplementalPrice(


### PR DESCRIPTION
### Motivation
- A low-volume CoinGecko fallback path constructed `coingecko-low-volume` price rows after the strict resolver failed but did not apply the pricing-source freshness gate, allowing stale or timestamp-less CoinGecko rows to be published.
- The intent is to keep a relaxed seven-day lane for legitimate slow-updating tickers while preserving the registry-enforced freshness checks and rejecting entries that lack a valid upstream timestamp.

### Description
- Add `resolveLowVolumeCoinGeckoPrice()` in `worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts` which uses `validatePricingSourceFreshness()` for `source: "coingecko-low-volume"` and requires an upstream timestamp inside the configured freshness window before returning a resolution.
- Replace the manual inline construction of `coingecko-low-volume` in `fetchFiatCoinGeckoTokens()` (`worker/src/cron/sync-stablecoins/supplemental-assets/fiat-cg.ts`) to route through the shared resolver so the registered 7-day TTL is enforced.
- Export the new resolver from `worker/src/cron/sync-stablecoins/supplemental-assets.ts` so callers use the validated path.
- Add regression tests in `worker/src/cron/__tests__/supplemental-assets.test.ts` covering an in-window low-volume row, an out-of-window stale row, and a missing-timestamp row.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/cron/__tests__/supplemental-assets.test.ts --reporter=verbose`, and all tests passed (new test cases included).
- Verified TypeScript: `cd worker && npx tsc --noEmit` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351afdd990833295563a138dac5c2f)