### PR TITLE
fix(worker): avoid status seeding after read failure

### DIFF
--- a/worker/src/lib/__tests__/_helpers/stateful-d1.ts
+++ b/worker/src/lib/__tests__/_helpers/stateful-d1.ts
@@ -59,6 +59,7 @@ export interface StatefulDbOptions {
   failOnSql?: string;
   failMessage?: string;
   failBatchAfterApplyOnce?: boolean;
+  failFirstOnSql?: string;
   failRunAfterApplyOnceOnSql?: string;
   seed?: Partial<StatusStateRow>;
 }
@@ -94,6 +95,7 @@ function seedToStateRow(seed: Partial<StatusStateRow>): StatusStateRow {
 
 export function makeStatefulDb(options: StatefulDbOptions = {}) {
   let batchPostApplyFailureUsed = false;
+  let firstSqlFailureUsed = false;
   let runPostApplyFailureUsed = false;
   const store: {
     stateRow: StatusStateRow | null;
@@ -131,6 +133,11 @@ export function makeStatefulDb(options: StatefulDbOptions = {}) {
       return { results: [] as T[], success: true, meta: {} };
     },
     first: async <T>() => {
+      if (options.failFirstOnSql && !firstSqlFailureUsed && sql.includes(options.failFirstOnSql)) {
+        firstSqlFailureUsed = true;
+        throw new Error(options.failMessage ?? "transient read failed");
+      }
+
       if (sql.includes("FROM status_state")) {
         return store.stateRow as T | null;
       }

--- a/worker/src/lib/__tests__/status-reliability.test.ts
+++ b/worker/src/lib/__tests__/status-reliability.test.ts
@@ -186,6 +186,43 @@ describe("status-reliability", () => {
     expect(failed).toEqual({ state: null, staleness: null });
   });
 
+  it("does not seed status state after a transient read failure", async () => {
+    const { db, store } = makeStatefulDb({
+      failFirstOnSql: "FROM status_state",
+      failMessage: "transient status read failed",
+      seed: {
+        current_status: "healthy",
+        raw_status: "healthy",
+        last_evaluated_at: 500,
+        last_changed_at: 500,
+        consecutive_healthy: 5,
+      },
+    });
+    const issues: Array<{ code: string; operation: string; message: string }> = [];
+
+    const result = await reconcileStatusState(db, 2_000, "degraded", 0.9, [], (issue) => issues.push(issue));
+
+    expect(result).toMatchObject({
+      effectiveStatus: "degraded",
+      persistenceSucceeded: false,
+      transition: null,
+    });
+    expect(result.state).toEqual(buildFallbackStatusState("degraded", 2_000));
+    expect(store.stateRow).toMatchObject({
+      current_status: "healthy",
+      raw_status: "healthy",
+      last_changed_at: 500,
+      consecutive_healthy: 5,
+    });
+    expect(store.transitions).toHaveLength(0);
+    expect(issues).toEqual([
+      expect.objectContaining({
+        code: "status_state_read_failed",
+        operation: "load-status-state",
+      }),
+    ]);
+  });
+
   it("reports persistence diagnostics when status-state tables are unavailable", async () => {
     const issues: Array<{ code: string; operation: string; message: string }> = [];
 
@@ -205,7 +242,6 @@ describe("status-reliability", () => {
 
     const summary = summarizeStatusPersistenceIssues(issues);
     expect(issues.some((issue) => issue.code === "status_state_read_failed")).toBe(true);
-    expect(issues.some((issue) => issue.code === "status_state_persistence_failed")).toBe(true);
     expect(issues.some((issue) => issue.code === "status_state_snapshot_failed")).toBe(true);
     expect(summary?.code).toBe("status_persistence_degraded");
     expect(summary?.message).toBe("Status persistence degraded.");

--- a/worker/src/lib/status-state-store.ts
+++ b/worker/src/lib/status-state-store.ts
@@ -50,6 +50,12 @@ export async function reconcileStatusState(
       .first<StatusStateRow>();
   } catch (error) {
     reportStatusPersistenceIssue(onIssue, "status_state_read_failed", "load-status-state", error);
+    return {
+      effectiveStatus: rawStatus,
+      state: buildFallbackStatusState(rawStatus, now),
+      transition: null,
+      persistenceSucceeded: false,
+    };
   }
 
   if (!current) {


### PR DESCRIPTION
### Motivation
- A transient D1 `SELECT` error left `current` as `null` and allowed the cold-start seed path to upsert/overwrite an existing `status_state` row, corrupting status/transition history.
- The change prevents transient read failures from mutating persisted status state or appending an init transition that does not reflect true history.

### Description
- On `status_state` read failure `reconcileStatusState()` now reports the issue and returns a fallback state without attempting the seed write or transition inserts, preserving existing rows and history.
- Added a regression test `does not seed status state after a transient read failure` in `worker/src/lib/__tests__/status-reliability.test.ts` that seeds an existing row, simulates a one-shot read failure, and asserts no writes or transitions occur.
- Extended the stateful D1 test helper (`worker/src/lib/__tests__/_helpers/stateful-d1.ts`) with a `failFirstOnSql` one-shot `first()` failure hook to simulate transient read failures; adjusted an existing diagnostics test to match the new behavior.

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/status-reliability.test.ts` and all tests passed (`16 passed`).
- Ran `cd worker && npx tsc --noEmit` and TypeScript checks completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe10848332bda490360b47d7ea)