### PR TITLE
test(status): add default action group in button helper

### DIFF
--- a/src/components/status/__tests__/admin-action-button.test.tsx
+++ b/src/components/status/__tests__/admin-action-button.test.tsx
@@ -13,6 +13,7 @@ function makeAction(overrides: Partial<StatusPageAction> = {}): StatusPageAction
     destructive: false,
     method: "POST",
     acceptsStablecoinFilter: true,
+    group: "recovery",
     ...overrides,
   };
 }


### PR DESCRIPTION
### Motivation
- `StatusPageAction.group` was made a required field and the `makeAction()` test factory did not set it, causing TypeScript assignability failures when tests are included in type checking.

### Description
- Add `group: "recovery"` to the `makeAction()` helper in `src/components/status/__tests__/admin-action-button.test.tsx` (placed before `...overrides` so individual tests can still override the group).

### Testing
- Ran `npm run typecheck` (the typecheck configuration that excludes tests) and the change removed the previous `admin-action-button` diagnostic.
- Ran `npx tsc --noEmit -p tsconfig.json` which still fails on unrelated existing test type errors but shows no errors referencing `admin-action-button` after the fix.
- Ran `npm run test -- src/components/status/__tests__/admin-action-button.test.tsx` which was blocked by a preexisting `react`/`react-dom` version mismatch (`react: 19.2.7` vs `react-dom: 19.2.6`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34051efa148332abe2b2e4a5611917)