### PR TITLE
fix(chains): classify BEVM resilience as tier 3

### DIFF
--- a/shared/lib/__tests__/chains.test.ts
+++ b/shared/lib/__tests__/chains.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHAIN_META,
   getActiveChainIds,
+  getChainResilienceTier,
   resolveChainId,
 } from "@shared/lib/chains";
 import { TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
@@ -72,6 +73,12 @@ describe("resolveChainId", () => {
     expect(resolveChainId("ZKsync Era")).toBe("zksync");
     expect(resolveChainId("Abcore")).toBe("abcore");
     expect(resolveChainId("edgeX L1")).toBe("edgechain");
+  });
+});
+
+describe("getChainResilienceTier", () => {
+  it("treats BEVM as a tier-3 chain", () => {
+    expect(getChainResilienceTier("bevm")).toBe(3);
   });
 });
 

--- a/shared/lib/chains/index.ts
+++ b/shared/lib/chains/index.ts
@@ -176,6 +176,7 @@ export const CHAIN_RESILIENCE_TIER: Partial<Record<string, ChainResilienceTier>>
   codex: 3,         // new payment-focused L1
   edgechain: 3,     // exchange-adjacent financial chain
   stable: 3,        // new USDT-focused chain
+  bevm: 3,          // newer BTC-aligned L2
 
   // Everything else defaults to tier 2 via getChainResilienceTier()
 };


### PR DESCRIPTION
### Motivation
- BEVM was added to `CHAIN_META` but not included in the `CHAIN_RESILIENCE_TIER` overrides, causing `getChainResilienceTier("bevm")` to fall back to tier 2 and inflate chain-environment scoring for BEVM deployments.

### Description
- Add `bevm: 3` to `CHAIN_RESILIENCE_TIER` in `shared/lib/chains/index.ts` and add a focused test asserting `getChainResilienceTier("bevm") === 3` in `shared/lib/__tests__/chains.test.ts` to prevent regression.

### Testing
- Ran the focused test and related aggregator test with `npx vitest run shared/lib/__tests__/chains.test.ts shared/lib/__tests__/chain-aggregator.test.ts --pool=threads --maxWorkers=1`, and the suite passed; also ran `npm run check:worker-boundary` and `npm run check:shared-cycles`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe45b083328771a73e915ee07e)