### PR TITLE
fix(worker): fail closed on malformed cache freshness

### DIFF
--- a/worker/src/cron/__tests__/cron-staleness-watchdog.test.ts
+++ b/worker/src/cron/__tests__/cron-staleness-watchdog.test.ts
@@ -151,6 +151,45 @@ describe("cron staleness watchdog", () => {
     ]);
   });
 
+  it("treats malformed watched cache freshness as stale", () => {
+    const stale = evaluateCronStaleness({
+      stablecoins: { ageSeconds: Number.NaN },
+      "fx-rates": { ageSeconds: Number.POSITIVE_INFINITY },
+      "dex-liquidity": { ageSeconds: 0 },
+      "yield-data": { ageSeconds: 0 },
+      dews: { ageSeconds: 0 },
+    });
+
+    expect(stale).toEqual([
+      expect.objectContaining({
+        cacheKey: "stablecoins",
+        ageSeconds: Number.NaN,
+        availabilityImpacting: true,
+      }),
+      expect.objectContaining({
+        cacheKey: "fx-rates",
+        ageSeconds: Number.POSITIVE_INFINITY,
+        availabilityImpacting: true,
+      }),
+    ]);
+  });
+
+  it("does not recover stale markers when watched cache freshness is malformed", async () => {
+    cacheStore.set(ALERT_KEY, JSON.stringify({ firstStaleAt: 100, lastObservedAt: 100, lastAlertedAt: 100 }));
+    mockCacheStatus({ stablecoins: Number.NaN });
+
+    const result = await runCronStalenessWatchdog(fakeDb(), "https://alerts.example/webhook");
+    const metadata = JSON.parse(result.metadata ?? "{}") as {
+      stale: Array<{ cacheKey: string }>;
+      recovered: string[];
+    };
+
+    expect(result.status).toBe("degraded");
+    expect(metadata.stale.map((entry) => entry.cacheKey)).toEqual(["stablecoins"]);
+    expect(metadata.recovered).toEqual([]);
+    expect(cacheStore.has(ALERT_KEY)).toBe(true);
+  });
+
   it("does not mark stale alerts delivered when the webhook send fails", async () => {
     sendAlertMock.mockResolvedValueOnce(false);
     mockCacheStatus({ stablecoins: 1_801 });

--- a/worker/src/cron/cron-staleness-watchdog.ts
+++ b/worker/src/cron/cron-staleness-watchdog.ts
@@ -169,6 +169,10 @@ function readMarker(value: string | null | undefined): AlertMarker | null {
   );
 }
 
+function isFreshAge(ageSeconds: number | null, thresholdSec: number): boolean {
+  return ageSeconds != null && Number.isFinite(ageSeconds) && ageSeconds <= thresholdSec;
+}
+
 function buildFullObservation(
   laneKey: CacheFreshnessLaneKey,
   lane: CacheFreshnessLaneConfig,
@@ -185,12 +189,12 @@ function buildFullObservation(
     producerThresholdSec: thresholdSec,
     endpointThresholdSec: lane.endpointMaxAgeSec,
     availabilityThresholdSec: lane.availabilityMaxAgeSec,
-    availabilityImpacting: ageSeconds == null || ageSeconds > lane.availabilityMaxAgeSec,
+    availabilityImpacting: !isFreshAge(ageSeconds, lane.availabilityMaxAgeSec),
   };
 }
 
 function isStale(observation: CronStalenessObservation): boolean {
-  return observation.ageSeconds == null || observation.ageSeconds > observation.thresholdSec;
+  return !isFreshAge(observation.ageSeconds, observation.thresholdSec);
 }
 
 function buildObservation(


### PR DESCRIPTION
### Motivation

- A refactor changed stale-detection to rely on a `> threshold` predicate which treated non-finite `ageSeconds` values (`NaN`, `Infinity`, non-numeric) as fresh, allowing malformed runtime cache ages to suppress stale alerts and recover markers incorrectly.
- The watchdog must be resilient to malformed D1/cache state and should fail-closed for invalid/non-finite age values so operational monitoring is not silently suppressed.

### Description

- Add a shared finite-age guard `isFreshAge(ageSeconds, thresholdSec)` that returns true only when `ageSeconds` is non-null, finite, and `<= thresholdSec`.
- Use `isFreshAge` for both `isStale()` and `availabilityImpacting` so stale filtering and availability classification share authoritative semantics.
- Add focused unit tests in `worker/src/cron/__tests__/cron-staleness-watchdog.test.ts` to assert that `NaN`/`Infinity` ages are treated as stale, availability-impacting, and do not recover existing alert markers.
- Keep behavior for genuine `null`/missing ages unchanged (still treated as stale) while tightening malformed-value handling.

### Testing

- Ran schedule consistency check with `npm run --silent check:cron-sync` and it passed.
- Ran the targeted Vitest suite with `cd worker && npx vitest run src/cron/__tests__/cron-staleness-watchdog.test.ts` and all tests in that file passed.
- Type-checked the Worker with `cd worker && npx tsc --noEmit` and it succeeded.
- Verified cron connection budgeting with `npm run --silent check:cron-connections` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051df7bc8332a76a97ad15f9c770)