### PR TITLE
fix(mint-authority): preserve inherited detail labels

### DIFF
--- a/src/app/stablecoin/[id]/page.tsx
+++ b/src/app/stablecoin/[id]/page.tsx
@@ -181,7 +181,7 @@ export default async function StablecoinDetailPage({ params }: { params: Promise
   const staticCoin = buildStablecoinStaticMeta(coin, {
     hasCollateralUsage: collateralUsageEntries.length > 0,
   });
-  const clientCoin = buildStablecoinDetailClientCoin(coin);
+  const clientCoin = buildStablecoinDetailClientCoin(coin, { parentById: TRACKED_META_BY_ID });
   const structuredDataDateModified = summary?.updatedAt ?? coin.frozenAt;
   // Server-rendered in both the crawl-state fallback and the hydrated dossier
   // so the FAQPage JSON-LD content stays visible in every render state.

--- a/src/lib/__tests__/stablecoin-detail-view-model.test.ts
+++ b/src/lib/__tests__/stablecoin-detail-view-model.test.ts
@@ -123,6 +123,25 @@ describe("stablecoin detail view-model builder", () => {
     expect(buildMintAuthorityDetailViewModel(clientCoin).status).toBe("reviewed");
   });
 
+  it("keeps inherited mint-authority weakest-control labels on detail pages", () => {
+    const coin = TRACKED_META_BY_ID.get("steakusdt-steakhouse");
+    expect(coin).toBeDefined();
+
+    const withoutRichParent = buildMintAuthorityDetailViewModel(buildStablecoinDetailClientCoin(coin!));
+    const withRichParent = buildMintAuthorityDetailViewModel(
+      buildStablecoinDetailClientCoin(coin!, { parentById: TRACKED_META_BY_ID }),
+    );
+
+    expect(withoutRichParent.score).toMatchObject({
+      score: 48,
+      weakestControlLabel: null,
+    });
+    expect(withRichParent.score).toMatchObject({
+      score: 48,
+      weakestControlLabel: "Ethereum USDT token owner multisig",
+    });
+  });
+
   it("projects mint-authority review gaps into the detail view model", () => {
     const viewModel = buildMintAuthorityDetailViewModel({
       mintAuthoritySummary: {

--- a/src/lib/mint-authority-display.ts
+++ b/src/lib/mint-authority-display.ts
@@ -234,15 +234,17 @@ const resolveClientParent: MintAuthorityParentResolver = (id) => {
 function computeMintAuthoritySummaryScore(
   id: string | undefined,
   summary?: MintAuthorityCoverageSummary | null,
+  parentResolver: MintAuthorityParentResolver = resolveClientParent,
 ): MintAuthorityScoreResult {
-  return computeMintAuthorityScore(mintAuthoritySummaryToScoringInput(id, summary), resolveClientParent);
+  return computeMintAuthorityScore(mintAuthoritySummaryToScoringInput(id, summary), parentResolver);
 }
 
 export function resolveMintAuthorityScoreDisplay(
   id: string | undefined,
   summary?: MintAuthorityCoverageSummary | null,
+  parentResolver: MintAuthorityParentResolver = resolveClientParent,
 ): MintAuthorityScoreDisplay {
-  const result = computeMintAuthoritySummaryScore(id, summary);
+  const result = computeMintAuthoritySummaryScore(id, summary, parentResolver);
   const bandKey = result.band ?? "nr";
   const scoreLabel = result.score != null ? `${result.score}/100` : "NR";
   const compactLabel = result.score != null ? `${result.score} ${result.bandLabel}` : "NR";

--- a/src/lib/stablecoin-detail-mint-authority-view-model.ts
+++ b/src/lib/stablecoin-detail-mint-authority-view-model.ts
@@ -17,6 +17,7 @@ import { formatMintAuthorityCustodyAttestation } from "@/lib/stablecoin-detail-m
 import {
   EOA_UNVERIFIED_CUSTODY_LABEL,
   type MintAuthorityCapKind,
+  type MintAuthorityParentResolver,
   type MintAuthorityCapTrace,
 } from "@shared/lib/mint-authority-scoring";
 
@@ -101,12 +102,48 @@ export interface MintAuthorityDetailViewModel {
 
 export type StablecoinDetailCoinMeta = Omit<StablecoinMeta, "mintAuthority"> & {
   mintAuthoritySummary?: MintAuthorityClientSummary | null;
+  mintAuthorityParentSummaries?: Record<string, MintAuthorityClientSummary>;
 };
 
-export function buildStablecoinDetailClientCoin(coin: StablecoinMeta): StablecoinDetailCoinMeta {
+interface BuildStablecoinDetailClientCoinOptions {
+  parentById?: ReadonlyMap<string, StablecoinMeta>;
+}
+
+function collectMintAuthorityParentSummaries(
+  summary: MintAuthorityClientSummary | null,
+  parentById: ReadonlyMap<string, StablecoinMeta> | undefined,
+): Record<string, MintAuthorityClientSummary> | undefined {
+  if (!summary?.inheritedFrom || !parentById) return undefined;
+
+  const parents: Record<string, MintAuthorityClientSummary> = {};
+  const seen = new Set<string>();
+  let inheritedFrom: string | undefined = summary.inheritedFrom;
+
+  while (inheritedFrom && !seen.has(inheritedFrom)) {
+    seen.add(inheritedFrom);
+    const parentCoin = parentById.get(inheritedFrom);
+    if (!parentCoin) break;
+    const parentSummary = projectMintAuthorityClientSummary(parentCoin);
+    if (!parentSummary) break;
+    parents[inheritedFrom] = parentSummary;
+    inheritedFrom = parentSummary.inheritedFrom;
+  }
+
+  return Object.keys(parents).length > 0 ? parents : undefined;
+}
+
+export function buildStablecoinDetailClientCoin(
+  coin: StablecoinMeta,
+  options: BuildStablecoinDetailClientCoinOptions = {},
+): StablecoinDetailCoinMeta {
   const { mintAuthority: _serverOnlyMintAuthority, ...clientCoin } = coin;
   const mintAuthoritySummary = projectMintAuthorityClientSummary(coin);
-  return mintAuthoritySummary ? { ...clientCoin, mintAuthoritySummary } : clientCoin;
+  const mintAuthorityParentSummaries = collectMintAuthorityParentSummaries(mintAuthoritySummary, options.parentById);
+  return {
+    ...clientCoin,
+    ...(mintAuthoritySummary ? { mintAuthoritySummary } : {}),
+    ...(mintAuthorityParentSummaries ? { mintAuthorityParentSummaries } : {}),
+  };
 }
 
 const NOT_REVIEWED_MINT_AUTHORITY: MintAuthorityDetailViewModel = {
@@ -377,6 +414,26 @@ function readMintIncidents(value: unknown): MintAuthorityDetailIncidentViewModel
   return incidents.sort((a, b) => b.date.localeCompare(a.date));
 }
 
+function buildMintAuthorityParentResolver(
+  parentSummaries: StablecoinDetailCoinMeta["mintAuthorityParentSummaries"],
+): MintAuthorityParentResolver | undefined {
+  if (!parentSummaries) return undefined;
+  return (id) => {
+    const parent = parentSummaries[id];
+    return parent
+      ? {
+          id,
+          mintPath: parent.mintPath,
+          authorityPosture: parent.authorityPosture,
+          confidence: parent.confidence,
+          inheritedFrom: parent.inheritedFrom,
+          mintIncidents: parent.mintIncidents,
+          controls: parent.controls,
+        }
+      : null;
+  };
+}
+
 function buildMintAuthorityScoreViewModel(display: MintAuthorityScoreDisplay): MintAuthorityDetailScoreViewModel {
   const result = display.result;
   const components = MINT_AUTHORITY_SCORE_COMPONENT_KEYS.map((key) => {
@@ -473,7 +530,10 @@ export function buildMintAuthorityDetailViewModel(coin: StablecoinDetailCoinMeta
   const controls = (candidate.controls ?? [])
     .map(buildMintAuthorityControlViewModel)
     .filter((control): control is MintAuthorityDetailControlViewModel => control !== null);
-  const score = buildMintAuthorityScoreViewModel(resolveMintAuthorityScoreDisplay(coin.id, coin.mintAuthoritySummary));
+  const parentResolver = buildMintAuthorityParentResolver(coin.mintAuthorityParentSummaries);
+  const score = buildMintAuthorityScoreViewModel(
+    resolveMintAuthorityScoreDisplay(coin.id, coin.mintAuthoritySummary, parentResolver),
+  );
 
   return {
     status: "reviewed",


### PR DESCRIPTION
### Motivation
- Detail pages for inherited stablecoins lost parent `weakestControl` labels after the cross-coin client registry stopped shipping per-control `label`, because the detail scoring path still resolved parents from the slim registry.
- The goal is to restore explanatory parent control labels on detail pages without reintroducing labels into the global slim client payload (keeping the cross-coin payload compact).

### Description
- Add an optional `mintAuthorityParentSummaries` field to the detail-page client coin and a `collectMintAuthorityParentSummaries()` helper to gather only the needed parent summaries from a provided parent registry when a coin `inheritedFrom` another coin (`src/lib/stablecoin-detail-mint-authority-view-model.ts`).
- Introduce a detail-only parent resolver builder `buildMintAuthorityParentResolver()` and allow `resolveMintAuthorityScoreDisplay()` / `computeMintAuthoritySummaryScore()` to accept an optional `parentResolver` so detail scoring can consult rich parent summaries instead of the slim global registry (`src/lib/mint-authority-display.ts`, `src/lib/stablecoin-detail-mint-authority-view-model.ts`).
- Wire the server-rendered detail page to pass the richer server-side registry into the detail projection via `buildStablecoinDetailClientCoin(coin, { parentById: TRACKED_META_BY_ID })` so inherited coins include parent summaries only when needed (`src/app/stablecoin/[id]/page.tsx`).
- Add regression coverage demonstrating an inherited coin whose numeric score is unchanged while the parent `weakestControl` label is restored (`src/lib/__tests__/stablecoin-detail-view-model.test.ts`).

### Testing
- Ran `npx vitest run src/lib/__tests__/stablecoin-detail-view-model.test.ts` and the updated test suite passed.
- Ran the repo scoped type check with `npm run typecheck` and it passed for the changed modules.
- Ran ESLint on the touched files with `npx eslint <files> --max-warnings=0` and it passed.
- `npx tsc --noEmit --pretty false` (a broad full-repo check) surfaced pre-existing type issues outside the scope of this patch and is not blocking this focused fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe03d48332a9fe5412497a52d2)