### PR TITLE
fix(seo): keep noindex routes crawlable

### DIFF
--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -3,7 +3,7 @@ import { SITE_ORIGIN } from "@shared/lib/runtime-origins";
 import robots from "../robots";
 
 describe("robots", () => {
-  it("allows crawlers to observe route-level noindex responses, except operational surfaces", () => {
+  it("allows crawlers to observe route-level noindex responses", () => {
     const metadata = robots();
 
     expect(metadata).toEqual({
@@ -11,7 +11,6 @@ describe("robots", () => {
         {
           userAgent: "*",
           allow: "/",
-          disallow: ["/admin/", "/admin-api/", "/pharoswatchbot/app/"],
         },
       ],
       sitemap: `${SITE_ORIGIN}/sitemap.xml`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,10 +9,6 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        // Operational surfaces that are noindex,nofollow anyway — disallowing
-        // them saves crawl budget. Routes that rely on crawlers observing a
-        // noindex response (portfolio, yield subpages, datasets) stay crawlable.
-        disallow: ["/admin/", "/admin-api/", "/pharoswatchbot/app/"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,


### PR DESCRIPTION
### Motivation
- A recent change added `robots.txt` `Disallow` rules for admin and mini-app surfaces which prevents compliant crawlers from fetching those URLs and observing the existing `noindex` headers/route metadata, causing an SEO/crawl-control regression.

### Description
- Removed the `disallow` entries from the robots metadata in `src/app/robots.ts` so the site remains crawlable and crawlers can observe per-route `noindex` signals.
- Updated the focused robots metadata test in `src/app/__tests__/robots.test.ts` to assert the crawlable `noindex` contract (removed the disallow expectation).

### Testing
- Ran the focused unit test with `npm test -- src/app/__tests__/robots.test.ts` which passed successfully.
- Ran `npm run seo:check` which failed due to a missing static build output directory (`/out`) in the environment, so full static SEO checks were not executed.
- Ran `npm run build` which failed in this environment because Playwright browsers are not installed, preventing a complete site build in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe7f808332bf73df37931673f8)