### PR TITLE
fix(yield): normalize source deep-dive params

### DIFF
--- a/src/components/__tests__/yield-source-sheet.test.tsx
+++ b/src/components/__tests__/yield-source-sheet.test.tsx
@@ -298,6 +298,24 @@ describe("YieldSourceSheet", () => {
     expect(deepDive.getAttribute("href")).toMatch(/^\/stablecoin\/usdc\/yield\/?\?sources=alt-usdc$/);
   });
 
+  it("normalizes malformed unicode source keys in the deep-dive link", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <YieldSourceSheet
+        ranking={makeRanking("usdc", "best-usdc", "\uD800")}
+        logo={undefined}
+        riskFreeRate={0.02}
+        medianApy={0.03}
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /usdc-alt/i }));
+    const deepDive = screen.getByRole("link", { name: /Deep dive yield/i });
+    expect(deepDive.getAttribute("href")).toMatch(/^\/stablecoin\/usdc\/yield\/?\?sources=%EF%BF%BD$/);
+  });
+
   it("keeps the existing View full dossier link to the main detail page", () => {
     const onOpenChange = vi.fn();
     render(

--- a/src/components/yield-source-sheet.tsx
+++ b/src/components/yield-source-sheet.tsx
@@ -64,9 +64,10 @@ function YieldSourceSheetBody({
   const confidenceLabel = confidenceTier ? YIELD_SOURCE_CONFIDENCE_DEFINITIONS[confidenceTier]?.label ?? null : null;
   const freshness = classifyYieldSourceFreshness(ranking.sourceRisk?.sourceAgeSeconds ?? null);
   const hasAlternateSelected = selectedSourceKey !== null && selectedSourceKey !== sourceExplorer.selectedSource.sourceKey;
-  const deepDiveHref = hasAlternateSelected
-    ? `${buildStablecoinUrl(ranking.id)}yield/?sources=${encodeURIComponent(selectedSourceKey!)}`
-    : `${buildStablecoinUrl(ranking.id)}yield/`;
+  const deepDiveSearch = hasAlternateSelected
+    ? new URLSearchParams({ sources: selectedSourceKey }).toString()
+    : "";
+  const deepDiveHref = `${buildStablecoinUrl(ranking.id)}yield/${deepDiveSearch ? `?${deepDiveSearch}` : ""}`;
 
   const handleSourceClick = (sourceKey: string) => {
     setSelectedSourceKey(sourceKey);


### PR DESCRIPTION
### Motivation
- The deep-dive link construction previously used `encodeURIComponent(selectedSourceKey)` which can throw `URIError` for malformed UTF-16 (e.g. an unpaired surrogate) when `selectedSourceKey` comes from upstream data.
- The change prevents a client-side render crash when a retained alternate `sourceKey` contains malformed unicode by normalizing the query value before building the href.

### Description
- Replace direct `encodeURIComponent(selectedSourceKey)` with `new URLSearchParams({ sources: selectedSourceKey }).toString()` when composing the deep-dive query string in `src/components/yield-source-sheet.tsx`.
- Build `deepDiveHref` using the safer `deepDiveSearch` variable so malformed UTF-16 is normalized to a safe USVString representation before rendering.
- Add a regression test in `src/components/__tests__/yield-source-sheet.test.tsx` that selects an alternate with an unpaired surrogate (`"\uD800"`) and asserts the deep-dive link is encoded safely.

### Testing
- Ran the component test file with Vitest: `npx vitest run src/components/__tests__/yield-source-sheet.test.tsx`, and all tests passed (`14 passed`).
- Ran TypeScript checks: `npm run typecheck -- --pretty false`, and typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350fedc83083329090f893108974d5)