### PR TITLE
Guard non-USD backfills against sparse price clamps

### DIFF
--- a/worker/src/api/__tests__/backfill-supply-history.test.ts
+++ b/worker/src/api/__tests__/backfill-supply-history.test.ts
@@ -79,6 +79,7 @@ describe("handleBackfillSupplyHistory", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     evmRpcMocks.resolveClosestBlockAtOrBeforeTimestamp.mockReset();
+    vi.mocked(fetchHistoricalFxRates).mockClear().mockResolvedValue({});
     vi.mocked(fetchMarketBackfillPriceSeries).mockClear().mockResolvedValue({
       prices: [{ timestamp: 1_700_000_000, price: 1.001 }],
       diagnostics: {
@@ -403,6 +404,70 @@ describe("handleBackfillSupplyHistory", () => {
       new Date(day2 * 1000).toISOString().slice(0, 10),
       expect.any(AbortSignal),
     );
+  });
+
+  it("does not clamp sparse non-USD price history outside its covered range", async () => {
+    const capturedStatements: Array<{ sql: string; args: unknown[] }> = [];
+    const beforePriceRange = Math.floor(1_699_913_600 / 86400) * 86400;
+    const afterPriceRange = Math.floor(1_700_086_400 / 86400) * 86400;
+
+    vi.mocked(fetchMarketBackfillPriceSeries).mockResolvedValue({
+      prices: [{ timestamp: 1_700_000_000, price: 2.5 }],
+      diagnostics: {
+        granularity: "daily",
+        sourcesUsed: ["coingecko"],
+        quoteMode: "usd",
+        quoteCurrency: "usd",
+        mergeReasons: [],
+        perSourceStats: [],
+        policyAdjustments: [],
+        finalPointCount: 1,
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          price: 1,
+          tokens: [
+            {
+              date: beforePriceRange,
+              circulating: { peggedEUR: 1_000 },
+            },
+            {
+              date: afterPriceRange,
+              circulating: { peggedEUR: 2_000 },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const res = await handleBackfillSupplyHistory(
+      makeDb(capturedStatements),
+      makeApiUrl("/api/backfill-supply-history?stablecoin=aeur-anchored-coins&startDay=2023-11-13&endDay=2023-11-15"),
+      true,
+      makeApiRequest("/api/backfill-supply-history?stablecoin=aeur-anchored-coins&startDay=2023-11-13&endDay=2023-11-15", {
+        adminKey: "secret",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      coinsProcessed: number;
+      rowsInserted: number;
+      errors?: string[];
+    };
+    expect(body.coinsProcessed).toBe(1);
+    expect(body.rowsInserted).toBe(0);
+    expect(body.errors).toBeUndefined();
+
+    const inserts = capturedStatements.filter((stmt) =>
+      stmt.sql.includes("INSERT OR REPLACE INTO supply_history"),
+    );
+    expect(inserts).toHaveLength(0);
+    expect(fetchMarketBackfillPriceSeries).toHaveBeenCalled();
+    expect(fetchHistoricalFxRates).not.toHaveBeenCalled();
   });
 
   it("falls back to on-chain totalSupply when CoinGecko market caps are all zero", async () => {

--- a/worker/src/api/backfill-supply-history.ts
+++ b/worker/src/api/backfill-supply-history.ts
@@ -955,6 +955,9 @@ async function executeBackfillSupplyHistory(
       const exact = priceBySnapshotDate.get(snapshotDate);
       if (exact != null) return exact;
       if (needsConversion && historicalPrices.length > 0) {
+        const first = historicalRateSeries[0];
+        const last = historicalRateSeries[historicalRateSeries.length - 1];
+        if (snapshotDate < first.timestamp || snapshotDate > last.timestamp) return null;
         const interpolated = interpolateRateAtTimestamp(historicalRateSeries, snapshotDate);
         return interpolated && interpolated > 0 ? interpolated : null;
       }


### PR DESCRIPTION
### Motivation

- Prevent sparse or truncated non-USD historical price series from producing clamped boundary prices that poison `supply_history` during admin backfills.
- Preserve the existing emergency constant-fallback behavior (recent 7-day window) only for the explicitly empty-price-series case.

### Description

- Added a range guard in the non-USD price lookup so `findHistoricalPrice()` returns `null` for snapshot dates outside the first/last timestamp of the fetched price series instead of using the series boundary rate via `interpolateRateAtTimestamp`.
- Kept exact-day lookup and in-range linear interpolation behavior intact by only rejecting out-of-range timestamps before calling `interpolateRateAtTimestamp`.
- Added a regression test `does not clamp sparse non-USD price history outside its covered range` in `worker/src/api/__tests__/backfill-supply-history.test.ts` that simulates a 1-point CoinGecko series and asserts no out-of-range `supply_history` inserts occur and that FX fallback is not invoked when a market price series exists.
- Cleared the mocked FX fetch in the test setup so the new test can assert FX fallback behavior deterministically.

### Testing

- Ran the focused test suite with `npm exec vitest run worker/src/api/__tests__/backfill-supply-history.test.ts` and observed all tests in that file pass.
- Type-checked the worker code with `cd worker && npx tsc --noEmit` which completed successfully.
- Ran `git diff --check` to ensure no whitespace or diff errors remained and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351afcfaf48332893d4533cd38cbab)