### PR TITLE
Sanitize cached Telegram pulse snapshots to enforce low-cardinality suppression

### DIFF
--- a/worker/src/api/__tests__/telegram-pulse.test.ts
+++ b/worker/src/api/__tests__/telegram-pulse.test.ts
@@ -17,10 +17,21 @@ describe("handleTelegramPulse", () => {
       topCoins: ["USDC"],
       alertTypeChats: { dews: 4, depeg: 5, safety: 6, launch: 1, reserve: 0, allTypes: 1 },
       quietHoursEnabledChats: 2,
-      pendingDeliveries: 0,
+      pendingDeliveries: 3,
+      miniAppSessionsToday: 4,
+      miniAppMutationsToday: 2,
       updatedAt: Math.floor(Date.now() / 1000),
       updatedEverySeconds: 300,
-      watcherHistory: [],
+      watcherHistory: [
+        {
+          date: "2026-04-01",
+          timestamp: 1_775_001_600_000,
+          newWatchers: 1,
+          activeWatchers: 8,
+          churnedWatchers: 2,
+          reactivatedWatchers: 0,
+        },
+      ],
     };
     const db = mockD1([
       {
@@ -39,6 +50,18 @@ describe("handleTelegramPulse", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       ...cachedPulse,
+      newWatchersToday: null,
+      quietHoursEnabledChats: null,
+      pendingDeliveries: null,
+      miniAppSessionsToday: null,
+      miniAppMutationsToday: null,
+      watcherHistory: [
+        {
+          ...cachedPulse.watcherHistory[0],
+          newWatchers: null,
+          churnedWatchers: null,
+        },
+      ],
       currentSnapshotAt: cachedPulse.updatedAt,
       lifecycleHistoryUpdatedAt: null,
       lifecycleHistoryEverySeconds: 900,
@@ -46,7 +69,15 @@ describe("handleTelegramPulse", () => {
       privacy: {
         exactActiveWatchers: true,
         lowCardinalityThreshold: 5,
-        suppressedFields: [],
+        suppressedFields: [
+          "miniAppMutationsToday",
+          "miniAppSessionsToday",
+          "newWatchersToday",
+          "pendingDeliveries",
+          "quietHoursEnabledChats",
+          "watcherHistory.churnedWatchers",
+          "watcherHistory.newWatchers",
+        ],
       },
     });
     expect(db.getHistory().some((entry) => entry.sql.includes("FROM telegram_subscribers s"))).toBe(false);
@@ -908,9 +939,13 @@ describe("publishTelegramPulseSnapshot", () => {
     expect(pulse.coinSubscriptions).toBe(18);
     expect(pulse.pendingDeliveries).toBe(42);
     expect(pulse.topCoins).toEqual(["USDC"]);
-    expect(pulse.watcherHistory).toEqual(cachedPulse.watcherHistory);
+    expect(pulse.watcherHistory).toEqual([
+      { ...cachedPulse.watcherHistory[0], newWatchers: null },
+      cachedPulse.watcherHistory[1],
+    ]);
     expect(pulse.miniAppSessionsToday).toBe(7);
     expect(pulse.lifecycleHistoryUpdatedAt).toBe(nowSec - 3_600);
+    expect(pulse.privacy.suppressedFields).toContain("watcherHistory.newWatchers");
 
     const history = db.getHistory();
     expect(history.some((entry) => entry.sql.includes("FROM telegram_pending_alerts"))).toBe(false);

--- a/worker/src/api/telegram-pulse.ts
+++ b/worker/src/api/telegram-pulse.ts
@@ -192,10 +192,45 @@ async function loadFallbackWatcherHistory(db: D1Database): Promise<TelegramWatch
     .filter((point) => point.date && Number.isFinite(point.timestamp) && point.timestamp > 0);
 }
 
+function sanitizePublicPulse(pulse: TelegramPulse): TelegramPulse {
+  const suppressedFields = new Set(pulse.privacy.suppressedFields);
+
+  return {
+    ...pulse,
+    newWatchersToday: pulse.newWatchersToday == null
+      ? pulse.newWatchersToday
+      : publicOptionalCount(pulse.newWatchersToday, "newWatchersToday", suppressedFields),
+    churnedWatchersToday: pulse.churnedWatchersToday == null
+      ? pulse.churnedWatchersToday
+      : publicOptionalCount(pulse.churnedWatchersToday, "churnedWatchersToday", suppressedFields),
+    reactivatedWatchersToday: pulse.reactivatedWatchersToday == null
+      ? pulse.reactivatedWatchersToday
+      : publicOptionalCount(pulse.reactivatedWatchersToday, "reactivatedWatchersToday", suppressedFields),
+    watcherHistory: sanitizeWatcherHistory(pulse.watcherHistory, suppressedFields),
+    quietHoursEnabledChats: pulse.quietHoursEnabledChats == null
+      ? pulse.quietHoursEnabledChats
+      : publicRequiredCount(pulse.quietHoursEnabledChats, "quietHoursEnabledChats", suppressedFields),
+    pendingDeliveries: pulse.pendingDeliveries == null
+      ? pulse.pendingDeliveries
+      : publicRequiredCount(pulse.pendingDeliveries, "pendingDeliveries", suppressedFields),
+    miniAppSessionsToday: pulse.miniAppSessionsToday == null
+      ? pulse.miniAppSessionsToday
+      : publicOptionalCount(pulse.miniAppSessionsToday, "miniAppSessionsToday", suppressedFields),
+    miniAppMutationsToday: pulse.miniAppMutationsToday == null
+      ? pulse.miniAppMutationsToday
+      : publicOptionalCount(pulse.miniAppMutationsToday, "miniAppMutationsToday", suppressedFields),
+    privacy: {
+      ...pulse.privacy,
+      lowCardinalityThreshold: PUBLIC_LOW_CARDINALITY_THRESHOLD,
+      suppressedFields: [...suppressedFields].sort(),
+    },
+  };
+}
+
 function parseCachedPulse(value: string): TelegramPulse | null {
   try {
     const result = TelegramPulseSchema.safeParse(JSON.parse(value));
-    return result.success ? result.data : null;
+    return result.success ? sanitizePublicPulse(result.data) : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
### Motivation

- A legacy cached Telegram pulse payload could contain exact low-cardinality telemetry (e.g. `newWatchersToday=1`) and bypass the new public suppression contract while the cache remained fresh. 
- The goal is to ensure any cached snapshot parsed from D1 is normalized to the public privacy contract so the low-cardinality suppression guarantees hold for the full cache freshness window.

### Description

- Add `sanitizePublicPulse()` in `worker/src/api/telegram-pulse.ts` to re-run schema-parsed cached payloads through the public suppression path using `publicOptionalCount`, `publicRequiredCount`, and `sanitizeWatcherHistory`. 
- Update `parseCachedPulse()` to return `sanitizePublicPulse(result.data)` so legacy cached snapshots cannot expose sub-threshold numeric fields before expiry. 
- Update tests in `worker/src/api/__tests__/telegram-pulse.test.ts` to assert that fresh materialized cache responses and reused heavy sections are sanitized and that `privacy.suppressedFields` reflects newly suppressed fields.

### Testing

- Ran the focused suite with `npx vitest run worker/src/api/__tests__/telegram-pulse.test.ts --reporter=verbose`, and all tests in that file passed. 
- Ran worker typechecking with `npm run typecheck:worker`, and the TypeScript check succeeded. 
- Tests were adjusted to cover both serving cached snapshots and reusing cached heavy sections to verify suppression behavior (all automated assertions now pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fefcb08332b0a76f3c0222f696)