### PR TITLE
Fix Telegram forget data deletion

### DIFF
--- a/worker/src/api/__tests__/telegram-mini-app.test.ts
+++ b/worker/src/api/__tests__/telegram-mini-app.test.ts
@@ -1202,6 +1202,8 @@ describe("handleTelegramMiniAppMutation", () => {
     expect(historyHas(db, "DELETE FROM telegram_preset_subscriptions WHERE chat_id = ?", ["42"])).toBe(true);
     expect(historyHas(db, "DELETE FROM telegram_pending_disambiguation WHERE chat_id = ?", ["42"])).toBe(true);
     expect(historyHas(db, "DELETE FROM telegram_pending_alerts WHERE chat_id = ?", ["42"])).toBe(true);
+    expect(historyHas(db, "DELETE FROM telegram_alert_job_targets WHERE chat_id = ?", ["42"])).toBe(true);
+    expect(historyHas(db, "DELETE FROM telegram_alert_dead_letters WHERE chat_id = ?", ["42"])).toBe(true);
     expect(historyHas(db, "DELETE FROM telegram_chat_delivery_diagnostics WHERE chat_id = ?", ["42"])).toBe(true);
     expect(historyHas(db, "DELETE FROM telegram_subscribers WHERE chat_id = ?", ["42"])).toBe(true);
     // processed_updates intentionally retained for idempotency.

--- a/worker/src/api/__tests__/telegram-webhook-callbacks.test.ts
+++ b/worker/src/api/__tests__/telegram-webhook-callbacks.test.ts
@@ -821,7 +821,17 @@ describe("handleCallbackQuery", () => {
       expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_subscriptions"))).toBe(true);
       expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_preset_subscriptions"))).toBe(true);
       expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_pending_alerts"))).toBe(true);
+      expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_alert_job_targets"))).toBe(true);
+      expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_alert_dead_letters"))).toBe(true);
       expect(history.some((entry) => entry.sql.includes("DELETE FROM telegram_subscribers"))).toBe(true);
+      expect(history.some((entry) => entry.sql.includes("INSERT INTO telegram_chat_delivery_diagnostics"))).toBe(false);
+      expect(sendAuditedTelegramReply).toHaveBeenCalledWith(
+        db,
+        "123",
+        "Your subscriber data has been deleted. Use /start to begin again.",
+        "fake-token",
+        { actionDetail: "callback_forget", recordReplyOutcome: false },
+      );
       expect(lastSentMessageBody().text).toContain("subscriber data has been deleted");
       expect(lastAckBody().text).toBe("Deleted.");
     });

--- a/worker/src/api/telegram-store/__tests__/forget.test.ts
+++ b/worker/src/api/telegram-store/__tests__/forget.test.ts
@@ -179,6 +179,9 @@ describe("forgetSubscriber", () => {
       )
       VALUES (?, ?, ?, ?)
     `).run(chatId, "alice", 100, 200);
+    sqlite.prepare("INSERT INTO telegram_alert_job_targets (job_id, target_key, chat_id, pending_dedupe_key) VALUES (?, ?, ?, ?)")
+      .run("job-1", "target-1", chatId, "pending-1");
+    sqlite.prepare("INSERT INTO telegram_alert_dead_letters (chat_id) VALUES (?)").run(chatId);
     const deletedCacheKeys = [
       `telegram:command-flood:${chatId}`,
       `telegram:command-flood:${chatId}:actor:99`,
@@ -203,6 +206,10 @@ describe("forgetSubscriber", () => {
     await forgetSubscriber(db, chatId);
 
     expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_subscribers WHERE chat_id = ?").get(chatId))
+      .toEqual({ count: 0 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_job_targets WHERE chat_id = ?").get(chatId))
+      .toEqual({ count: 0 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_dead_letters WHERE chat_id = ?").get(chatId))
       .toEqual({ count: 0 });
     for (const key of deletedCacheKeys) {
       expect(sqlite.prepare("SELECT key FROM cache WHERE key = ?").get(key)).toBeUndefined();

--- a/worker/src/api/telegram-store/forget.ts
+++ b/worker/src/api/telegram-store/forget.ts
@@ -43,6 +43,8 @@ export async function forgetSubscriber(db: D1Database, chatId: string): Promise<
     db.prepare("DELETE FROM telegram_preset_subscriptions WHERE chat_id = ?").bind(chatId),
     db.prepare("DELETE FROM telegram_pending_disambiguation WHERE chat_id = ?").bind(chatId),
     db.prepare("DELETE FROM telegram_pending_alerts WHERE chat_id = ?").bind(chatId),
+    db.prepare("DELETE FROM telegram_alert_job_targets WHERE chat_id = ?").bind(chatId),
+    db.prepare("DELETE FROM telegram_alert_dead_letters WHERE chat_id = ?").bind(chatId),
     db.prepare("DELETE FROM telegram_chat_delivery_diagnostics WHERE chat_id = ?").bind(chatId),
     db.prepare("DELETE FROM telegram_subscribers WHERE chat_id = ?").bind(chatId),
     ...prepareDeleteTelegramChatCacheStatements(db, chatId),

--- a/worker/src/api/telegram-webhook-replies.ts
+++ b/worker/src/api/telegram-webhook-replies.ts
@@ -8,6 +8,7 @@ import { splitMessage } from "../lib/telegram-alerts";
 
 export interface AuditedTelegramReplyOptions extends SendToChatOpts {
   actionDetail?: string;
+  recordReplyOutcome?: boolean;
 }
 
 export interface AuditedTelegramReplyResult {
@@ -29,6 +30,7 @@ export async function sendAuditedTelegramReply(
 ): Promise<AuditedTelegramReplyResult> {
   const {
     actionDetail = "reply",
+    recordReplyOutcome = true,
     replyMarkup,
     ...sendOptions
   } = options;
@@ -62,6 +64,8 @@ export async function sendAuditedTelegramReply(
       if (result.errorClass === "rate_limit" || !result.retryable) break;
     }
   }
-  await recordTelegramReplyOutcome(db, { chatId, ok, errorClass });
+  if (recordReplyOutcome) {
+    await recordTelegramReplyOutcome(db, { chatId, ok, errorClass });
+  }
   return { ok, errorClass };
 }

--- a/worker/src/api/webhook-callbacks/confirm.ts
+++ b/worker/src/api/webhook-callbacks/confirm.ts
@@ -122,7 +122,7 @@ async function handleForgetConfirmCallback(
     chatId,
     "Your subscriber data has been deleted. Use /start to begin again.",
     botToken,
-    { actionDetail: "callback_forget" },
+    { actionDetail: "callback_forget", recordReplyOutcome: false },
   );
   await answerCallbackQuery(cb.id, botToken, { text: "Deleted." });
 }


### PR DESCRIPTION
### Motivation

- The `/forget` and Mini App `forget-me` flows claimed to remove all subscriber-owned Telegram rows but left `telegram_alert_job_targets` and `telegram_alert_dead_letters` behind, and the confirmation reply immediately re-created `telegram_chat_delivery_diagnostics`, undermining the privacy intent.
- The change aims to ensure a true per-chat data wipe for subscriber-initiated deletion while avoiding reintroducing diagnostic rows as part of the success acknowledgement.

### Description

- Extend the shared `forgetSubscriber` helper to also delete `telegram_alert_job_targets` and `telegram_alert_dead_letters` in addition to the existing subscriber tables (now deletes `telegram_alert_job_targets`, `telegram_alert_dead_letters`, `telegram_chat_delivery_diagnostics`, etc.).
- Add an optional `recordReplyOutcome` flag to `sendAuditedTelegramReply` (defaults to `true`) so callers can opt out of writing `telegram_chat_delivery_diagnostics` for privacy-sensitive replies.
- Use `recordReplyOutcome: false` when sending the `/forget` confirmation reply so the acknowledgement does not recreate delivery diagnostics after deletion.
- Update unit tests to assert the expanded deletion set and the diagnostics suppression in the callback path and Mini App flow (`worker/src/api/telegram-store/__tests__/forget.test.ts`, `worker/src/api/__tests__/telegram-webhook-callbacks.test.ts`, `worker/src/api/__tests__/telegram-mini-app.test.ts`).

### Testing

- Ran the targeted Vitest suites: `npx vitest run worker/src/api/telegram-store/__tests__/forget.test.ts worker/src/api/__tests__/telegram-webhook-callbacks.test.ts worker/src/api/__tests__/telegram-mini-app.test.ts` and all tests passed.
- Performed a TypeScript build check with `cd worker && npx tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35149a932c83328024cbbc590ee592)