### PR TITLE
Fix mint authority coverage bar partition

### DIFF
--- a/src/app/coverage/coverage-feature-snapshot.test.tsx
+++ b/src/app/coverage/coverage-feature-snapshot.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { COVERAGE_FEATURES } from "@/lib/coverage";
+import type { CoverageFeatureSummary } from "@/lib/coverage";
+import { CoverageFeatureSnapshotRow } from "./coverage-feature-snapshot";
+
+afterEach(cleanup);
+
+describe("CoverageFeatureSnapshotRow", () => {
+  it("uses only mint-authority route buckets for stacked-bar semantics", () => {
+    const summary: CoverageFeatureSummary = {
+      feature: COVERAGE_FEATURES.find((feature) => feature.key === "mintAuthority")!,
+      availableCount: 1,
+      totalCount: 2,
+      coveragePct: 50,
+      coveredMcapUsd: 800,
+      mcapSharePct: 80,
+      countLabel: "Reviewed authority",
+      coverageLabel: "50% with reviewed mint authority",
+      shareLabel: "Reviewed mint-authority market-cap reach",
+      breakdown: [
+        { key: "issuer-or-backend-mint", label: "issuer/backend", count: 1 },
+        { key: "unknown", label: "unknown", count: 1 },
+        { key: "score-concentrated", label: "Concentrated", count: 1 },
+        { key: "score-nr", label: "NR", count: 1 },
+      ],
+    };
+
+    render(<CoverageFeatureSnapshotRow summary={summary} />);
+
+    const bar = screen.getByRole("img", {
+      name: "Mint Authority coverage: issuer/backend 1, unknown 1",
+    });
+
+    expect(bar).toBeTruthy();
+    expect(bar.querySelectorAll("[title]")).toHaveLength(2);
+    expect(bar.getAttribute("aria-label")).not.toContain("Concentrated");
+    expect(bar.getAttribute("aria-label")).not.toContain("NR");
+  });
+});

--- a/src/app/coverage/coverage-feature-snapshot.tsx
+++ b/src/app/coverage/coverage-feature-snapshot.tsx
@@ -57,6 +57,10 @@ export interface CoverageFeatureSnapshotRowProps {
 function getStackedBarItems(summary: CoverageFeatureSummary): CoverageBreakdownItem[] {
   const nonZeroItems = summary.breakdown.filter((item) => item.count > 0);
 
+  if (summary.feature.key === "mintAuthority") {
+    return nonZeroItems.filter((item) => !item.key.startsWith("score-"));
+  }
+
   if (summary.feature.key !== "price") {
     return nonZeroItems;
   }


### PR DESCRIPTION
### Motivation
- The mint-authority feature started including both route/status buckets and score-band buckets in the same breakdown array, which caused the coverage snapshot stacked-bar renderer to double-count rows and display misleading proportions and ARIA/tooltip labels.

### Description
- Exclude score-band breakdown items (keys starting with `score-`) from the stacked-bar partition for the `mintAuthority` feature in `src/app/coverage/coverage-feature-snapshot.tsx` so the bar/ARIA semantics remain a single mutually-exclusive route/status partition.
- Add a focused regression test `src/app/coverage/coverage-feature-snapshot.test.tsx` that reproduces a mixed route+score breakdown and asserts the rendered bar and `aria-label` only include route buckets.

### Testing
- Ran `npx vitest run src/app/coverage/coverage-feature-snapshot.test.tsx src/lib/__tests__/coverage.test.ts` and the tests passed (all tests green).
- Ran `npm run typecheck` and the TypeScript checks completed without errors.
- Ran `npx eslint src/app/coverage/coverage-feature-snapshot.tsx src/app/coverage/coverage-feature-snapshot.test.tsx --max-warnings=0` and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe075c833287b2b860411e5a6c)