### PR TITLE
Fix duplicate Learn breadcrumb on case-study hub

### DIFF
--- a/src/app/learn/case-studies/__tests__/case-study-page-shell.test.ts
+++ b/src/app/learn/case-studies/__tests__/case-study-page-shell.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildCaseStudyVisibleBreadcrumbs } from "../case-study-page-shell";
+
+describe("buildCaseStudyVisibleBreadcrumbs", () => {
+  it("keeps the case-study hub breadcrumb labels unique", () => {
+    expect(buildCaseStudyVisibleBreadcrumbs().map((item) => item.label)).toEqual([
+      "Dashboard",
+      "Learn",
+      "Case Studies",
+    ]);
+  });
+
+  it("keeps detail pages under the linked case-study hub", () => {
+    expect(buildCaseStudyVisibleBreadcrumbs("Study")).toEqual([
+      { label: "Dashboard", href: "/" },
+      { label: "Learn", href: "/learn/" },
+      { label: "Case Studies", href: "/learn/case-studies/" },
+      { label: "Study" },
+    ]);
+  });
+});

--- a/src/app/learn/case-studies/case-study-page-shell.tsx
+++ b/src/app/learn/case-studies/case-study-page-shell.tsx
@@ -1,6 +1,21 @@
 import type { BreadcrumbItem } from "@/components/breadcrumb-json-ld";
 import { LearnPageShell } from "../_shared/learn-page-shell";
 
+interface VisibleCaseStudyBreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export function buildCaseStudyVisibleBreadcrumbs(finalLabel?: string): readonly VisibleCaseStudyBreadcrumbItem[] {
+  return [
+    { label: "Dashboard", href: "/" },
+    { label: "Learn", href: "/learn/" },
+    ...(finalLabel
+      ? [{ label: "Case Studies", href: "/learn/case-studies/" }, { label: finalLabel }]
+      : [{ label: "Case Studies" }]),
+  ];
+}
+
 interface CaseStudyPageShellProps {
   /** Drives the BreadcrumbList JSON-LD (site-relative urls). */
   breadcrumbItems: BreadcrumbItem[];
@@ -23,19 +38,7 @@ export function CaseStudyPageShell({
   return (
     <LearnPageShell
       breadcrumbItems={breadcrumbItems}
-      visibleBreadcrumbs={[
-        { label: "Dashboard", href: "/" },
-        { label: "Learn", href: "/learn/" },
-        ...(finalLabel
-          ? [
-              { label: "Case Studies", href: "/learn/case-studies/" },
-              { label: finalLabel },
-            ]
-          : [
-              { label: "Learn", href: "/learn/" },
-              { label: "Case Studies" },
-            ]),
-      ]}
+      visibleBreadcrumbs={buildCaseStudyVisibleBreadcrumbs(finalLabel)}
       title={title}
       subtitle={subtitle}
       leadParagraphs={leadParagraphs}


### PR DESCRIPTION
### Motivation
- Remove a UI/accessibility regression that caused the case-study hub breadcrumb to render `Dashboard > Learn > Learn > Case Studies` by eliminating the duplicated `Learn` crumb while preserving the intended breadcrumb structure for detail pages.

### Description
- Centralize visible breadcrumb construction into `buildCaseStudyVisibleBreadcrumbs(finalLabel?)` in `src/app/learn/case-studies/case-study-page-shell.tsx` and use it via `visibleBreadcrumbs={buildCaseStudyVisibleBreadcrumbs(finalLabel)}` to avoid the duplicate `Learn` item.
- Add a focused unit test `src/app/learn/case-studies/__tests__/case-study-page-shell.test.ts` that asserts the hub and detail breadcrumb output is correct and non-duplicated.

### Testing
- Ran the focused Vitest suite with `npx vitest run src/app/learn/case-studies/__tests__/case-study-page-shell.test.ts src/app/learn/case-studies/__tests__/content.test.ts` and the tests passed.
- Ran `npm run typecheck` and it completed successfully, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051ec09083329254889e9d8c0640)