### PR TITLE
Escape Telegram yield source HTML

### DIFF
--- a/worker/src/api/__tests__/telegram-status-flow.test.ts
+++ b/worker/src/api/__tests__/telegram-status-flow.test.ts
@@ -52,3 +52,26 @@ describe("buildStatusMessage 24h mint/burn flow line (C122)", () => {
     expect(msg).not.toContain("Flow 24h");
   });
 });
+
+describe("buildStatusMessage Telegram HTML escaping", () => {
+  it("escapes provider-controlled yield source text", () => {
+    const msg = buildStatusMessage(
+      "USDC",
+      baseStatus({
+        yield: {
+          currentApy: 4.8,
+          apy30d: 4.2,
+          source: 'Morpho: Safe Vault <a href="https://attacker.example/phish">CLAIM</a> & <b>verified</b>',
+          pharosYieldScore: 42,
+          updatedAt: Math.floor(Date.now() / 1000),
+        },
+      }),
+    );
+
+    expect(msg).toContain(
+      "Morpho: Safe Vault &lt;a href=&quot;https://attacker.example/phish&quot;&gt;CLAIM&lt;/a&gt; &amp; &lt;b&gt;verified&lt;/b&gt;",
+    );
+    expect(msg).not.toContain('<a href="https://attacker.example/phish">');
+    expect(msg).not.toContain("<b>verified</b>");
+  });
+});

--- a/worker/src/api/__tests__/telegram-webhook-insights.test.ts
+++ b/worker/src/api/__tests__/telegram-webhook-insights.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockD1 } from "../../test-helpers/__shared/mock-d1";
 import { createSqliteD1 } from "../../test-helpers/sqlite-d1";
-import { buildBriefMessage, buildTopMessage } from "../telegram-webhook-insights";
+import { buildBriefMessage, buildCoverageMessage, buildTopMessage } from "../telegram-webhook-insights";
+import type { StatusForCoin } from "../telegram-webhook-status";
 
 describe("buildBriefMessage", () => {
   afterEach(() => {
@@ -156,5 +157,37 @@ describe("buildTopMessage", () => {
       "Did you mean /top safety?\nUsage: /top depeg|dews|yield|liquidity|chains|safety",
     );
     expect(db.getHistory()).toEqual([]);
+  });
+});
+
+describe("buildCoverageMessage", () => {
+  it("escapes provider-controlled yield source text", () => {
+    const status: StatusForCoin = {
+      stablecoinId: "usdc-circle",
+      priceUsd: 1,
+      priceUpdatedAt: null,
+      supplyUsd: null,
+      stablecoinsUpdatedAt: null,
+      dews: null,
+      safety: null,
+      liquidity: null,
+      yield: {
+        currentApy: 4.8,
+        apy30d: 4.2,
+        source: 'Pendle: PT-USDC <a href="https://attacker.example/phish">CLAIM</a> & <i>boost</i>',
+        pharosYieldScore: 42,
+        updatedAt: Math.floor(Date.now() / 1000),
+      },
+      flow: null,
+      depeg: { status: "stable" },
+    };
+
+    const message = buildCoverageMessage("USDC", status);
+
+    expect(message).toContain(
+      "Pendle: PT-USDC &lt;a href=&quot;https://attacker.example/phish&quot;&gt;CLAIM&lt;/a&gt; &amp; &lt;i&gt;boost&lt;/i&gt;",
+    );
+    expect(message).not.toContain('<a href="https://attacker.example/phish">');
+    expect(message).not.toContain("<i>boost</i>");
   });
 });

--- a/worker/src/api/telegram-webhook-insights.ts
+++ b/worker/src/api/telegram-webhook-insights.ts
@@ -312,7 +312,7 @@ export function buildCoverageMessage(symbol: string, status: StatusForCoin): str
     `Safety: ${status.safety ? `${status.safety.grade}${status.safety.score != null ? ` (${status.safety.score})` : ""}` : "missing"}`,
     `Active depeg: ${status.depeg.status === "active" ? "yes" : "no"}`,
     `DEX liquidity: ${status.liquidity ? `score ${status.liquidity.score ?? "NR"}, TVL ${formatTelegramCompactUsd(status.liquidity.totalTvlUsd) ?? "n/a"}` : "missing"}`,
-    `Yield: ${status.yield ? `${status.yield.apy30d.toFixed(2)}% 30d at ${status.yield.source}` : "missing"}`,
+    `Yield: ${status.yield ? `${status.yield.apy30d.toFixed(2)}% 30d at ${escapeHtml(status.yield.source)}` : "missing"}`,
     `<a href="https://pharos.watch/stablecoin/${status.stablecoinId}">Open coin page</a>`,
   ];
   return lines.join("\n");

--- a/worker/src/api/telegram-webhook-messages.ts
+++ b/worker/src/api/telegram-webhook-messages.ts
@@ -493,7 +493,7 @@ export function buildStatusMessage(symbol: string, s: StatusForCoin): string {
     ? `Liquidity: ${s.liquidity.score ?? "NR"}${liquidityTvl ? `, TVL ${liquidityTvl}` : ""} (${formatAge(s.liquidity.updatedAt, nowSec)})`
     : null;
   const yieldLine = s.yield
-    ? `Yield: ${s.yield.apy30d.toFixed(2)}% 30d at ${s.yield.source}${s.yield.pharosYieldScore != null ? `, PYS ${Math.round(s.yield.pharosYieldScore)}` : ""}`
+    ? `Yield: ${s.yield.apy30d.toFixed(2)}% 30d at ${escapeHtml(s.yield.source)}${s.yield.pharosYieldScore != null ? `, PYS ${Math.round(s.yield.pharosYieldScore)}` : ""}`
     : null;
   const flowSigned = s.flow ? formatTelegramSignedCompactUsd(s.flow.netFlowUsd) : null;
   const flowLine =


### PR DESCRIPTION
### Motivation
- Prevent HTML injection in Telegram bot responses by ensuring provider-controlled `yield_source` labels are not interpolated as raw HTML in messages sent with `parse_mode: "HTML"`.
- The `/status` and `/coverage` message builders previously inserted `yield.source`/`status.yield.source` directly into HTML-formatted messages, which could allow upstream metadata to inject tags or malformed markup.
- Apply the smallest, targeted fix to preserve existing message formatting while eliminating the security regression.

### Description
- HTML-escape provider-controlled yield source text before interpolation in the status message builder by calling `escapeHtml(s.yield.source)` in `worker/src/api/telegram-webhook-messages.ts`.
- HTML-escape provider-controlled yield source text before interpolation in the coverage message builder by calling `escapeHtml(status.yield.source)` in `worker/src/api/telegram-webhook-insights.ts`.
- Add regression tests that assert malicious anchor and formatting tags in yield source strings are escaped for both `buildStatusMessage` (`worker/src/api/__tests__/telegram-status-flow.test.ts`) and `buildCoverageMessage` (`worker/src/api/__tests__/telegram-webhook-insights.test.ts`).

### Testing
- Ran the focused Vitest suites: `npx vitest run worker/src/api/__tests__/telegram-status-flow.test.ts worker/src/api/__tests__/telegram-webhook-insights.test.ts`, and both test files passed (2 files, 12 tests total).
- Ran the TypeScript build check: `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351afee0b48332b9a9450dbe3daf06)