### PR TITLE
Fix query verification token scrubbing

### DIFF
--- a/src/components/__tests__/api-key-request-form.test.tsx
+++ b/src/components/__tests__/api-key-request-form.test.tsx
@@ -127,13 +127,13 @@ describe("ApiKeyRequestForm", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
     expect(window.location.href).toContain("utm_source=email");
-    expect(window.location.href).toContain(`verify=qs-${suffix}`);
+    expect(window.location.href).not.toContain(`verify=qs-${suffix}`);
     expect(window.location.href).not.toContain(`akv_${suffix}`);
     const [, init] = fetchMock.mock.calls[0] ?? [];
     expect(JSON.parse(String((init as RequestInit).body)).token).toBe(`akv_${suffix}`);
   });
 
-  it("ignores a query-string verify parameter without posting or rewriting the URL", async () => {
+  it("ignores a query-string verify parameter without posting and scrubs it from the URL", async () => {
     const suffix = randomUUID().slice(0, 8);
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -143,8 +143,8 @@ describe("ApiKeyRequestForm", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(window.location.search).toContain(`verify=qs-${suffix}`);
-    expect(window.location.search).toContain("utm_source=email");
+    expect(window.location.search).not.toContain(`verify=qs-${suffix}`);
+    expect(window.location.search).toBe("?utm_source=email");
   });
 
   it("does not display the durable request id after a pending submission", async () => {

--- a/src/components/__tests__/google-analytics.test.tsx
+++ b/src/components/__tests__/google-analytics.test.tsx
@@ -18,6 +18,7 @@ afterEach(() => {
   delete window.dataLayer;
   delete window.gtag;
   pathnameMock.mockReset();
+  window.history.replaceState(null, "", "/");
 });
 
 describe("GoogleAnalytics", () => {
@@ -57,6 +58,25 @@ describe("GoogleAnalytics", () => {
         ),
       { timeout: 2500 },
     );
+  });
+
+  it("scrubs query-string verification tokens before page_view tracking", async () => {
+    pathnameMock.mockReturnValue("/api/");
+    window.history.replaceState(null, "", "/api/?verify=legacy-secret&utm_source=email");
+
+    render(<GoogleAnalytics measurementId="G-TEST" />);
+
+    await waitFor(() => expect(window.dataLayer?.length).toBeGreaterThanOrEqual(4));
+    const pageViewEntry = Array.from(window.dataLayer?.at(3) ?? []);
+    expect(window.location.search).toBe("?utm_source=email");
+    expect(pageViewEntry).toEqual([
+      "event",
+      "page_view",
+      expect.objectContaining({
+        page_path: "/api/?utm_source=email",
+        page_location: "http://localhost:3000/api/?utm_source=email",
+      }),
+    ]);
   });
 
   it("tracks SPA path changes after bootstrap", async () => {

--- a/src/components/google-analytics.tsx
+++ b/src/components/google-analytics.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { clearAllTrackingTimers } from "@/lib/analytics";
+import { stripQueryVerificationTokenFromUrl } from "@/lib/api-key-self-serve";
 import { scheduleIdle } from "@/lib/browser-utils";
 
 declare global {
@@ -59,6 +60,7 @@ export function GoogleAnalytics({ measurementId }: GoogleAnalyticsProps) {
     // Cancel any debounced search timer from the previous route so it cannot
     // fire a search_performed event attributed to the page we just left.
     clearAllTrackingTimers();
+    stripQueryVerificationTokenFromUrl();
     const search = window.location.search ?? "";
     const pagePath = pathname + search;
     window.gtag?.("event", "page_view", {

--- a/src/hooks/use-api-key-request-form-state.ts
+++ b/src/hooks/use-api-key-request-form-state.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import type { ApiKeySelfServeCadence } from "@shared/types";
 import {
   readVerificationTokenFromUrl,
+  stripQueryVerificationTokenFromUrl,
   stripVerificationTokenFromUrl,
   submitApiKeyRequest,
   verifyApiKeyRequestToken,
@@ -28,6 +29,7 @@ function useVerificationTokenEffect(verifyToken: (token: string) => Promise<void
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    stripQueryVerificationTokenFromUrl();
     const token = readVerificationTokenFromUrl();
     if (!token || consumedVerificationTokenRef.current === token) return;
     consumedVerificationTokenRef.current = token;

--- a/src/lib/api-key-self-serve.ts
+++ b/src/lib/api-key-self-serve.ts
@@ -104,18 +104,39 @@ function scrubHashVerificationToken(hash: string): string {
   return parseHashVerificationToken(hash) ? "" : hash;
 }
 
+function scrubQueryVerificationToken(search: string): string {
+  if (!search.includes("verify=")) return search;
+  const params = new URLSearchParams(search);
+  if (!params.has("verify")) return search;
+  params.delete("verify");
+  const next = params.toString();
+  return next ? `?${next}` : "";
+}
+
 export function readVerificationTokenFromUrl(): string | null {
   if (typeof window === "undefined") return null;
   return parseHashVerificationToken(window.location.hash);
 }
 
-export function stripVerificationTokenFromUrl(): void {
+export function stripQueryVerificationTokenFromUrl(): void {
   if (typeof window === "undefined") return;
-  const nextHash = scrubHashVerificationToken(window.location.hash);
-  if (nextHash === window.location.hash) return;
+  const nextSearch = scrubQueryVerificationToken(window.location.search);
+  if (nextSearch === window.location.search) return;
   window.history.replaceState(
     null,
     "",
-    `${window.location.pathname}${window.location.search}${nextHash}`,
+    `${window.location.pathname}${nextSearch}${window.location.hash}`,
+  );
+}
+
+export function stripVerificationTokenFromUrl(): void {
+  if (typeof window === "undefined") return;
+  const nextSearch = scrubQueryVerificationToken(window.location.search);
+  const nextHash = scrubHashVerificationToken(window.location.hash);
+  if (nextSearch === window.location.search && nextHash === window.location.hash) return;
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${nextSearch}${nextHash}`,
   );
 }


### PR DESCRIPTION
### Motivation
- Prevent residual `?verify=…` tokens from remaining in `location.search` and being included in analytics or same-origin referrers after the app moved to a hash-only verification flow.
- Preserve the existing hash (`#akv_…`) verification flow while removing the leftover query-token exposure path for legacy links or rewrites.

### Description
- Added a query-token scrubber `scrubQueryVerificationToken` and exported `stripQueryVerificationTokenFromUrl()` in `src/lib/api-key-self-serve.ts` to remove only the `verify` query parameter while preserving other search params. 
- Updated `stripVerificationTokenFromUrl()` to remove both `?verify=…` and hash tokens in a single history `replaceState` so the URL is fully sanitized after consumption. 
- Call `stripQueryVerificationTokenFromUrl()` before reading/consuming the hash token in the verification effect (`useVerificationTokenEffect` in `src/hooks/use-api-key-request-form-state.ts`) so legacy `?verify=` is removed prior to analytics or history exposure. 
- Invoke `stripQueryVerificationTokenFromUrl()` in the GA page-view path construction (`src/components/google-analytics.tsx`) so `page_path`/`page_location` never include a `?verify=` token. 
- Updated tests to cover the scrub behavior: adjusted `src/components/__tests__/api-key-request-form.test.tsx` to assert the query token is removed, and added/updated `src/components/__tests__/google-analytics.test.tsx` to assert GA events do not include `?verify=` while preserving other query params.

### Testing
- Ran the focused Vitest suites: `npx vitest run src/components/__tests__/api-key-request-form.test.tsx src/components/__tests__/google-analytics.test.tsx --reporter=verbose` and observed all tests pass (`10 passed`).
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) with no errors.
- Ran lint on the touched files with `npx eslint ... --max-warnings=0` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fef5bc8332bff402563cea24af)