### PR TITLE
Refresh DDR degraded row reasons

### DIFF
--- a/worker/src/cron/__tests__/compute-depeg-resolver.test.ts
+++ b/worker/src/cron/__tests__/compute-depeg-resolver.test.ts
@@ -341,6 +341,11 @@ describe("computeDepegResolver", () => {
       nowSec: NOW_SEC - 600,
       storageAvailable: true,
     });
+    previousSnapshot.rows[0].live = {
+      ...previousSnapshot.rows[0].live,
+      stale: true,
+      degradedReason: "previous-context-failure",
+    };
     const db = mockD1([
       { match: "FROM depeg_events_with_provenance WHERE (provenance_audit_verdict", rows: [event] },
       { match: "FROM depeg_events_with_provenance WHERE ended_at IS NULL", rows: [event] },

--- a/worker/src/cron/compute-depeg-resolver.ts
+++ b/worker/src/cron/compute-depeg-resolver.ts
@@ -92,7 +92,7 @@ async function degradedPublicSnapshotFromCache(input: {
       live: {
         ...row.live,
         stale: true,
-        degradedReason: row.live.degradedReason ?? input.reason,
+        degradedReason: input.reason,
       },
     })),
   };


### PR DESCRIPTION
### Motivation
- Preserve public diagnostics correctness by ensuring preserved DDR rows republished during degraded runs always carry the current snapshot-level degraded reason instead of retaining an old per-row reason.

### Description
- Update `degradedPublicSnapshotFromCache` in `worker/src/cron/compute-depeg-resolver.ts` to set `live.degradedReason` to the current `input.reason` for every preserved row instead of `row.live.degradedReason ?? input.reason`.
- Extend the scheduler-health degradation test in `worker/src/cron/__tests__/compute-depeg-resolver.test.ts` to seed a cached row with an old `degradedReason` and assert the republished row is overwritten with the current degraded reason.
- Changes touch `worker/src/cron/compute-depeg-resolver.ts` and `worker/src/cron/__tests__/compute-depeg-resolver.test.ts`.

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/compute-depeg-resolver.test.ts` and the test suite passed (all tests succeeded).
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff534883328f2e330c1ff0034a)