### PR TITLE
fix(docs): only remediate auto-fixable doc-wrong findings

### DIFF
--- a/.claude/workflows/docs-verify-remediate.mjs
+++ b/.claude/workflows/docs-verify-remediate.mjs
@@ -65,13 +65,26 @@ const loaded = await agent(
 )
 if (!loaded || !loaded.findings || !loaded.findings.length) throw new Error('findings load failed')
 
+function isAutoFixableDocFinding(f) {
+  return f.partition === 'auto-fixable' && f.finalClassification === 'doc-wrong' && typeof f.confidence === 'number' && f.confidence >= 0.7
+}
+
+const autoFixableFindings = loaded.findings.filter(isAutoFixableDocFinding)
+const heldForReview = loaded.findings.length - autoFixableFindings.length
+if (!autoFixableFindings.length) {
+  log(`No auto-fixable doc-wrong findings found; held ${heldForReview} findings for human review`)
+  return { docsProcessed: 0, totalDocs: 0, applied: 0, skipped: 0, skippedDetail: [], perDoc: [], heldForReview }
+}
+
 // Group by doc — one agent per doc so no two agents edit the same file.
 const byDoc = {}
-for (const f of loaded.findings) {
+for (const f of autoFixableFindings) {
   ;(byDoc[f.doc] ||= []).push(f)
 }
 const docs = Object.keys(byDoc).sort()
-log(`Applying ${loaded.findings.length} fixes across ${docs.length} docs (one agent per doc, disjoint files)`)
+log(
+  `Applying ${autoFixableFindings.length} auto-fixable doc-wrong fixes across ${docs.length} docs (one agent per doc, disjoint files); held ${heldForReview} findings for human review`,
+)
 
 phase('Apply')
 const SPECIAL_NOTE = {
@@ -113,7 +126,7 @@ const ok = results.filter(Boolean)
 const applied = ok.reduce((n, r) => n + (r.appliedCount || 0), 0)
 const skipped = ok.reduce((n, r) => n + (r.skippedCount || 0), 0)
 const skippedDetail = ok.flatMap((r) => (r.edits || []).filter((e) => e.status === 'skipped').map((e) => `${r.doc}:${e.docLine} — ${e.reason}`))
-log(`Applied ${applied}, skipped ${skipped} across ${ok.length}/${docs.length} docs`)
+log(`Applied ${applied}, skipped ${skipped} across ${ok.length}/${docs.length} docs; held ${heldForReview} findings for human review`)
 
 return {
   docsProcessed: ok.length,
@@ -122,4 +135,5 @@ return {
   skipped,
   skippedDetail,
   perDoc: ok.map((r) => ({ doc: r.doc, applied: r.appliedCount, skipped: r.skippedCount })),
+  heldForReview,
 }


### PR DESCRIPTION
### Motivation
- The remediation workflow was loading `agents/doc-verify/findings.json` verbatim and passing every finding to edit agents, which could auto-apply `needs-decision` / `code-wrong` / low-confidence items and mask issues that require human review. 
- The verify stage already partitions findings into `auto-fixable` and `needs-decision`, so remediation must respect that partition to avoid automatically rewriting docs where the code may be wrong. 
- This change aims to preserve the adversarial verification safeguards and prevent automated prompts from asserting "the DOC is wrong and the CODE is the source of truth" for findings that should be held for a human. 

### Description
- Added `isAutoFixableDocFinding()` and filter logic so only findings with `partition === 'auto-fixable'`, `finalClassification === 'doc-wrong'`, and `confidence >= 0.7` are passed to remediation agents in `/.claude/workflows/docs-verify-remediate.mjs`. 
- Early-return when no auto-fixable findings exist so no apply agents are spawned and the held count is reported. 
- Grouping and apply-phase logic now operates on the filtered `autoFixableFindings` set, and the workflow logs and returned summary include a `heldForReview` count. 
- Changed only `/.claude/workflows/docs-verify-remediate.mjs` to enforce the safety filter and reporting. 

### Testing
- Ran a custom runner-style Node harness that simulates mixed `auto-fixable`, `needs-decision`, and low-confidence findings and verified only the safe item was sent to the apply prompt (harness passed). 
- Ran `npm run check:agent-doc-sync` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff193c833289c78c7fa34e47ad)