### PR TITLE
Harden Telegram disambiguation cleanup (index + batched deletes)

### DIFF
--- a/docs/telegram-alerts.md
+++ b/docs/telegram-alerts.md
@@ -418,7 +418,7 @@ Ticker parsing lives in `worker/src/lib/telegram-alerts.ts` and is built from `T
 - Ambiguous symbols create a row in `telegram_pending_disambiguation`.
 - Users reply with `1` or `1,2` style selections.
 - Pending disambiguation rows expire after `5 minutes`.
-- Expired rows are swept by the `telegram-disambiguation-cleanup` job on the 5-minute Telegram cron slot once `expires_at` is older than `2 * DISAMBIGUATION_TTL_SEC` (10 min minimum) so a slow user mid-selection is not raced. The pass emits `disambiguationRowsCleaned` in its run metadata.
+- Expired rows are swept by the `telegram-disambiguation-cleanup` job on the 5-minute Telegram cron slot once `expires_at` is older than `2 * DISAMBIGUATION_TTL_SEC` (10 min minimum) so a slow user mid-selection is not raced. The expiry scan is indexed and capped at 5,000 deletions per run; overflow is left for later ticks and surfaced via `disambiguationCleanupHasMore`. The pass emits `disambiguationRowsCleaned` in its run metadata.
 - Pending rows record the initiating Telegram user when Telegram provides `message.from.id`; in groups, only that user can complete or cancel the selection.
 - Unknown tickers return a contextual error, with a prefix-based suggestion when available.
 - Unknown preset aliases are reported through the same contextual error path, with `/presets` suggested as the discovery surface.

--- a/worker/migrations/0000_baseline.sql
+++ b/worker/migrations/0000_baseline.sql
@@ -776,6 +776,9 @@ CREATE TABLE IF NOT EXISTS telegram_pending_disambiguation (
   action_payload TEXT NOT NULL DEFAULT '{}'
 );
 
+CREATE INDEX IF NOT EXISTS idx_telegram_pending_disambiguation_expires_at
+  ON telegram_pending_disambiguation (expires_at);
+
 -- ---------------------------------------------------------------------------
 -- telegram_pending_alerts: Overflow delivery queue for telegram alerts
 -- ---------------------------------------------------------------------------

--- a/worker/migrations/0158_telegram_disambiguation_expiry_index.sql
+++ b/worker/migrations/0158_telegram_disambiguation_expiry_index.sql
@@ -1,0 +1,6 @@
+-- rollout-safety: backward-compatible
+-- 0158: Index pending Telegram disambiguation expiry time so the 5-minute
+-- cleanup can find old rows without scanning attacker-amplified backlog rows.
+
+CREATE INDEX IF NOT EXISTS idx_telegram_pending_disambiguation_expires_at
+  ON telegram_pending_disambiguation (expires_at);

--- a/worker/migrations/MANIFEST.md
+++ b/worker/migrations/MANIFEST.md
@@ -101,6 +101,7 @@ Applied sequentially after the baseline (fresh setup) or after the previous indi
 | 0155     | `0155_telegram_retention_indexes.sql`                    | Add Telegram retention indexes for inactive subscriber scans and alert-job cleanup batches                                                       |
 | 0156     | `0156_telegram_reserve_alerts.sql`                       | Add reserve-drift alert flags to telegram subscribers and subscriptions                                                                          |
 | 0157     | `0157_telegram_global_alert_reserve_index.sql`           | Partial index on `telegram_subscribers.global_alert_reserve` for dispatcher reserve-drift fan-out                                                 |
+| 0158     | `0158_telegram_disambiguation_expiry_index.sql`          | Add an expiry index for pending Telegram disambiguation cleanup so five-minute pruning avoids full-table scans                                    |
 
 ## Retired Individual Migrations
 

--- a/worker/src/api/telegram-store/disambiguation.ts
+++ b/worker/src/api/telegram-store/disambiguation.ts
@@ -185,6 +185,8 @@ export async function clearPendingDisambiguation(
 // cleanup. Two TTLs gives a slow user mid-selection room to finish, with a
 // 10-minute floor so the guard remains meaningful if the TTL is ever shortened.
 const DISAMBIGUATION_CLEANUP_GRACE_SEC = Math.max(2 * DISAMBIGUATION_TTL_SEC, 600);
+const DISAMBIGUATION_CLEANUP_BATCH_SIZE = 500;
+const DISAMBIGUATION_CLEANUP_MAX_BATCHES = 10;
 
 /**
  * Deletes expired rows from `telegram_pending_disambiguation`. Rows are only
@@ -200,18 +202,42 @@ export async function cleanExpiredDisambiguations(
 ): Promise<CronResult> {
   throwIfAborted(signal);
   const cutoffSec = Math.floor(Date.now() / 1000) - DISAMBIGUATION_CLEANUP_GRACE_SEC;
-  const result = await runWithOverloadRetry(() =>
-    db
-      .prepare("DELETE FROM telegram_pending_disambiguation WHERE expires_at < ?")
-      .bind(cutoffSec)
-      .run(),
-    3,
-    signal,
-  );
-  const disambiguationRowsCleaned = result.meta?.changes ?? 0;
+  let disambiguationRowsCleaned = 0;
+  let batches = 0;
+  let lastBatchSize = 0;
+
+  do {
+    throwIfAborted(signal);
+    const result = await runWithOverloadRetry(
+      () =>
+        db
+          .prepare(
+            `
+          DELETE FROM telegram_pending_disambiguation
+          WHERE chat_id IN (
+            SELECT chat_id
+              FROM telegram_pending_disambiguation
+             WHERE expires_at < ?
+             ORDER BY expires_at ASC
+             LIMIT ?
+          )
+        `,
+          )
+          .bind(cutoffSec, DISAMBIGUATION_CLEANUP_BATCH_SIZE)
+          .run(),
+      3,
+      signal,
+    );
+    lastBatchSize = result.meta?.changes ?? 0;
+    disambiguationRowsCleaned += lastBatchSize;
+    batches += 1;
+  } while (lastBatchSize >= DISAMBIGUATION_CLEANUP_BATCH_SIZE && batches < DISAMBIGUATION_CLEANUP_MAX_BATCHES);
+
+  throwIfAborted(signal);
+  const disambiguationCleanupHasMore = lastBatchSize >= DISAMBIGUATION_CLEANUP_BATCH_SIZE;
   return createCronResult({
     status: "ok",
     itemCount: disambiguationRowsCleaned,
-    metadata: { disambiguationRowsCleaned, cutoffSec },
+    metadata: { disambiguationRowsCleaned, cutoffSec, batches, disambiguationCleanupHasMore },
   });
 }

--- a/worker/src/cron/__tests__/telegram-quiet-hours.test.ts
+++ b/worker/src/cron/__tests__/telegram-quiet-hours.test.ts
@@ -107,14 +107,19 @@ function createStubDb(rows: DisambiguationRow[]): D1Database {
         return stmt as unknown as D1PreparedStatement;
       },
       run: async () => {
-        if (sql.startsWith("DELETE FROM telegram_pending_disambiguation WHERE expires_at <")) {
-          const [cutoff] = bound as [number];
+        if (sql.includes("DELETE FROM telegram_pending_disambiguation") && sql.includes("ORDER BY expires_at ASC")) {
+          const [cutoff, limit] = bound as [number, number];
           let removed = 0;
-          for (let i = rows.length - 1; i >= 0; i--) {
-            if (rows[i].expires_at < cutoff) {
-              rows.splice(i, 1);
-              removed += 1;
-            }
+          const doomed = rows
+            .map((row, index) => ({ row, index }))
+            .filter(({ row }) => row.expires_at < cutoff)
+            .sort((a, b) => a.row.expires_at - b.row.expires_at)
+            .slice(0, limit)
+            .map(({ index }) => index)
+            .sort((a, b) => b - a);
+          for (const index of doomed) {
+            rows.splice(index, 1);
+            removed += 1;
           }
           return { success: true, meta: { changes: removed } };
         }
@@ -192,6 +197,44 @@ describe("cleanExpiredDisambiguations", () => {
 
     expect(rows.map((row) => row.chat_id)).toEqual(["active", "fresh-expired", "boundary"]);
     expect(result.itemCount).toBe(0);
+  });
+
+  it("deletes expired rows in bounded batches", async () => {
+    const rows: DisambiguationRow[] = Array.from({ length: 501 }, (_, index) => ({
+      chat_id: `old-${index}`,
+      expires_at: NOW_SEC - GRACE_SEC - 60 - index,
+    }));
+    const db = createStubDb(rows);
+
+    const result = await cleanExpiredDisambiguations(db);
+
+    expect(rows).toHaveLength(0);
+    expect(result.itemCount).toBe(501);
+    const metadata = JSON.parse(result.metadata!) as {
+      batches: number;
+      disambiguationCleanupHasMore: boolean;
+    };
+    expect(metadata.batches).toBe(2);
+    expect(metadata.disambiguationCleanupHasMore).toBe(false);
+  });
+
+  it("caps each cron pass to avoid monopolizing the Telegram slot", async () => {
+    const rows: DisambiguationRow[] = Array.from({ length: 5_001 }, (_, index) => ({
+      chat_id: `old-${index}`,
+      expires_at: NOW_SEC - GRACE_SEC - 60 - index,
+    }));
+    const db = createStubDb(rows);
+
+    const result = await cleanExpiredDisambiguations(db);
+
+    expect(rows).toHaveLength(1);
+    expect(result.itemCount).toBe(5_000);
+    const metadata = JSON.parse(result.metadata!) as {
+      batches: number;
+      disambiguationCleanupHasMore: boolean;
+    };
+    expect(metadata.batches).toBe(10);
+    expect(metadata.disambiguationCleanupHasMore).toBe(true);
   });
 
   it("reports zero cleaned when the table is empty", async () => {


### PR DESCRIPTION
### Motivation
- The five-minute Telegram cleanup previously issued an unbounded `DELETE FROM telegram_pending_disambiguation WHERE expires_at < ?` against an unindexed `expires_at`, which forces full-table scans and can overload D1/cron when many pending rows accumulate. 
- The goal is to prevent expensive full-table scans and ensure the Telegram cron slot cannot be monopolized by cleanup work while preserving the existing cleanup semantics and grace window.

### Description
- Add a migration `0158_telegram_disambiguation_expiry_index.sql` and update the baseline to create `idx_telegram_pending_disambiguation_expires_at` on `telegram_pending_disambiguation(expires_at)` so expiry predicates can use an index. 
- Replace the single unbounded delete in `cleanExpiredDisambiguations` with bounded, ordered batch deletes using a subselect `ORDER BY expires_at ASC LIMIT ?`, and introduce `DISAMBIGUATION_CLEANUP_BATCH_SIZE = 500` and `DISAMBIGUATION_CLEANUP_MAX_BATCHES = 10` to cap per-run work. 
- Add abort checks between batches and surface `batches` and `disambiguationCleanupHasMore` in the cron result metadata so overflow is visible and left for later ticks. 
- Update tests in `worker/src/cron/__tests__/telegram-quiet-hours.test.ts` to exercise multi-batch and capped-run behavior, and update `docs/telegram-alerts.md` to document the indexed/capped cleanup semantics.

### Testing
- Ran the focused cron tests with `npx vitest run worker/src/cron/__tests__/telegram-quiet-hours.test.ts` and the suite passed. 
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit` and it succeeded. 
- Ran migration and cron checks with `npm run check:migrations`, `npm run check:cron-connections`, and `npm run check:cron-sync`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fdff308332a10a741dd23630bb)