### PR TITLE
fix(digest): evaluate weekly supply triggers from full 7d changes

### DIFF
--- a/shared/types/digest.ts
+++ b/shared/types/digest.ts
@@ -148,6 +148,10 @@ export interface DigestInputData {
     change7d: number;
     signal: string;
   }[];
+  supplyChanges7d?: {
+    coin: string;
+    change7d: number;
+  }[];
   safetyScores?: {
     mentionedCoins: { symbol: string; grade: string; score: number; peg: number | null; liq: number | null }[];
     medianGrade: string;

--- a/worker/src/cron/__tests__/daily-digest.test.ts
+++ b/worker/src/cron/__tests__/daily-digest.test.ts
@@ -1475,6 +1475,41 @@ describe("digest intelligence enrichment", () => {
     expect(intelligence.calmNarrativeFrame?.label).toBe("Supply rotation");
   });
 
+  it("evaluates a supply-7d trigger against the coin's weekly change when no velocity signal is emitted", () => {
+    const previous: DigestInputData = {
+      ...current,
+      dataQuality: { generatedAt: 1_772_668_800, stablecoinsCacheUpdatedAt: null, stablecoinsCacheAgeSec: null, windows: current.dataQuality?.windows ?? {
+        blacklistActivity: { label: "x", start: 0, end: 0 },
+        mintBurnFlows: { label: "x", start: 0, end: 0 },
+        supplyVelocity: { label: "x", dates: [] },
+        psi: { label: "x", sampleAt: null, dailySnapshotAt: null },
+      } },
+      nextTriggers: [{
+        id: "trigger:supply-7d:usdc",
+        label: "USDC weekly supply move",
+        metric: "supply-7d-usd",
+        comparator: "abs-gte",
+        thresholdValue: 30_000_000,
+        thresholdLabel: "$30M 7d move",
+        symbol: "USDC",
+        rationale: "The largest weekly mover stays useful only if the move keeps scaling.",
+        detail: "If USDC's 7d supply move clears $30M, the story has follow-through.",
+      }],
+    };
+    const today: DigestInputData = {
+      ...current,
+      supplyVelocity: [],
+      supplyChanges7d: [{ coin: "USDC", change7d: 40_000_000 }],
+    };
+
+    const intelligence = buildDigestIntelligence(today, previous);
+
+    expect(intelligence.forwardLookOutcomes?.[0]).toMatchObject({
+      status: "hit",
+      triggerId: "trigger:supply-7d:usdc",
+    });
+  });
+
   it("evaluates a supply-7d trigger against the coin's own velocity even when a different coin is the biggest weekly mover", () => {
     const previous: DigestInputData = {
       ...current,

--- a/worker/src/cron/daily-digest/digest-next-triggers.ts
+++ b/worker/src/cron/daily-digest/digest-next-triggers.ts
@@ -238,11 +238,18 @@ function supply1dOutcome(trigger: DigestNextTrigger, data: DigestInputData, thre
 }
 
 function supply7dOutcome(trigger: DigestNextTrigger, data: DigestInputData, threshold: number) {
-  const velocity = (data.supplyVelocity ?? []).find((entry) => entry.coin.toUpperCase() === trigger.symbol?.toUpperCase());
-  if (!velocity) return { status: "missed" as const, detail: `${trigger.symbol} has no current weekly supply signal.` };
+  const symbol = trigger.symbol?.toUpperCase();
+  const biggestChange = data.biggestSupplyChange;
+  const biggestWeeklyChange = biggestChange && biggestChange.symbol.toUpperCase() === symbol
+    ? { coin: biggestChange.symbol, change7d: biggestChange.changeUsd }
+    : null;
+  const weeklyChange = (data.supplyChanges7d ?? []).find((entry) => entry.coin.toUpperCase() === symbol)
+    ?? biggestWeeklyChange
+    ?? (data.supplyVelocity ?? []).find((entry) => entry.coin.toUpperCase() === symbol);
+  if (!weeklyChange) return { status: "missed" as const, detail: `${trigger.symbol} has no current weekly supply change.` };
   return {
-    status: Math.abs(velocity.change7d) >= threshold ? "hit" as const : "missed" as const,
-    detail: `${trigger.symbol} moved ${signedCurrency(velocity.change7d)} over 7d versus ${trigger.thresholdLabel}.`,
+    status: Math.abs(weeklyChange.change7d) >= threshold ? "hit" as const : "missed" as const,
+    detail: `${trigger.symbol} moved ${signedCurrency(weeklyChange.change7d)} over 7d versus ${trigger.thresholdLabel}.`,
   };
 }
 

--- a/worker/src/cron/daily-digest/input.ts
+++ b/worker/src/cron/daily-digest/input.ts
@@ -114,6 +114,7 @@ export async function buildDailyDigestInput(db: D1Database): Promise<DailyDigest
   let totalMcapUsd = 0;
   let totalPrevWeek = 0;
   let biggestSupplyChange: DigestInputData["biggestSupplyChange"] = null;
+  const supplyChanges7d: NonNullable<DigestInputData["supplyChanges7d"]> = [];
   let biggestAbsChange = 0;
 
   for (const coin of trackedStablecoinAssets) {
@@ -124,14 +125,16 @@ export async function buildDailyDigestInput(db: D1Database): Promise<DailyDigest
     totalPrevWeek += prevWeek;
 
     if (mcap > 1_000_000) {
-      const absChange = Math.abs(mcap - prevWeek);
+      const change7d = mcap - prevWeek;
+      supplyChanges7d.push({ coin: coin.symbol, change7d });
+      const absChange = Math.abs(change7d);
       if (absChange > biggestAbsChange) {
         biggestAbsChange = absChange;
         biggestSupplyChange = {
           id: coin.id,
           symbol: coin.symbol,
           name: coin.name,
-          changeUsd: mcap - prevWeek,
+          changeUsd: change7d,
           currentMcap: mcap,
         };
       }
@@ -283,6 +286,7 @@ export async function buildDailyDigestInput(db: D1Database): Promise<DailyDigest
       yesterdayIndex,
       blacklistActivity,
       supplyVelocity,
+      supplyChanges7d,
       safetyScores,
       resolvedDepegs,
       mintBurnFlows,


### PR DESCRIPTION
### Motivation
- Prevent false-miss outcomes for weekly supply triggers by using a complete per-coin 7d-change table instead of relying exclusively on the sparse `supplyVelocity` anomaly list.
- Preserve backwards compatibility for older snapshots and retain editorial intent that the largest mover remains visible when applicable.

### Description
- Add a new `supplyChanges7d` field to the input type `DigestInputData` to record per-coin 7d supply changes (`shared/types/digest.ts`).
- Populate `supplyChanges7d` while computing market-cap deltas in `buildDailyDigestInput()` so the digest contains a full table of weekly changes (`worker/src/cron/daily-digest/input.ts`).
- Update the `supply7dOutcome()` evaluator to prefer `supplyChanges7d`, fall back to `biggestSupplyChange` when it matches the trigger, and finally fall back to legacy `supplyVelocity` entries (`worker/src/cron/daily-digest/digest-next-triggers.ts`).
- Add a regression test asserting a weekly supply trigger can `hit` when no `supplyVelocity` entry exists but the complete weekly-change table shows the coin cleared the threshold (`worker/src/cron/__tests__/daily-digest.test.ts`).

### Testing
- Ran the focused Vitest case with `npx vitest run worker/src/cron/__tests__/daily-digest.test.ts -t "supply-7d"`, which passed.
- Type-checked the Worker code with `cd worker && npx tsc --noEmit`, which completed successfully after the change.
- Executed the full cron test file with `npx vitest run worker/src/cron/__tests__/daily-digest.test.ts`, and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fef25c8332add624292322ae36)