### PR TITLE
Fix mixed-verify shell argument injection

### DIFF
--- a/.claude/workflows/mixed-verify.mjs
+++ b/.claude/workflows/mixed-verify.mjs
@@ -38,6 +38,10 @@ const MAX = cfg.maxItems || 50
 // inside the Bash node (glob picks the newest installed plugin version — survives
 // plugin updates that bump the version-pinned directory). --effort 'minimal' is
 // intentionally never used: it 400s against the user's image_gen/web_search tools.
+function shellArg(value) {
+  return `'${String(value).replaceAll(`'`, `'\"'\"'`)}'`
+}
+
 function gptNode(taskText, { model, effort, label }) {
   const m = model || EXEC.model
   const e = effort || EXEC.effort
@@ -46,7 +50,7 @@ function gptNode(taskText, { model, effort, label }) {
   // so it runs on Haiku; the real work happens in the Codex/GPT call it shells to.
   const cmd =
     `CODEX=$(ls -t ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | head -1); ` +
-    `node "$CODEX" task --effort ${e} --model ${m} ${JSON.stringify(taskText)} 2>&1 | grep -v '^\\[codex\\]'`
+    `node "$CODEX" task --effort ${shellArg(e)} --model ${shellArg(m)} ${shellArg(taskText)} 2>&1 | grep -v '^\\[codex\\]'`
   return agent(
     `Run EXACTLY this one Bash command and return ONLY its stdout verbatim, with no commentary:\n\n${cmd}`,
     { label: label || `gpt:${m}`, phase: 'Verify', model: 'haiku' }


### PR DESCRIPTION
### Motivation
- The `mixed-verify` Claude workflow built a Bash command by interpolating developer-configurable `model`, `effort`, and generated task text directly into a shell line, allowing shell metacharacters (e.g. `$()`, backticks, `;`) in inputs to be interpreted by Bash and enabling local command execution.

### Description
- Add `shellArg()` to `.claude/workflows/mixed-verify.mjs` to wrap dynamic values in single quotes and escape embedded single quotes so they are safe for the shell.
- Use `shellArg(...)` when constructing the Codex companion invocation so `effort`, `model`, and the assembled `taskText` are passed as quoted argv data instead of raw interpolated tokens.
- Preserve the workflow behavior and argument ordering while preventing shell command substitution and token injection from caller-supplied `checks`, item ids, or focus text.

### Testing
- Ran `npm run check:agent-doc-sync` which completed successfully. 
- Executed a targeted Node/Bash harness that launched the generated command against a fake Codex companion inside a temporary `HOME` and confirmed malicious `model`, `effort`, `checks`, item id, and focus values did not cause Shell substitution (no marker file was created) and the values arrived as argv data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a350fecd0648332b68b859215385aee)