### PR TITLE
Fix peg-rate derivation for inherited-property peg types

### DIFF
--- a/shared/lib/__tests__/peg-rates.test.ts
+++ b/shared/lib/__tests__/peg-rates.test.ts
@@ -130,6 +130,20 @@ describe("derivePegRates", () => {
     expect(result.rates.peggedBRL).toBeUndefined();
     expect(result.rates.peggedREAL).toBe(0.18);
   });
+
+  it("handles peg types that match inherited object property names", () => {
+    const result = derivePegRates([
+      asset("constructor-token", "constructor", 1.23, 2_000_000),
+      asset("proto-token", "__proto__", 1.25, 2_000_000),
+      asset("tostring-token", "toString", 1.27, 2_000_000),
+    ]);
+
+    expect(result.rates["constructor"]).toBe(1.23);
+    expect(result.rates["__proto__"]).toBe(1.25);
+    expect(result.rates["toString"]).toBe(1.27);
+    expect(result.sources["constructor"]).toBe("median");
+    expect(result.counts["__proto__"]).toBe(1);
+  });
 });
 
 describe("getPegReference", () => {

--- a/shared/lib/peg-rates.ts
+++ b/shared/lib/peg-rates.ts
@@ -41,7 +41,7 @@ export function derivePegRates(
   metaById?: ReadonlyMap<string, Pick<StablecoinMeta, "commodityOunces">>,
   fallbackRates?: Record<string, number>,
 ): PegRatesResult {
-  const groups: Record<string, number[]> = {};
+  const groups = new Map<string, number[]>();
 
   for (const a of assets) {
     const peg = normalizePegType(a.pegType);
@@ -62,8 +62,9 @@ export function derivePegRates(
       }
     }
 
-    if (!groups[peg]) groups[peg] = [];
-    groups[peg].push(price);
+    const prices = groups.get(peg) ?? [];
+    prices.push(price);
+    groups.set(peg, prices);
   }
 
   // Use only live cached FX rates — no stale hardcoded defaults.
@@ -71,10 +72,10 @@ export function derivePegRates(
   // and thin-group validation is skipped for one cycle.
   const mergedFallbacks = fallbackRates ?? {};
 
-  const rates: Record<string, number> = {};
-  const sources: Record<string, PegRateSource> = {};
-  const counts: Record<string, number> = {};
-  for (const [peg, prices] of Object.entries(groups)) {
+  const rates: Record<string, number> = Object.create(null) as Record<string, number>;
+  const sources: Record<string, PegRateSource> = Object.create(null) as Record<string, PegRateSource>;
+  const counts: Record<string, number> = Object.create(null) as Record<string, number>;
+  for (const [peg, prices] of groups.entries()) {
     // Keep the scoring reference unrounded; display medians round at the API edge.
     // medianOf() returns null for empty groups, so no separate empty-array guard is needed.
     const median = medianOf(prices);
@@ -85,7 +86,7 @@ export function derivePegRates(
     // Commodity pegs (gold/silver) use peer median — XAUT/PAXG are arbitraged
     // against spot within seconds, so the median is a live reference. metals.dev
     // spot is only fetched once per day and can be >1.5% stale, causing false depegs.
-    const fallback = mergedFallbacks[peg];
+    const fallback = Object.hasOwn(mergedFallbacks, peg) ? mergedFallbacks[peg] : undefined;
     if (fallback && prices.length < 3) {
       rates[peg] = fallback;
       sources[peg] = "fallback";


### PR DESCRIPTION
### Motivation
- `derivePegRates` grouped prices using plain object keys derived from upstream `pegType` strings, which can collide with inherited object properties (`constructor`, `__proto__`, `toString`) and cause a runtime `TypeError` when consumers (e.g. the command palette) process live stablecoin data.
- The command-palette now invokes live peg-rate derivation, exposing a new client-side crash path when pinned or malicious pegType values are present, so a minimal hardening was required to preserve availability.

### Description
- Replace the plain-object grouping with a `Map<string, number[]>` to safely collect prices by `pegType` without touching any prototype chain. (`shared/lib/peg-rates.ts`).
- Return `rates`, `sources`, and `counts` as null-prototype record objects (`Object.create(null)`) so stored peg keys cannot resolve inherited members. (`shared/lib/peg-rates.ts`).
- Guard fallback lookups with an own-property check (`Object.hasOwn`) before using `fallbackRates[peg]` to avoid pulling inherited properties from the fallback map. (`shared/lib/peg-rates.ts`).
- Add a regression test that exercises peg types matching inherited names (`constructor`, `__proto__`, `toString`) to ensure they are treated as ordinary peg keys and do not crash consumers. (`shared/lib/__tests__/peg-rates.test.ts`).

### Testing
- Ran `npm test -- shared/lib/__tests__/peg-rates.test.ts` and all tests in that file passed. 
- Ran linting with `npx eslint --config eslint.typed.config.mjs shared/lib/peg-rates.ts --max-warnings=0` and it completed successfully. 
- Ran `npm run typecheck` and TypeScript checks completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350febb6b08332abf021fc403b2767)