### PR TITLE
fix(timeline): keep event pagination manual

### DIFF
--- a/src/app/timeline/client.test.tsx
+++ b/src/app/timeline/client.test.tsx
@@ -25,14 +25,14 @@ type LatestEventsResult = {
   meta: null;
 };
 
-const useEventsMock = vi.fn<() => UseEventsResult>();
+const useEventsMock = vi.fn<(...args: Parameters<typeof import("@/hooks/use-events").useEvents>) => UseEventsResult>();
 const useLatestEventsMock = vi.fn<() => LatestEventsResult>();
 
 vi.mock("@/hooks/use-events", async () => {
   const actual = await vi.importActual<typeof import("@/hooks/use-events")>("@/hooks/use-events");
   return {
     ...actual,
-    useEvents: () => useEventsMock(),
+    useEvents: (...args: Parameters<typeof actual.useEvents>) => useEventsMock(...args),
     useLatestEvents: () => useLatestEventsMock(),
   };
 });
@@ -108,6 +108,17 @@ function mockEvents(events: TapeEvent[], overrides: Partial<UseEventsResult> = {
 }
 
 describe("TimelineClient", () => {
+  it("keeps timeline pagination manual on initial page load", () => {
+    mockEvents([]);
+
+    render(<TimelineClient />);
+
+    expect(useEventsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ severityFloor: "notice" }),
+      { autoLoadAll: false },
+    );
+  });
+
   it("renders the empty state when there are no events", () => {
     mockEvents([]);
     render(<TimelineClient />);

--- a/src/app/timeline/use-timeline-feed-data.ts
+++ b/src/app/timeline/use-timeline-feed-data.ts
@@ -12,10 +12,7 @@ interface UseTimelineFeedDataArgs {
   nowMs: number;
 }
 export function useTimelineFeedData({ queryParams, permalinkId, nowMs }: UseTimelineFeedDataArgs) {
-  const events = useEvents(
-    queryParams,
-    { maxAutoPages: 10 },
-  );
+  const events = useEvents(queryParams, { autoLoadAll: false });
 
   const {
     data: { events: rawEvents },


### PR DESCRIPTION
### Motivation
- A previous change passed `{ maxAutoPages: 10 }` into the timeline feed hook, which implicitly enabled `autoLoadAll` and caused public `/timeline/` visits to automatically fetch up to 10 pages of 500 events each, amplifying unauthenticated backend load and reducing shared-cache effectiveness.
- The intent of the change is to preserve the timeline's manual "Load more" / infinite-scroll behavior and avoid client-driven resource-amplification on ordinary page loads.

### Description
- Replace the timeline feed option from `maxAutoPages: 10` to an explicit `{ autoLoadAll: false }` in `src/app/timeline/use-timeline-feed-data.ts` to keep pagination manual on initial page load.
- Update the timeline client test mocking so `useEvents` preserves and verifies its call arguments and add a regression assertion that the timeline invokes `useEvents` with `{ autoLoadAll: false }` in `src/app/timeline/client.test.tsx`.
- Files changed: `src/app/timeline/use-timeline-feed-data.ts`, `src/app/timeline/client.test.tsx`.

### Testing
- Ran the focused Vitest suites: `npm -s exec vitest -- run src/app/timeline/client.test.tsx src/hooks/__tests__/use-events.test.tsx --reporter=verbose`, and all tests passed.
- Ran type-checking: `npm run typecheck`, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350febae388332bd3005616c085072)