### PR TITLE
fix: sanitize picker Telegram targets

### DIFF
--- a/src/app/screener/picker/client.test.tsx
+++ b/src/app/screener/picker/client.test.tsx
@@ -365,6 +365,52 @@ describe("SelectorClient — state machine", () => {
     expect(botLink.getAttribute("href")).toBe("https://t.me/PharosWatchBot");
   });
 
+  it("excludes unsafe snapshot tokens from the Telegram subscribe command", async () => {
+    const mod = await import("@shared/lib/selector");
+    (mod.runSelector as ReturnType<typeof vi.fn>).mockImplementationOnce((input: SelectorInput) =>
+      mockSelectorOutput({
+        input,
+        recommended: [
+          {
+            ...baseRecommendation,
+            id: "all depeg-step 100 usd-top25",
+            symbol: "$USDC",
+            profile: "treasury",
+            recommendedSource: null,
+            perInputStaleness: null,
+          },
+          {
+            ...baseRecommendation,
+            id: "safe-fallback",
+            symbol: "unsafe token",
+            name: "Safe Fallback",
+            rank: 2,
+            profile: "treasury",
+            recommendedSource: null,
+            perInputStaleness: null,
+          },
+          {
+            ...baseRecommendation,
+            id: "reserved-symbol-fallback",
+            symbol: "all",
+            name: "Reserved Symbol Fallback",
+            rank: 3,
+            profile: "treasury",
+            recommendedSource: null,
+            perInputStaleness: null,
+          },
+        ],
+      }));
+
+    setUrlSearch("p=treasury&h=6mplus&d=zero&v=custody&step=result");
+    render(<SelectorClient />);
+
+    expect(
+      await screen.findByText("/subscribe dews, depeg, safety safe-fallback, reserved-symbol-fallback"),
+    ).toBeTruthy();
+    expect(screen.queryByText(/all depeg-step 100 usd-top25/)).toBeNull();
+  });
+
   it("shows near misses even when a shortlist is present", async () => {
     const mod = await import("@shared/lib/selector");
     (mod.runSelector as ReturnType<typeof vi.fn>).mockImplementationOnce((input: SelectorInput) =>

--- a/src/app/screener/picker/result-pane.tsx
+++ b/src/app/screener/picker/result-pane.tsx
@@ -418,14 +418,51 @@ function TelegramSubscribeCommand({ command }: { command: string }) {
   );
 }
 
+const TELEGRAM_TARGET_TOKEN_PATTERN = /^[A-Za-z0-9_-]+$/;
+const TELEGRAM_RESERVED_COMMAND_TOKENS = new Set([
+  "all",
+  "dews",
+  "depeg",
+  "depeg-step",
+  "launch",
+  "reserve",
+  "safety",
+  "usd-top10",
+  "usd-top-10",
+  "usd-top25",
+  "usd-top-25",
+  "usd-top50",
+  "usd-top-50",
+  "non-usd-top10",
+  "non-usd-top-10",
+  "non-usd-top25",
+  "non-usd-top-25",
+  "non-usd-top50",
+  "non-usd-top-50",
+  "eur-top10",
+  "eur-top-10",
+  "gold-top5",
+  "gold-top-5",
+  "mcap-ge-1b",
+  "mcap-ge-100m",
+]);
+
 function buildTelegramSubscribeCommand(recommendations: readonly SelectorRecommendation[]): string {
-  const targets = Array.from(new Set(recommendations.map((rec) => telegramTargetToken(rec))));
-  return `/subscribe dews, depeg, safety ${targets.join(", ")}`;
+  const targets = Array.from(
+    new Set(recommendations.map((rec) => telegramTargetToken(rec)).filter(Boolean)),
+  );
+  return `/subscribe dews, depeg, safety ${targets.join(", ")}`.trim();
 }
 
-function telegramTargetToken(rec: SelectorRecommendation): string {
-  const symbol = rec.symbol.trim();
-  return /^[A-Za-z0-9_-]+$/.test(symbol) ? symbol : rec.id;
+function telegramTargetToken(rec: SelectorRecommendation): string | null {
+  return safeTelegramTargetToken(rec.symbol) ?? safeTelegramTargetToken(rec.id);
+}
+
+function safeTelegramTargetToken(value: string): string | null {
+  const token = value.trim();
+  if (!TELEGRAM_TARGET_TOKEN_PATTERN.test(token)) return null;
+  if (TELEGRAM_RESERVED_COMMAND_TOKENS.has(token.toLowerCase())) return null;
+  return token;
 }
 
 function NearMissesDisclosure({


### PR DESCRIPTION
### Motivation
- The Picker built a Telegram `/subscribe` command from `SelectorOutput.recommended` and used recommendation `id` as an unvalidated fallback, which allowed crafted snapshots to inject reserved Telegram tokens or separators into the generated command. 
- The repository's Telegram parser treats tokens like `all`, `depeg-step`, and preset aliases as control operators, so a malicious fallback `id` could change bot behavior when a user copies/pastes the command. 

### Description
- Add a strict token pattern and a `TELEGRAM_RESERVED_COMMAND_TOKENS` set and reject any candidate that fails the pattern or matches a reserved token. 
- Replace the previous symbol-first fallback with `safeTelegramTargetToken()` and make `telegramTargetToken()` return `null` for unsafe values so only validated tokens are included. 
- Filter out falsy/unsafe tokens before joining and trim the final `/subscribe` string to avoid trailing separators. 
- Add a regression test in `src/app/screener/picker/client.test.tsx` that exercises a crafted snapshot `id` containing reserved tokens to ensure unsafe tokens are excluded from the displayed/copyable command. 

### Testing
- Ran the Picker unit test file with `npx vitest run src/app/screener/picker/client.test.tsx` and the suite passed. 
- Ran the banned-phrase scan with `npm run check:selector-banned-phrases` and it returned `ok`. 
- Ran the TypeScript check with `npm run typecheck` and it completed with no errors. 
- Ran ESLint on the modified files with `npx eslint` and there were no warnings/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350fec628c833284e1b6bb7256ec5f)