### PR TITLE
fix(security): scan data-src inline scripts

### DIFF
--- a/scripts/__tests__/check-phishing-signatures.test.ts
+++ b/scripts/__tests__/check-phishing-signatures.test.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const checker = resolve(process.cwd(), "scripts/ci/check-phishing-signatures.mjs");
+
+function runChecker(html: string) {
+  const cwd = mkdtempSync(resolve(tmpdir(), "pharos-phishing-signatures-"));
+  mkdirSync(resolve(cwd, "out"));
+  writeFileSync(resolve(cwd, "out/index.html"), html);
+  try {
+    return execFileSync(process.execPath, [checker], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("check-phishing-signatures", () => {
+  it("scans executable inline scripts even when they carry data-src attributes", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><script data-src="inline-metadata">try { const params = new URLSearchParams(window.location.hash.slice(1)); window.__PHAROS_TOKEN__ = params.get("token"); history.replaceState(null, "", location.pathname); } catch (error) {}</script></body></html>`,
+      ),
+    ).toThrow(/Inline-script phishing-kit signatures detected/);
+  });
+
+  it("continues to skip external script tags that use a real src attribute", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><script src="/bundle.js">try { const params = new URLSearchParams(window.location.hash.slice(1)); window.__PHAROS_TOKEN__ = params.get("token"); history.replaceState(null, "", location.pathname); } catch (error) {}</script></body></html>`,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/scripts/ci/check-phishing-signatures.mjs
+++ b/scripts/ci/check-phishing-signatures.mjs
@@ -35,15 +35,12 @@ const SIGNATURES = [
     id: "history-replacestate-near-credential",
     severity: "red",
     test: (script) =>
-      /history\.replaceState/.test(script) &&
-      /\b(verify|token|auth|key|session|otp|magic)\b/i.test(script),
+      /history\.replaceState/.test(script) && /\b(verify|token|auth|key|session|otp|magic)\b/i.test(script),
   },
   {
     id: "url-hash-token-extraction",
     severity: "red",
-    test: (script) =>
-      /URLSearchParams\s*\(/.test(script) &&
-      /(window\.)?location\.hash/.test(script),
+    test: (script) => /URLSearchParams\s*\(/.test(script) && /(window\.)?location\.hash/.test(script),
   },
   {
     id: "token-shaped-window-global",
@@ -54,18 +51,19 @@ const SIGNATURES = [
     id: "phishing-kit-shape",
     severity: "red",
     // The textbook structure: try{...read hash...replaceState...}
-    test: (script) =>
-      /try\s*\{[\s\S]*location\.hash[\s\S]*replaceState[\s\S]*\}\s*catch/.test(script),
+    test: (script) => /try\s*\{[\s\S]*location\.hash[\s\S]*replaceState[\s\S]*\}\s*catch/.test(script),
   },
 ];
 
 /** Extract the textual content of every inline <script>...</script> block. */
 function extractInlineScripts(html) {
   const inline = [];
-  const pattern = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
   let match;
   while ((match = pattern.exec(html)) !== null) {
-    const body = match[1];
+    const attributes = match[1];
+    if (/(?:^|\s)src\s*=/i.test(attributes)) continue;
+    const body = match[2];
     if (body.trim().length === 0) continue;
     inline.push(body);
   }


### PR DESCRIPTION
### Motivation
- Prevent credential-harvesting/phishing-kit shaped inline scripts from being shipped by ensuring the inline-script scanner inspects any executable inline `<script>` even when it carries metadata attributes like `data-src`.
- Confirmed the CI/release parity already includes `npm run check:phishing-signatures` in HEAD, so the actionable gap was the extractor skipping executable scripts with `data-src` rather than an enforcement issue in workflows.

### Description
- Tighten the inline-script extractor in `scripts/ci/check-phishing-signatures.mjs` so it parses script attributes and only treats tags with a real `src` attribute as external, thereby scanning scripts with `data-src` metadata. 
- Add regression tests in `scripts/__tests__/check-phishing-signatures.test.ts` that assert scanning flags executable `<script data-src="...">` while preserving skip behavior for true external `src` tags. 
- Keep existing signature detection logic unchanged and preserve the allowlist mechanism and error reporting semantics.

### Testing
- Ran `npx vitest run scripts/__tests__/check-phishing-signatures.test.ts scripts/__tests__/validate-ci-parity.test.ts --reporter=dot` and the tests passed (`Test Files 2 passed`, `Tests 21 passed`).
- Ran `npm run check:phishing-signatures` locally which printed the expected diagnostic when `out/` is missing and exited as designed (requires a built `out/` directory), confirming the script's runtime guard behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe36dc833297dfa93c354b9210)