### PR TITLE
fix(worker): rebuild reUSD mint burn history

### DIFF
--- a/docs/mint-burn-flows.md
+++ b/docs/mint-burn-flows.md
@@ -484,7 +484,7 @@ CREATE TABLE mint_burn_config_deferral (
 CREATE INDEX idx_mbcd_until ON mint_burn_config_deferral(deferred_until);
 ```
 
-**Migration history:** The earlier per-step mint/burn migrations were squashed into the baseline; the `mint_burn_events`, `mint_burn_hourly`, and `mint_burn_sync_state` tables (v2 layout) now live in `0000_baseline.sql`. Migration 0096 adds `mint_burn_config_deferral`; migration 0097 adds the `(flow_type, timestamp)` composite index on `mint_burn_events`. These are the only post-baseline mint/burn migrations.
+**Migration history:** The earlier per-step mint/burn migrations were squashed into the baseline; the `mint_burn_events`, `mint_burn_hourly`, and `mint_burn_sync_state` tables (v2 layout) now live in `0000_baseline.sql`. Migration 0096 adds `mint_burn_config_deferral`; migration 0097 adds the `(flow_type, timestamp)` composite index on `mint_burn_events`; migration 0158 purges Re Protocol reUSD rows and resets the old vault plus canonical token cursors so the canonical `Transfer` source rebuilds history without stale vault rows.
 
 ---
 

--- a/worker/migrations/0158_reusd_mint_burn_source_rebuild.sql
+++ b/worker/migrations/0158_reusd_mint_burn_source_rebuild.sql
@@ -1,0 +1,22 @@
+-- rollout-safety: backward-compatible
+-- 0158: Rebuild Re Protocol reUSD mint/burn history after switching from
+-- vault Deposited/InstantRedemptionRouted events to canonical token Transfer
+-- events. The old vault rows cannot be distinguished from canonical rows once
+-- inserted because mint_burn_events stores tx/log identity, not source contract,
+-- so purge the affected coin/chain and reset the token cursor for a clean
+-- backfill from the checked-in startBlock.
+
+DELETE FROM mint_burn_hourly
+WHERE stablecoin_id = 'reusd-re-protocol'
+  AND chain_id = 'ethereum';
+
+DELETE FROM mint_burn_events
+WHERE stablecoin_id = 'reusd-re-protocol'
+  AND chain_id = 'ethereum';
+
+DELETE FROM mint_burn_sync_state
+WHERE config_key IN (
+  '1-0x4691c475be804fa85f91c2d6d0adf03114de3093',
+  '1-0x8aeb9453ef22cb38abc7a3af9c208f65c1bfe31e',
+  '1-0x5086bf358635b81d8c47c66d1c8b9e567db70c72'
+);

--- a/worker/migrations/MANIFEST.md
+++ b/worker/migrations/MANIFEST.md
@@ -101,6 +101,7 @@ Applied sequentially after the baseline (fresh setup) or after the previous indi
 | 0155     | `0155_telegram_retention_indexes.sql`                    | Add Telegram retention indexes for inactive subscriber scans and alert-job cleanup batches                                                       |
 | 0156     | `0156_telegram_reserve_alerts.sql`                       | Add reserve-drift alert flags to telegram subscribers and subscriptions                                                                          |
 | 0157     | `0157_telegram_global_alert_reserve_index.sql`           | Partial index on `telegram_subscribers.global_alert_reserve` for dispatcher reserve-drift fan-out                                                 |
+| 0158     | `0158_reusd_mint_burn_source_rebuild.sql`                | Purge Re Protocol reUSD mint/burn rows and reset old/new cursors so canonical token Transfer history backfills cleanly                            |
 
 ## Retired Individual Migrations
 


### PR DESCRIPTION
### Motivation
- Switching reUSD ingestion from vault-level events to canonical token `Transfer` logs leaves previously-ingested vault rows in `mint_burn_events` that are indistinguishable from canonical rows and can double-count historical flows. 
- The sync-state keys are derived from contract address, so the new token-based config starts with a fresh cursor and would backfill without removing stale vault rows. 
- A targeted purge/rebuild migration is required to keep historical aggregates correct while preserving future canonical ingestion.

### Description
- Add D1 migration `0158_reusd_mint_burn_source_rebuild.sql` that deletes `mint_burn_events` and `mint_burn_hourly` rows for `stablecoin_id='reusd-re-protocol'` on `ethereum` and removes the old/new `mint_burn_sync_state` keys so the canonical Transfer-based config backfills from its checked-in `startBlock`.
- Register the new migration in `worker/migrations/MANIFEST.md` and update `docs/mint-burn-flows.md` to document the purge/rebuild step for reUSD.
- The migration is marked `-- rollout-safety: backward-compatible` and is intentionally scoped to the affected coin/chain to minimize blast radius.

### Testing
- Ran migration validation with `npm run check:migrations` and it completed successfully (validated migrations against the manifest).
- Ran unit tests `npx vitest run worker/src/lib/__tests__/mint-burn-contracts.test.ts worker/src/lib/__tests__/mint-burn-parse.test.ts` and all tests passed.
- Typecheck run with `cd worker && npx tsc --noEmit` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe39cc8332acabb73110c30958)