### PR TITLE
fix(status): trust registry for CoinGecko drift scope

### DIFF
--- a/worker/src/api/__tests__/status.test.ts
+++ b/worker/src/api/__tests__/status.test.ts
@@ -868,6 +868,7 @@ describe("handleStatus", () => {
           name: "PayPal USD",
           symbol: "PYUSD",
           geckoId: "paypal-usd",
+          frozen: true,
           pegType: "peggedUSD",
           pegMechanism: "fiat-backed",
           price: 0.9,

--- a/worker/src/api/status-supplements.ts
+++ b/worker/src/api/status-supplements.ts
@@ -180,7 +180,7 @@ async function loadCoinGeckoPriceDiff(
   }
 
   const trackedWithGeckoId = stablecoinsCache.payload.peggedAssets.filter(
-    (asset) => !asset.frozen && ACTIVE_IDS.has(asset.id) && typeof asset.geckoId === "string" && asset.geckoId.length > 0,
+    (asset) => ACTIVE_IDS.has(asset.id) && typeof asset.geckoId === "string" && asset.geckoId.length > 0,
   );
   if (trackedWithGeckoId.length === 0) {
     return {


### PR DESCRIPTION
### Motivation

- Prevent lenient cached stablecoin metadata from suppressing CoinGecko price-drift diagnostics by relying on the authoritative registry-derived active set rather than an untrusted `frozen` passthrough field.

### Description

- Remove the cached `asset.frozen` gate from the CoinGecko comparison filter in `worker/src/api/status-supplements.ts` so scope is determined by `ACTIVE_IDS` and a valid `geckoId` only. 
- Update the status API test fixture in `worker/src/api/__tests__/status.test.ts` to include `frozen: true` on an active asset to verify it is still compared while registry-archived assets remain excluded.
- Preserve existing behavior for registry-based exclusions; this change only hardens the diagnostic/filtering logic against untrusted cache fields.

### Testing

- Ran `npx vitest run worker/src/api/__tests__/status.test.ts -t "CoinGecko"`, and the relevant tests passed (`3 passed | 54 skipped`).
- Ran `cd worker && npx tsc --noEmit`, and TypeScript type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe215883328fda75c0935ab68f)