### PR TITLE
Fix DeFiLlama row timestamp source-age scoring

### DIFF
--- a/worker/src/cron/__tests__/yield-evaluation.test.ts
+++ b/worker/src/cron/__tests__/yield-evaluation.test.ts
@@ -375,6 +375,35 @@ describe("evaluateYieldSources", () => {
     expect(stale?.sourceRiskPenalty).toBeGreaterThan(1);
   });
 
+  it("uses DeFiLlama row-level observed timestamps before input metadata age", () => {
+    const startSec = 1776729600;
+    const rowObservedAt = startSec - 8 * 60 * 60;
+    const result = evaluateYieldSources(baseEvaluationInput({
+      startSec,
+      dlPoolsMeta: {
+        mode: "dex-cache",
+        updatedAt: startSec - 60,
+        ageSeconds: 60,
+        poolCount: 1,
+        fallbackMode: null,
+      },
+      resolved: [
+        {
+          id: "coin-a",
+          symbol: "A",
+          yield: resolvedYield({
+            sourceKey: "defillama:coin-a:row-stale",
+            sourceObservedAt: rowObservedAt,
+          }),
+        },
+      ],
+    }));
+
+    const stale = result.evaluatedSources.find((source) => source.sourceKey === "defillama:coin-a:row-stale");
+    expect(stale?.sourceObservedAt).toBe(rowObservedAt);
+    expect(stale?.sourceRiskPenalty).toBeGreaterThan(1);
+  });
+
   it("marks derived rows with materially stale comparison anchors", () => {
     const startSec = 1776729600;
     const result = evaluateYieldSources(baseEvaluationInput({

--- a/worker/src/cron/yield-sync/evaluation.ts
+++ b/worker/src/cron/yield-sync/evaluation.ts
@@ -171,6 +171,9 @@ function resolveSourceAgeSeconds(
   sourceObservedAt: number | null,
   dlPoolsMeta: YieldSourceInputMeta | undefined,
 ): number | null {
+  if (typeof source.sourceObservedAt === "number" && Number.isFinite(source.sourceObservedAt)) {
+    return computeSourceAgeSeconds(startSec, sourceObservedAt);
+  }
   if (
     isDefiLlamaDataSource(source.dataSource) &&
     typeof dlPoolsMeta?.ageSeconds === "number" &&


### PR DESCRIPTION
### Motivation
- DeFiLlama input metadata age was being applied unconditionally for `defillama`/`defillama-auto` rows, which could override a valid row-level `sourceObservedAt` and let stale rows avoid source-age penalties.
- The change ensures row-level observation evidence drives source-age and source-risk scoring, with shared DeFiLlama metadata used only as a fallback so scoring integrity is preserved.

### Description
- Update `resolveSourceAgeSeconds` in `worker/src/cron/yield-sync/evaluation.ts` to prefer a finite row-level `source.sourceObservedAt` and compute age from it before considering `dlPoolsMeta.ageSeconds` as a fallback.
- Keep the existing fallback behavior of using `dlPoolsMeta.ageSeconds` when a row lacks its own observed timestamp.
- Add a regression test in `worker/src/cron/__tests__/yield-evaluation.test.ts` that verifies a stale DeFiLlama row still incurs the source-age penalty even when the global DeFiLlama input metadata is fresh.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/__tests__/yield-evaluation.test.ts --testNamePattern "DeFiLlama input metadata age|row-level observed timestamps|derives source-risk penalties" --reporter=dot`, which completed with the targeted tests passing (`Test Files 1 passed (1)`, `Tests 3 passed | 13 skipped`).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351afdd35c833299f60e2be1afda7e)