### PR TITLE
fix(telegram): refresh pending capacity after retry deferrals

### DIFF
--- a/worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts
+++ b/worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts
@@ -1806,6 +1806,7 @@ describe("dispatchTelegramAlerts", () => {
     expect(metadata.freshSent).toBe(1);
     expect(metadata.freshDeferredPerChat).toBe(0);
     expect(mockSendBatch).toHaveBeenCalled();
+    expect(db.getHistory().filter((entry) => entry.sql.includes("COUNT(*) AS total")).length).toBe(2);
   });
 
   it("defers fresh alerts for chats already in per-chat backoff without sending", async () => {

--- a/worker/src/cron/dispatch-telegram-alerts.ts
+++ b/worker/src/cron/dispatch-telegram-alerts.ts
@@ -637,7 +637,10 @@ async function executeFullFanoutPath({
   const expiredCount = await cleanupExpiredPendingAlerts(db, nowSec);
   const pendingQueueChanged =
     drainResult.sent > 0 ||
+    drainResult.blocked > 0 ||
+    drainResult.retryQueued > 0 ||
     drainResult.dropped > 0 ||
+    drainResult.deferred > 0 ||
     expiredCount > 0 ||
     pendingEnqueued > 0;
   const pendingCapacityAfter = pendingQueueChanged


### PR DESCRIPTION
### Motivation
- Prevent dispatch from reusing a stale pending-capacity snapshot when the pending drain performs retry, defer, or blocked-cleanup mutations to `telegram_pending_alerts`, which could surface incorrect telemetry and watchdog/pulse snapshots.

### Description
- Treat `drainResult.blocked`, `drainResult.retryQueued`, and `drainResult.deferred` as queue-changing outcomes in `worker/src/cron/dispatch-telegram-alerts.ts` so a fresh `readPendingCapacitySnapshot()` is performed when those counters are nonzero, and add a regression assertion in `worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts` to verify a retry-queued drain forces the reread.

### Testing
- `npx vitest run worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts` — passed (1 file, 53 tests).
- Attempted `npx vitest run ... --runInBand` — failed due to unsupported Vitest option (flag misuse), not related to the change.
- `npm run check:cron-connections` — passed.
- `cd worker && npx tsc --noEmit` — passed.
- `npm run check:cron-sync` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051db42483328465718bf12ebe7b)