### PR TITLE
Fix feedback modal page URL freshness

### DIFF
--- a/src/components/__tests__/feedback-modal.test.tsx
+++ b/src/components/__tests__/feedback-modal.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackModal } from "@/components/feedback-modal";
+
+const fetchMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  buildApiUrl: (path: string) => `https://api.example.test${path}`,
+}));
+
+describe("FeedbackModal", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("submits the current page URL after mounting closed", async () => {
+    window.history.replaceState(null, "", "/stablecoin/usdc?panel=overview#top");
+
+    const { rerender } = render(
+      <FeedbackModal
+        open={false}
+        onOpenChange={vi.fn()}
+        defaultType="data-correction"
+        stablecoinId="usdc"
+        stablecoinName="USDC"
+      />,
+    );
+
+    window.history.replaceState(null, "", "/stablecoin/usdc?panel=proof#source");
+
+    rerender(
+      <FeedbackModal
+        open={true}
+        onOpenChange={vi.fn()}
+        defaultType="data-correction"
+        stablecoinId="usdc"
+        stablecoinName="USDC"
+      />,
+    );
+
+    await screen.findByText("/stablecoin/usdc?panel=proof#source");
+
+    fireEvent.change(screen.getByLabelText("What is wrong?"), {
+      target: { value: "The current reserve source is stale." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      pageUrl: "/stablecoin/usdc?panel=proof#source",
+    });
+  });
+});

