### PR TITLE
Fix variant verdict mechanism inheritance

### DIFF
--- a/src/lib/__tests__/stablecoin-detail-view-model.test.ts
+++ b/src/lib/__tests__/stablecoin-detail-view-model.test.ts
@@ -446,6 +446,65 @@ describe("stablecoin detail view-model builder", () => {
     });
   });
 
+  it("inherits parent mechanism archetypes for variant verdicts", () => {
+    const sourceVariant = TRACKED_META_BY_ID.get("autousd-auto-finance");
+    expect(sourceVariant).toBeDefined();
+
+    const coin = {
+      ...sourceVariant!,
+      flags: {
+        ...sourceVariant!.flags,
+        governance: "centralized" as const,
+        yieldBearing: false,
+        navToken: false,
+      },
+    };
+
+    const viewModel = buildStablecoinDetailViewModel(
+      makeBuildStablecoinDetailViewModelParams({
+        core: {
+          id: coin.id,
+          coin,
+        },
+        queries: {
+          supplyHistory: { data: [{ date: 1_700_000_000, circulatingUsd: 100, price: 1 }] },
+          stablecoinList: {
+            data: {
+              peggedAssets: [
+                {
+                  id: coin.id,
+                  name: coin.name,
+                  symbol: coin.symbol,
+                  pegType: "peggedUSD",
+                  price: 1,
+                  circulating: { peggedUSD: 100 },
+                },
+              ],
+              fxFallbackRates: {},
+            } as never,
+            dataUpdatedAt: 1,
+          },
+          reportCards: {
+            data: {
+              cards: [{ id: coin.id, overallGrade: "B", overallScore: 80, dimensions: {} }],
+              dependencyGraph: { nodes: [], edges: [] },
+            } as never,
+            dataUpdatedAt: 1,
+          },
+        },
+      }),
+    );
+
+    expect(viewModel.status).toBe("ready");
+    if (viewModel.status !== "ready") return;
+
+    expect(coin.mechanismArchetype).toBeUndefined();
+    expect(viewModel.verdict).toEqual({
+      archetype: "institutional-default",
+      label: "Institutional Default",
+    });
+  });
+
   it("wires the selected redemption backstop and stale-query state", () => {
     const coin = TRACKED_META_BY_ID.get("usdt-tether");
     expect(coin).toBeDefined();

--- a/src/lib/stablecoin-detail-view-model.ts
+++ b/src/lib/stablecoin-detail-view-model.ts
@@ -41,7 +41,7 @@ import {
 import type { ApiMeta } from "@/lib/api";
 import type { ReserveResult } from "@shared/lib/reserve-templates";
 import { REPORT_CARD_GRADE_COLORS } from "@shared/lib/report-cards";
-import { isThreatBand } from "@shared/lib/classification";
+import { isThreatBand, resolveMechanismArchetype } from "@shared/lib/classification";
 import { deriveStablecoinVerdict, type StablecoinVerdict } from "@shared/lib/stablecoin-verdict";
 import { getReserves } from "@shared/lib/reserve-templates";
 import { buildLiveCompareUrl, getPrimaryStaticComparisonLinkForCoin } from "@/lib/compare-links";
@@ -851,7 +851,7 @@ export function buildStablecoinDetailViewModel({
     reportCardGrade: reportCard?.overallGrade ?? null,
     pegScore: isNavToken ? null : pegPrice.pegScoreResult?.pegScore ?? null,
     dewsBand: stressBand,
-    mechanismArchetype: coin.mechanismArchetype,
+    mechanismArchetype: resolveMechanismArchetype(coin, CLIENT_TRACKED_META_BY_ID) ?? undefined,
     governance: coin.flags.governance,
     yieldBearing: coin.flags.yieldBearing ?? false,
     navToken: isNavToken,


### PR DESCRIPTION
### Motivation

- Variant stablecoins that omit their own `mechanismArchetype` should inherit their parent's archetype when computing the detail-page verdict, but recent changes caused verdict derivation to read the raw coin field and produced `uncategorized` for many wrapper variants.

### Description

- Resolve the effective archetype before deriving the detail verdict by calling `resolveMechanismArchetype(coin, CLIENT_TRACKED_META_BY_ID)` and passing the result into `deriveStablecoinVerdict` in `src/lib/stablecoin-detail-view-model.ts`.
- Import `resolveMechanismArchetype` from `@shared/lib/classification` and preserve `undefined` semantics by using `?? undefined` when passing to `deriveStablecoinVerdict`.
- Add a regression test `it("inherits parent mechanism archetypes for variant verdicts")` to `src/lib/__tests__/stablecoin-detail-view-model.test.ts` that asserts a variant with no raw `mechanismArchetype` receives the inherited `institutional-default` verdict.

### Testing

- Ran `npx vitest run src/lib/__tests__/stablecoin-detail-view-model.test.ts` and the test file passed (all tests in the file succeeded). 
- Ran full TypeScript check with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe4f348332a1fda53a82d8036e)