### PR TITLE
Fix USDGO EFFR rate-derived benchmark

### DIFF
--- a/worker/src/cron/__tests__/yield-config-registry.test.ts
+++ b/worker/src/cron/__tests__/yield-config-registry.test.ts
@@ -455,20 +455,27 @@ describe("yield config registry", () => {
     expect(config).toMatchObject({
       stablecoinId: "usdgo-osl",
       spreadBps: 38,
+      benchmarkCurrency: "USD_EFFR",
       benchmarkOverrideKey: "USD_EFFR",
     });
-    expect(config?.benchmarkCurrency).toBeUndefined();
     expect(intentionalGapIds.has("usdgo-osl")).toBe(false);
     expect(INTENTIONAL_GAP_REASONS["usdgo-osl"]).toBeUndefined();
   });
 
-  it("keeps EFFR-linked rate-derived rows on benchmarkOverrideKey instead of benchmarkCurrency", () => {
-    const effrConfigs = RATE_DERIVED_CONFIGS.filter((entry) =>
-      entry.label.toUpperCase().includes("EFFR") || entry.benchmarkOverrideKey === "USD_EFFR",
+  it("distinguishes EFFR APY sources from EFFR PYS benchmark overrides", () => {
+    const effrApyConfigs = RATE_DERIVED_CONFIGS.filter((entry) => entry.label.toUpperCase().includes("EFFR"));
+    const effrOverrideOnlyConfigs = RATE_DERIVED_CONFIGS.filter(
+      (entry) => entry.benchmarkOverrideKey === "USD_EFFR" && !entry.label.toUpperCase().includes("EFFR"),
     );
 
-    expect(effrConfigs.length).toBeGreaterThan(0);
-    for (const config of effrConfigs) {
+    expect(effrApyConfigs.length).toBeGreaterThan(0);
+    for (const config of effrApyConfigs) {
+      expect(config.benchmarkCurrency, config.stablecoinId).toBe("USD_EFFR");
+      expect(config.benchmarkOverrideKey, config.stablecoinId).toBe("USD_EFFR");
+    }
+
+    expect(effrOverrideOnlyConfigs.length).toBeGreaterThan(0);
+    for (const config of effrOverrideOnlyConfigs) {
       expect(config.benchmarkOverrideKey, config.stablecoinId).toBe("USD_EFFR");
       expect(config.benchmarkCurrency, config.stablecoinId).toBeUndefined();
     }

--- a/worker/src/cron/yield-config-rate-sources.ts
+++ b/worker/src/cron/yield-config-rate-sources.ts
@@ -236,7 +236,7 @@ export const RATE_DERIVED_CONFIGS: RateDerivedConfig[] = [
   { stablecoinId: "fusd-finchain", spreadBps: 0, label: "Tokenized T-bill/MMF reserve-yield proxy", benchmarkOverrideKey: "USD_EFFR" },
   { stablecoinId: "safo-spiko-usd", spreadBps: 0, label: "Amundi Smart Cash overnight swap proxy (USD)" },
   { stablecoinId: "spkcc-spiko", spreadBps: 0, label: "Cash-and-carry strategy proxy (USD risk-free leg)" },
-  { stablecoinId: "usdgo-osl", spreadBps: 38, label: "EFFR-linked reserve-yield proxy (net of 0.38% fee)", benchmarkOverrideKey: "USD_EFFR" },
+  { stablecoinId: "usdgo-osl", spreadBps: 38, label: "EFFR-linked reserve-yield proxy (net of 0.38% fee)", benchmarkCurrency: "USD_EFFR", benchmarkOverrideKey: "USD_EFFR" },
   { stablecoinId: "witry-brix", spreadBps: 0, label: "BIST TLREF overnight proxy (TRY)", benchmarkCurrency: "TRY" },
   { stablecoinId: "a7a5-old-vector", spreadBps: 100, label: "CBR key-rate reserve-yield proxy (net of 1.00pp)", benchmarkCurrency: "RUB", benchmarkOverrideKey: "RUB" },
 ];


### PR DESCRIPTION
### Motivation
- USDGO is documented and intended to compute its rate-derived APY from the Effective Federal Funds Rate (EFFR) net of a 38 bps spread, but the runtime config left `benchmarkCurrency` unset and only set `benchmarkOverrideKey`, causing APY to be computed from the default `USD` benchmark instead of `USD_EFFR`.
- This produced a data-integrity regression where the publicly-published `currentApy` for `usdgo-osl` diverged from methodology and vendor-provided metadata.
- The change restores consistency between the documented methodology, stablecoin metadata, and runtime APY calculation logic.

### Description
- Set `benchmarkCurrency: "USD_EFFR"` (in addition to `benchmarkOverrideKey`) for `usdgo-osl` in `worker/src/cron/yield-config-rate-sources.ts` so the `rate-derived` path requests EFFR for current APY computation.
- Updated `worker/src/cron/__tests__/yield-config-registry.test.ts` to expect `benchmarkCurrency: "USD_EFFR"` for EFFR-linked APY sources and to distinguish APY sources that require `benchmarkCurrency` from rows that only use `benchmarkOverrideKey` for PYS/provenance comparisons.
- The change is intentionally minimal and preserves existing `benchmarkOverrideKey` behavior used later in evaluation/provenance logic.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/cron/__tests__/yield-config-registry.test.ts -t "USDGO|EFFR" --reporter=dot` and the targeted tests passed.
- Ran TypeScript typecheck: `cd worker && npx tsc --noEmit` and the build check succeeded with no emitted errors.
- Ran repository checks (`git diff --check`) to ensure whitespace/patch cleanliness and observed no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff0ba48332a1306a70411ce247)