--- a/src/components/feedback-modal.tsx
+++ b/src/components/feedback-modal.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { useState, useCallback } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -36,10 +31,15 @@ const TYPE_LABELS: Record<FeedbackType, string> = {
 
 const DESCRIPTION_HINTS: Record<FeedbackType, string> = {
   bug: "Describe what happened and what you expected instead.",
-  "data-correction":
-    "e.g. USDC shows $0.00 price since yesterday. CoinGecko shows $1.0001.",
+  "data-correction": "e.g. USDC shows $0.00 price since yesterday. CoinGecko shows $1.0001.",
   "feature-request": "Describe the feature and why it would be useful.",
 };
+
+function getCurrentPageUrl() {
+  return typeof window === "undefined"
+    ? "/"
+    : `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
 
 export function FeedbackModal({
   open,
@@ -57,6 +57,7 @@ export function FeedbackModal({
   const [website, setWebsite] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
+  const [pageUrl, setPageUrl] = useState(getCurrentPageUrl);
 
   const reset = useCallback(() => {
     setType(defaultType);
@@ -74,20 +75,15 @@ export function FeedbackModal({
       if (!next) reset();
       onOpenChange(next);
     },
-    [onOpenChange, reset]
-  );
-
-  const pageUrl = useMemo(
-    () =>
-      typeof window === "undefined"
-        ? "/"
-        : `${window.location.pathname}${window.location.search}${window.location.hash}`,
-    [],
+    [onOpenChange, reset],
   );
 
   const handleSubmit = useCallback(async () => {
     setStatus("loading");
     setErrorMsg("");
+
+    const currentPageUrl = getCurrentPageUrl();
+    setPageUrl(currentPageUrl);
 
     const body = {
       type,
@@ -98,7 +94,7 @@ export function FeedbackModal({
       ...(stablecoinName ? { stablecoinName } : {}),
       ...(pegValue ? { pegValue } : {}),
       ...(contactHandle.trim() ? { contactHandle: contactHandle.trim() } : {}),
-      pageUrl,
+      pageUrl: currentPageUrl,
       website,
     };
 
@@ -122,12 +118,13 @@ export function FeedbackModal({
       setErrorMsg("Network error. Please try again.");
       setStatus("error");
     }
-  }, [type, title, description, expectedValue, stablecoinId, stablecoinName, pegValue, contactHandle, website, pageUrl]);
+  }, [type, title, description, expectedValue, stablecoinId, stablecoinName, pegValue, contactHandle, website]);
+
+  const displayPageUrl = open ? getCurrentPageUrl() : pageUrl;
 
   const needsTitle = type === "bug" || type === "feature-request";
   const contactValid =
-    contactHandle.trim().length === 0 ||
-    (contactHandle.trim().length >= 2 && contactHandle.trim().length <= 100);
+    contactHandle.trim().length === 0 || (contactHandle.trim().length >= 2 && contactHandle.trim().length <= 100);
   const isValid =
     description.trim().length >= 10 &&
     description.trim().length <= 2000 &&
@@ -144,9 +141,7 @@ export function FeedbackModal({
         {status === "success" ? (
           <div className="py-8 text-center space-y-2">
             <p className="text-lg font-medium">Thanks — submitted!</p>
-            <p className="text-sm text-muted-foreground">
-              We review all submissions and prioritize data corrections.
-            </p>
+            <p className="text-sm text-muted-foreground">We review all submissions and prioritize data corrections.</p>
             <Button variant="outline" className="mt-4" onClick={() => handleOpenChange(false)}>
               Close
             </Button>
@@ -172,11 +167,23 @@ export function FeedbackModal({
             </div>
 
             {/* Context banner */}
-            {(stablecoinName || pageUrl) && (
+            {(stablecoinName || displayPageUrl) && (
               <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground space-y-0.5">
-                {stablecoinName && <div><span className="font-medium">Stablecoin:</span> {stablecoinName}</div>}
-                {pegValue && <div><span className="font-medium">Current value:</span> {pegValue}</div>}
-                {pageUrl && <div><span className="font-medium">Page:</span> {pageUrl}</div>}
+                {stablecoinName && (
+                  <div>
+                    <span className="font-medium">Stablecoin:</span> {stablecoinName}
+                  </div>
+                )}
+                {pegValue && (
+                  <div>
+                    <span className="font-medium">Current value:</span> {pegValue}
+                  </div>
+                )}
+                {displayPageUrl && (
+                  <div>
+                    <span className="font-medium">Page:</span> {displayPageUrl}
+                  </div>
+                )}
               </div>
             )}
 
@@ -197,9 +204,7 @@ export function FeedbackModal({
 
             {/* Description */}
             <div className="space-y-1.5">
-              <Label htmlFor="fb-desc">
-                {type === "data-correction" ? "What is wrong?" : "Description"}
-              </Label>
+              <Label htmlFor="fb-desc">{type === "data-correction" ? "What is wrong?" : "Description"}</Label>
               <Textarea
                 id="fb-desc"
                 placeholder={DESCRIPTION_HINTS[type]}
@@ -211,17 +216,14 @@ export function FeedbackModal({
                 className="max-w-full resize-none whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
                 style={{ fieldSizing: "fixed" }}
               />
-              <p className="text-xs text-muted-foreground text-right">
-                {description.length}/2000
-              </p>
+              <p className="text-xs text-muted-foreground text-right">{description.length}/2000</p>
             </div>
 
             {/* Expected value (data-correction only) */}
             {type === "data-correction" && (
               <div className="space-y-1.5">
                 <Label htmlFor="fb-expected">
-                  Expected value / source{" "}
-                  <span className="text-muted-foreground">(optional)</span>
+                  Expected value / source <span className="text-muted-foreground">(optional)</span>
                 </Label>
                 <Input
                   id="fb-expected"
@@ -236,8 +238,7 @@ export function FeedbackModal({
 
             <div className="space-y-1.5">
               <Label htmlFor="fb-contact">
-                Contact handle{" "}
-                <span className="text-xs text-muted-foreground">(optional)</span>
+                Contact handle <span className="text-xs text-muted-foreground">(optional)</span>
               </Label>
               <Input
                 id="fb-contact"
@@ -247,9 +248,7 @@ export function FeedbackModal({
                 maxLength={100}
                 disabled={status === "loading"}
               />
-              <p className="text-xs text-muted-foreground">
-                This handle will be included publicly on GitHub issues.
-              </p>
+              <p className="text-xs text-muted-foreground">This handle will be included publicly on GitHub issues.</p>
             </div>
 
             {/* Honeypot */}
@@ -265,23 +264,14 @@ export function FeedbackModal({
             />
 
             {/* Error */}
-            {status === "error" && errorMsg && (
-              <p className="text-sm text-destructive">{errorMsg}</p>
-            )}
+            {status === "error" && errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
 
             {/* Submit */}
             <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={() => handleOpenChange(false)}
-                disabled={status === "loading"}
-              >
+              <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={status === "loading"}>
                 Cancel
               </Button>
-              <Button
-                onClick={handleSubmit}
-                disabled={!isValid || status === "loading"}
-              >
+              <Button onClick={handleSubmit} disabled={!isValid || status === "loading"}>
                 {status === "loading" ? "Submitting…" : "Submit"}
               </Button>
             </div>


### PR DESCRIPTION
### Motivation
- The feedback modal captured the page URL once at component mount via a memoized value, causing stale `pageUrl` metadata when the modal was mounted while closed and the client-side URL later changed.
- This impacted feedback triage accuracy (hash/query/client-side route changes were not reflected) even though the server validates page paths; the fix preserves existing UX while correcting submitted metadata.

### Description
- Replace the mount-time `useMemo` URL capture with a small helper `getCurrentPageUrl()` that reads `window.location.pathname + search + hash` and use it at render/submit time in `src/components/feedback-modal.tsx`.
- Store an initial `pageUrl` state for the mounted instance but render the live URL while the modal is open and re-read the current URL at submit time to ensure the submitted payload contains the latest path.
- Keep the modal reset behavior unchanged and avoid calling `setState` from an effect; compute the current URL inline when needed to prevent cascading renders.
- Add a focused jsdom regression test `src/components/__tests__/feedback-modal.test.tsx` that mounts the modal closed, mutates `window.history`, opens the modal, submits feedback, and asserts the payload contains the updated `pageUrl`.

### Testing
- Ran the new focused test with `npx vitest run src/components/__tests__/feedback-modal.test.tsx` and it passed (1/1 tests).
- Ran `npm run typecheck` and TypeScript checks succeeded with no errors.
- Ran `npm run lint` (table-primitive check + ESLint) and the lint step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351701d0908332a96ed75c1273331a)