### PR TITLE
Fix non-finite safety score tone

### DIFF
--- a/src/app/safety-scores/inspection-board.test.tsx
+++ b/src/app/safety-scores/inspection-board.test.tsx
@@ -79,4 +79,35 @@ describe("SafetyInspectionBoard", () => {
     );
     expect(liquidityButton.getAttribute("aria-pressed")).toBe("false");
   });
+
+  it("maps non-finite safety scores to the conservative critical tone", () => {
+    const nanModel: SafetyInspectionBoardModel = {
+      ...MODEL,
+      leadFinding: {
+        ...MODEL.leadFinding!,
+        averageScore: Number.NaN,
+        weightedScore: null,
+      },
+      rows: [
+        {
+          ...MODEL.rows[0],
+          averageScore: Number.NaN,
+          weightedScore: null,
+        },
+      ],
+    };
+
+    render(
+      <SafetyInspectionBoard
+        model={nanModel}
+        sortKey="liquidity"
+        sortDirection="asc"
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    const liquidityButton = screen.getByRole("button", { name: "Sort report cards by weakest Liquidity first" });
+    expect(liquidityButton.textContent).toContain("Critical");
+    expect(liquidityButton.querySelector(".bg-red-500")).not.toBeNull();
+  });
 });

--- a/src/app/safety-scores/inspection-board.tsx
+++ b/src/app/safety-scores/inspection-board.tsx
@@ -62,6 +62,8 @@ const SCORE_TONE_BANDS = [
   },
 ] as const satisfies readonly (ScoreTone & { min: number })[];
 
+const CRITICAL_SCORE_TONE = SCORE_TONE_BANDS[SCORE_TONE_BANDS.length - 1];
+
 function scoreTone(row: SafetyInspectionRow): {
   text: string;
   bar: string;
@@ -73,7 +75,7 @@ function scoreTone(row: SafetyInspectionRow): {
   if (score == null) {
     return NOT_RATED_SCORE_TONE;
   }
-  return SCORE_TONE_BANDS.find((band) => score >= band.min) ?? SCORE_TONE_BANDS[0];
+  return SCORE_TONE_BANDS.find((band) => score >= band.min) ?? CRITICAL_SCORE_TONE;
 }
 
 function formatScoreOrNotRated(score: number | null): string {


### PR DESCRIPTION
### Motivation
- A refactor of the safety-score tone lookup caused `NaN` (non-finite) scores to fall through and incorrectly render as the top/"Clean" band because the fallback used the first entry in `SCORE_TONE_BANDS`.
- Non-finite or malformed in-memory scores should be handled conservatively (treated as critical) rather than presented as clean, to avoid misleading UI/state.

### Description
- Add an explicit `CRITICAL_SCORE_TONE` constant and change the `scoreTone()` fallback to return `CRITICAL_SCORE_TONE` when no band matches instead of `SCORE_TONE_BANDS[0]` in `src/app/safety-scores/inspection-board.tsx`.
- Preserve the existing `Not rated` handling for `null`/`undefined` scores and only change the fallback for scores that miss all bands (e.g., `NaN`).
- Add a regression test in `src/app/safety-scores/inspection-board.test.tsx` that renders a `NaN` safety inspection row and asserts the board shows the `Critical` label and red tone, and adjust the assertion to a compatible matcher for the test environment.

### Testing
- Ran `npx vitest run src/app/safety-scores/inspection-board.test.tsx` and the suite passed (2 tests).
- Ran `npm run typecheck` (`tsc --noEmit -p tsconfig.typecheck.json`) and the project typecheck passed.
- Verified the changed test covers the `NaN` case and confirms the UI tone renders as `Critical`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe64c48332ab79eb154fa80ea7)