### PR TITLE
fix: exclude NAV events from cached peg counters

### DIFF
--- a/worker/src/lib/__tests__/report-cards-snapshot.test.ts
+++ b/worker/src/lib/__tests__/report-cards-snapshot.test.ts
@@ -1063,8 +1063,9 @@ describe("buildReportCardsSnapshot", () => {
       pegDataById: new Map([["usdt-tether", pegSummary]]),
       eventsByCoin: new Map(),
       allEvents: [
-        { startedAt: Math.max(todayStartSec, nowSec - 60) },
-        { startedAt: todayStartSec - 60 },
+        { stablecoinId: "usdt-tether", startedAt: Math.max(todayStartSec, nowSec - 60) },
+        { stablecoinId: "fpi-frax", startedAt: Math.max(todayStartSec, nowSec - 30) },
+        { stablecoinId: "usdt-tether", startedAt: todayStartSec - 60 },
       ],
       nowSec,
       methodology: {

--- a/worker/src/lib/report-cards-snapshot.ts
+++ b/worker/src/lib/report-cards-snapshot.ts
@@ -1,4 +1,4 @@
-import { ACTIVE_STABLECOINS, ACTIVE_META_BY_ID } from "@shared/lib/stablecoins/registry";
+import { ACTIVE_STABLECOINS, ACTIVE_META_BY_ID, TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import { derivePegAnalyticsSnapshot } from "./peg-analytics";
 import { writePegAnalyticsCache } from "./peg-analytics-cache";
 import { DAY_SECONDS } from "@shared/lib/time-constants";
@@ -106,6 +106,7 @@ export async function buildReportCardsSnapshot(
     let depegEventsToday = 0;
     let depegEventsYesterday = 0;
     for (const event of pegAnalytics.allEvents ?? []) {
+      if (TRACKED_META_BY_ID.get(event.stablecoinId)?.flags.navToken === true) continue;
       if (event.startedAt >= todayStartSec) depegEventsToday += 1;
       else if (event.startedAt >= yesterdayStartSec) depegEventsYesterday += 1;
     }


### PR DESCRIPTION
### Motivation
- The peg-summary endpoint produced inconsistent depeg counters because the producer-published peg-analytics cache included NAV-token depeg rows while the on-demand recompute path filtered them out. 
- This caused cache-hit `/api/peg-summary` responses to report inflated `depegEventsToday`/`depegEventsYesterday` compared with the cache-miss direct computation.

### Description
- Import `TRACKED_META_BY_ID` and skip NAV-token events when counting `depegEventsToday`/`depegEventsYesterday` in `buildReportCardsSnapshot` so the published peg-analytics cache excludes NAV events. 
- Preserve the existing `includeNavTokens: true` peg analytics snapshot but apply the NAV filter only when computing the published summary counters. 
- Add a regression fixture to `worker/src/lib/__tests__/report-cards-snapshot.test.ts` that injects a same-day NAV event (`fpi-frax`) into `allEvents` and asserts the published counters do not count it. 

### Testing
- Ran the focused Vitest suites with `npx vitest run worker/src/lib/__tests__/report-cards-snapshot.test.ts worker/src/api/__tests__/peg-summary.test.ts worker/src/lib/__tests__/peg-analytics.test.ts --reporter=dot` and all tests passed. 
- Ran `npm run typecheck:worker` (worker `tsc --noEmit`) and it completed without type errors. 
- Verified there are no diff/check issues with `git diff --check` (no reported problems).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe72708332a0f140df7e22ca65)