### PR TITLE
Restore runtime validation for weekly grade transitions

### DIFF
--- a/worker/src/cron/__tests__/weekly-recap.test.ts
+++ b/worker/src/cron/__tests__/weekly-recap.test.ts
@@ -402,6 +402,35 @@ describe("generateWeeklyRecap", () => {
     expect(body.messages[0].content).toMatch(/PSI midpoint: current .+ prior .+/i);
   });
 
+  it("filters malformed grade transitions before building the weekly risk leaderboard", async () => {
+    const rows = buildDailyRows();
+    rows[1] = {
+      ...rows[1]!,
+      input_data: JSON.stringify({
+        ...(JSON.parse(rows[1]!.input_data) as Record<string, unknown>),
+        gradeTransitions: [{ mcapUsd: 1_000_000 }],
+      }),
+    };
+    rows[2] = {
+      ...rows[2]!,
+      input_data: JSON.stringify({
+        ...(JSON.parse(rows[2]!.input_data) as Record<string, unknown>),
+        gradeTransitions: [{ symbol: "USDT", fromGrade: "A", toGrade: "B", mcapUsd: 2_000_000 }],
+      }),
+    };
+    const db = mockD1(makeTables({ dailyRows: rows }), { requireMatch: true });
+    vi.mocked(fetchWithRetry).mockImplementation(async () => weeklyClaudeResponse());
+
+    await expect(generateWeeklyRecap(db, "anthropic-key", null)).resolves.toMatchObject({ itemCount: 1 });
+
+    const body = JSON.parse(String(vi.mocked(fetchWithRetry).mock.calls[0]?.[1]?.body)) as {
+      messages: { content: string }[];
+    };
+    const prompt = body.messages[0].content;
+    expect(prompt).toContain("USDT: grade A -> B");
+    expect(prompt).not.toContain("undefined: grade undefined");
+  });
+
   it("selects the latest daily row per UTC date before limiting the weekly input window", async () => {
     const db = mockD1(makeTables(), { requireMatch: true });
     vi.mocked(fetchWithRetry).mockImplementation(async () => weeklyClaudeResponse());

--- a/worker/src/cron/weekly-recap.ts
+++ b/worker/src/cron/weekly-recap.ts
@@ -585,7 +585,13 @@ function collectWeeklyTopSignals(parsed: WeeklyParsedRow[]): WeeklyTopSignals {
         mcapUsd: transition.mcapUsd,
         date: d.date,
       }))
-      .filter((transition) => transition.mcapUsd != null),
+      .filter((transition) => (
+        typeof transition.symbol === "string"
+        && typeof transition.fromGrade === "string"
+        && typeof transition.toGrade === "string"
+        && typeof transition.mcapUsd === "number"
+        && Number.isFinite(transition.mcapUsd)
+      )),
     (row) => row.mcapUsd,
   );
   const topYieldAnomalies = topSignals(


### PR DESCRIPTION
### Motivation
- A recent change loosened validation for stored `gradeTransitions`, allowing malformed rows with only `mcapUsd` to reach `gradeRiskRank` and throw when `trim()` is called on undefined, causing weekly recap generation to crash.

### Description
- Reintroduced runtime checks in `worker/src/cron/weekly-recap.ts` so `gradeTransitions` are filtered to require `symbol`, `fromGrade`, and `toGrade` to be strings and `mcapUsd` to be a finite number before they are used in the weekly risk leaderboard.
- Added a focused regression test in `worker/src/cron/__tests__/weekly-recap.test.ts` that injects a malformed transition (`{ mcapUsd: 1_000_000 }`) and a valid transition, asserting the malformed row is skipped and the valid row appears in the prompt.

### Testing
- Ran the targeted unit tests with `npm test -- worker/src/cron/__tests__/weekly-recap.test.ts` and observed all tests in that file pass (13 passed).
- Verified TypeScript compilation for the worker with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe4e5c833293930ae4afc15d0f)