### PR TITLE
Fix methodology decimal version ordering

### DIFF
--- a/shared/lib/__tests__/methodology-version.test.ts
+++ b/shared/lib/__tests__/methodology-version.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  compareMethodologyVersions,
   createMethodologyVersion,
   formatMethodologyDisplayDate,
   methodologyChangelogEntryId,
   toMethodologyVersionLabel,
 } from "../methodology-version";
 import { DDR_METHODOLOGY_CHANGELOG, DDR_V2_EFFECTIVE_AT } from "../depeg-resolver-version";
+
+describe("compareMethodologyVersions", () => {
+  it("orders decimal methodology versions with leading-zero hundredths before tenths", () => {
+    expect(compareMethodologyVersions("6.09", "6.1")).toBeLessThan(0);
+    expect(compareMethodologyVersions("6.1", "6.09")).toBeGreaterThan(0);
+    expect(compareMethodologyVersions("6.10", "6.1")).toBe(0);
+    expect(compareMethodologyVersions("6.16", "6.11")).toBeGreaterThan(0);
+  });
+});
 
 describe("createMethodologyVersion", () => {
   it("resolves to the higher version when two entries share effectiveAt", () => {

--- a/shared/lib/methodology-versions/base.ts
+++ b/shared/lib/methodology-versions/base.ts
@@ -60,20 +60,24 @@ export interface MethodologyVersion {
   getVersionAt: (unixSeconds: number) => string;
 }
 
-function parseMethodologyVersion(version: string): number[] {
-  return version.split(".").map((segment) => {
-    const value = Number.parseInt(segment, 10);
-    return Number.isFinite(value) ? value : 0;
-  });
+function normalizeMethodologyVersionSegment(segment: string, width: number): number {
+  const normalized = segment.padEnd(width, "0");
+  const value = Number.parseInt(normalized, 10);
+  return Number.isFinite(value) ? value : 0;
 }
 
 export function compareMethodologyVersions(a: string, b: string): number {
-  const aParts = parseMethodologyVersion(a);
-  const bParts = parseMethodologyVersion(b);
+  const aParts = a.split(".");
+  const bParts = b.split(".");
   const maxLength = Math.max(aParts.length, bParts.length);
 
   for (let index = 0; index < maxLength; index += 1) {
-    const diff = (aParts[index] ?? 0) - (bParts[index] ?? 0);
+    const aPart = aParts[index] ?? "0";
+    const bPart = bParts[index] ?? "0";
+    const width = Math.max(aPart.length, bPart.length, 1);
+    const diff =
+      normalizeMethodologyVersionSegment(aPart, width) -
+      normalizeMethodologyVersionSegment(bPart, width);
     if (diff !== 0) return diff;
   }
 


### PR DESCRIPTION
### Motivation

- The dotted-version comparator compared segments as raw integers, causing versions like `6.09` (minor=9) to sort after `6.1` (minor=1) and producing incorrect "Latest Version" presentation on methodology changelogs.

### Description

- Normalize dotted version segments by right-padding each segment before numeric comparison so decimal-like spellings (e.g. `6.09`) sort correctly relative to `6.1`, implemented in `shared/lib/methodology-versions/base.ts`.
- Add a regression test exercising `compareMethodologyVersions` for `6.09` vs `6.1`, `6.10` equivalence, and later `6.x` ordering in `shared/lib/__tests__/methodology-version.test.ts`.

### Testing

- Ran the focused unit test with `npm test -- --run shared/lib/__tests__/methodology-version.test.ts` and it passed (1 file, 6 tests passed). 
- Ran typecheck with `npm run typecheck -- --pretty false` and it completed without errors. 
- Performed a runtime spot-check with `npx tsx -e "import { PRICING_PIPELINE_METHODOLOGY_CHANGELOG, PRICING_PIPELINE_METHODOLOGY_VERSION } from './shared/lib/methodology-versions/pricing-pipeline'; ..."` which printed the declared current version and a sorted changelog with `6.1` ordered correctly relative to `6.09`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe0d808332a98958e816db8ef5)