### PR TITLE
fix(ci): preserve Pages git-derived metadata

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -75,7 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 1
+          # Full history is required because the build prehook regenerates
+          # git-history-derived sitemap/docs metadata before Next builds.
+          fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.ACTIONS_CHECKOUT_TOKEN || github.token }}
       - uses: ./.github/actions/setup-workspace

--- a/scripts/__tests__/validate-ci-parity.test.ts
+++ b/scripts/__tests__/validate-ci-parity.test.ts
@@ -582,6 +582,8 @@ describe("validate-ci parity", () => {
     expect(pagesReleaseJob).toContain("PUBLIC_DATASETS_API_URL:");
     expect(pagesReleaseJob).toContain('PUBLIC_DATASETS_REQUIRE_API: "1"');
     expect(pagesReleaseJob).toContain('NEXT_PUBLIC_FORCE_SITE_DATA_PROXY: "true"');
+    expect(pagesReleaseJob).toContain("fetch-depth: 0");
+    expect(pagesReleaseJob).toContain("git-history-derived sitemap/docs metadata");
     expect(pagesReleaseJob).toContain('PUBLIC_DATASETS_API_URL: ""');
     expect(pagesReleaseJob).toContain('PUBLIC_DATASETS_REQUIRE_API: ""');
     expectTextInOrder(pagesReleaseJob, [


### PR DESCRIPTION
### Motivation
- A shallow `fetch-depth: 1` checkout in the Pages release job caused generators that read git history (sitemap dates and docs metadata) to collapse to the release HEAD timestamp, producing incorrect deployed timestamps.
- The Pages release build still runs the `prebuild` hook that regenerates git-history-derived artifacts, so the release checkout must provide full history for correct metadata generation.

### Description
- Change `actions/checkout` in `.github/workflows/pages-release.yml` to use `fetch-depth: 0` and add a comment explaining that full history is required for git-derived sitemap/docs metadata generation before the Next build.
- Add CI parity assertions in `scripts/__tests__/validate-ci-parity.test.ts` to ensure the Pages release workflow includes the `fetch-depth: 0` change and documents the rationale so future edits do not regress this requirement.
- No runtime application code was modified and the generator behavior is preserved; this is a CI/workflow fix to ensure correctness of produced artifacts.

### Testing
- Ran the focused CI parity tests with `npx vitest run scripts/__tests__/validate-ci-parity.test.ts`, and all tests passed (19 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe3d6c833283c01d13ce4121f4)