### PR TITLE
fix(worker): keep ambiguous Telegram 429s chat-scoped

### DIFF
--- a/worker/src/lib/__tests__/telegram.test.ts
+++ b/worker/src/lib/__tests__/telegram.test.ts
@@ -135,7 +135,7 @@ describe("sendToChat", () => {
     expect(fetchSpy.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("classifies ambiguous long retry-after 429s as global", async () => {
+  it("keeps ambiguous long retry-after 429s chat-scoped", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response("Too Many Requests", {
         status: 429,
@@ -151,7 +151,7 @@ describe("sendToChat", () => {
       statusCode: 429,
       errorClass: "rate_limit",
       delivery: "retryable_failure",
-      rateLimitScope: "global",
+      rateLimitScope: "chat",
     });
     expect(result.retryAfterSec).toBe(30);
   });
@@ -368,6 +368,42 @@ describe("sendBatch", () => {
     expect(results).toHaveLength(5);
     expect(results.slice(0, 3).every((result) => result.rateLimitScope === "global" && result.attempted === true)).toBe(true);
     expect(results.slice(3).every((result) => result.rateLimitScope === "global" && result.attempted === false)).toBe(true);
+  });
+
+
+  it("keeps sending later batches after an ambiguous Telegram JSON retry_after", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error_code: 429,
+            description: "Too Many Requests: retry after 38",
+            parameters: { retry_after: 38 },
+          }),
+          { status: 429 },
+        ),
+      )
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const messages = Array.from({ length: 5 }, (_, index) => ({
+      chatId: `chat-${index}`,
+      html: `<b>Alert ${index}</b>`,
+      disableNotification: false,
+    }));
+
+    const results = await sendBatch(messages, "bot-token", 2);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(results).toHaveLength(5);
+    expect(results[0]).toMatchObject({
+      chatId: "chat-0",
+      errorClass: "rate_limit",
+      retryAfterSec: 38,
+      rateLimitScope: "chat",
+      attempted: true,
+    });
+    expect(results.slice(1).every((result) => result.ok && result.attempted === true)).toBe(true);
   });
 
   it("marks the untouched tail as global retryable after a global rate limit stop", async () => {

--- a/worker/src/lib/telegram.ts
+++ b/worker/src/lib/telegram.ts
@@ -150,19 +150,15 @@ export interface SendToChatResult {
   rateLimitScope?: "chat" | "global";
 }
 
-const GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC = 30;
 const GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD = 3;
 
-function inferRateLimitScope(responseBody: string, retryAfterSec: number | null): "chat" | "global" {
+function inferRateLimitScope(responseBody: string): "chat" | "global" {
   const lower = responseBody.toLowerCase();
   if (lower.includes("global") || lower.includes("bot-wide") || lower.includes("bot wide")) {
     return "global";
   }
   if (lower.includes("chat") || lower.includes("group") || lower.includes("user")) {
     return "chat";
-  }
-  if (retryAfterSec != null && retryAfterSec >= GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC) {
-    return "global";
   }
   return "chat";
 }
@@ -205,7 +201,7 @@ function buildResponseFailure(statusCode: number, responseBody = "", retryAfterS
       errorClass: "rate_limit",
       delivery: "retryable_failure",
       retryAfterSec: null,
-      rateLimitScope: inferRateLimitScope(responseBody, retryAfterSec),
+      rateLimitScope: inferRateLimitScope(responseBody),
     };
   }
   if (statusCode >= 500) {


### PR DESCRIPTION
### Motivation
- An ambiguous Telegram 429 that includes a JSON `parameters.retry_after` was being inferred as a bot-wide/global limit, which could cause a single noisy chat to pause delivery to all subscribers (availability regression).
- The intent is to avoid treating ambiguous Retry-After signals as global unless Telegram explicitly indicates a bot-wide/global scope. 

### Description
- Stop inferring global scope from a parsed `retry_after` value by removing the retry-based global heuristic and making `inferRateLimitScope()` rely only on explicit text indicators like `global`/`bot-wide` vs `chat`/`group`/`user` in the response body. (`worker/src/lib/telegram.ts`)
- Update `buildResponseFailure()` / `sendToChat()` usage to call the simplified `inferRateLimitScope()` so ambiguous responses remain chat-scoped unless explicitly global. (`worker/src/lib/telegram.ts`)
- Preserve the existing multi-chat escalation logic in `sendBatch()` that promotes repeated distinct-chat 429s to a global backoff after the configured threshold. (`worker/src/lib/telegram.ts`)
- Adjust tests to reflect the new behavior and add regression coverage for ambiguous Telegram JSON `retry_after` cases so later unrelated chats continue to be attempted. (`worker/src/lib/__tests__/telegram.test.ts`)

### Testing
- Ran unit tests with `npx vitest run worker/src/lib/__tests__/telegram.test.ts`, all tests passed (`29 passed`).
- Type-checking passed with `cd worker && npx tsc --noEmit`.
- Cron connection budget check passed with `npm run check:cron-connections`.
- Verified diffs with `git diff --check` and committed the change; checks were clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe3eb0833293676a7d2b353dbe)