### PR TITLE
fix(selector): constrain relaxed fallback exclusions

### DIFF
--- a/docs/screener-picker-page.md
+++ b/docs/screener-picker-page.md
@@ -27,7 +27,7 @@ The route shell is intentionally `noindex,follow` via route metadata and uses ca
 
 Initial selectable pegs are `USD`, `EUR`, `CHF`, and `GOLD`. This pass is limited to pegs that have enough active rows and live Safety/Peg/DEWS/liquidity/yield coverage to avoid empty Picker routes.
 
-Yield exposes the same peg set (`USD`, `EUR`, `CHF`, `GOLD`). Thin or strict combinations can use the engine's low-confidence fallback rather than returning an empty result, but rows still need required profile signals and a usable Yield source before they can be recommended.
+Yield exposes the same peg set (`USD`, `EUR`, `CHF`, `GOLD`). Thin or strict combinations can use the engine's low-confidence fallback rather than returning an empty result, but the fallback is limited to the explicitly relaxable peg-score floor. Rows still need required profile signals, a usable Yield source, and must not violate other profile or input-driven exclusions before they can be recommended.
 
 `SILVER`, `VAR`, and `OTHER` are intentionally excluded because their current live signal coverage still produces empty picker routes or needs separate reference-asset treatment. `BRL` is also held back until the `peggedREAL` alias path is audited across sync, price validation, and supplemental-asset creation.
 
@@ -173,7 +173,7 @@ When changing Picker behavior, update this doc alongside:
 1. **Snapshot endpoint contract** (POST/GET, failure modes, canonicalization rules) → `functions/selector-snapshot/[[path]].ts`, `functions/__tests__/selector-snapshot.test.ts`, `docs/api-reference.md` Pages Function endpoints section.
 2. **localStorage keys or schema** → `src/components/selector/selector-callout.tsx` (frontend), `docs/privacy-page.md`.
 3. **Banned-phrase policy** → `scripts/ci/check-selector-banned-phrases.mjs`. Wire any new banned phrase into `BANNED_PATTERNS`; document durable replacement guidance in this file or a focused `/docs/` page.
-4. **Weight, exclusion, scoring, ranking, yield-source, or deterministic output behavior changes** → bump `engineVersion` via `shared/lib/selector/version.ts`, update editorial worked examples, and rerun selector engine tests plus banned-phrase lint. The current picker remediation is `selector-v1.8`.
+4. **Weight, exclusion, scoring, ranking, yield-source, or deterministic output behavior changes** → bump `engineVersion` via `shared/lib/selector/version.ts`, update editorial worked examples, and rerun selector engine tests plus banned-phrase lint. The current picker remediation is `selector-v1.9`.
 5. **OG content** → replace `public/og-selector-*.png` and re-verify the marketing copy is calibrated against the banned-phrase list before commit.
 6. **Methodology page** → `/methodology/selector/` ships within 30 days post-MVP (design §9.1 item 7; project-tracker post-ship task).
 

--- a/shared/lib/selector/__tests__/engine.test.ts
+++ b/shared/lib/selector/__tests__/engine.test.ts
@@ -546,6 +546,66 @@ describe("runSelector — universal properties", () => {
     }
   });
 
+  it("does not use relaxed fallback for non-relaxable or input-driven exclusions", () => {
+    const base = buildFixtureData().rows.get("usdc-circle");
+    expect(base).toBeDefined();
+
+    const cases: Array<{
+      name: string;
+      input: Partial<SelectorInput>;
+      row: Partial<MergedRow>;
+      reason: string;
+    }> = [
+      {
+        name: "minimum APY floor",
+        input: { profile: "yield", minApy: 10 },
+        row: { apy30d: 1, pegScore: 95 },
+        reason: "apy-below-floor",
+      },
+      {
+        name: "decentralization requirement",
+        input: { profile: "yield", decentralization: "required" },
+        row: { governance: "centralized", canBeBlacklisted: true, pegScore: 95 },
+        reason: "decentralization-required-violation",
+      },
+      {
+        name: "on-chain custody requirement",
+        input: { profile: "yield", custodyOk: "onchain-only" },
+        row: { custodyModel: "institutional-regulated", pegScore: 95 },
+        reason: "custody-onchain-only-violation",
+      },
+      {
+        name: "yield-native-only requirement",
+        input: { profile: "yield", yieldNativeOnly: true },
+        row: { deploymentPlace: "lp", pegScore: 95 },
+        reason: "yield-native-only-violation",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const row: MergedRow = {
+        ...base!,
+        id: `fallback-blocked-${testCase.name.replaceAll(" ", "-")}`,
+        symbol: "BLK",
+        name: `Blocked ${testCase.name}`,
+        protocolSlug: `blocked-${testCase.name.replaceAll(" ", "-")}`,
+        variantOf: null,
+        ...testCase.row,
+      };
+      const out = runSelector(
+        makeInput(testCase.input),
+        { rows: new Map([[row.id, row]]) },
+        FIXTURE_DATASET,
+      );
+
+      expect(out.universe.surviving, testCase.name).toBe(0);
+      expect(out.recommended.map((rec) => rec.id), testCase.name).not.toContain(row.id);
+      expect(out.usedRelaxedFallback, testCase.name).toBe(false);
+      expect(out.relaxedReasons, testCase.name).not.toContain(testCase.reason);
+      expect(out.exclusionSummary.some((item) => item.reason === testCase.reason), testCase.name).toBe(true);
+    }
+  });
+
   it("emits authored explanation text and confidence reasons instead of raw keys", () => {
     const rows = new Map(buildFixtureData().rows);
     const base = rows.get("usds-sky");

--- a/shared/lib/selector/engine.ts
+++ b/shared/lib/selector/engine.ts
@@ -47,18 +47,8 @@ import { selectYieldSource } from "./yield-source";
 export const ENGINE_VERSION = SELECTOR_VERSION;
 export { scoreIgnoringExclusion };
 
-const RELAXED_FALLBACK_BLOCKED_REASONS: ReadonlySet<ExclusionReason> = new Set([
-  "active-depeg",
-  "apy-below-floor",
-  "below-supply-floor",
-  "coverage-too-thin",
-  "howey-uncertain",
-  "lifecycle-non-active",
-  "peg-currency-mismatch",
-  "pys-null",
-  "safety-grade-floor",
-  "template-coverage-gap",
-  "yield-native-only-violation",
+const RELAXED_FALLBACK_ALLOWED_REASONS: ReadonlySet<ExclusionReason> = new Set([
+  "peg-score-floor",
 ]);
 
 const SELECTOR_DEBUG =
@@ -243,13 +233,8 @@ function relaxedFallbackReason(
   if (!coverage.ok) return null;
   const exclusion = evaluateExclusions(row, input);
   if (exclusion == null) return null;
-  if (RELAXED_FALLBACK_BLOCKED_REASONS.has(exclusion.reason)) return null;
-  if (
-    input.profile === "treasury" &&
-    exclusion.reason === "peg-score-floor"
-  ) {
-    return null;
-  }
+  if (!RELAXED_FALLBACK_ALLOWED_REASONS.has(exclusion.reason)) return null;
+  if (input.profile === "treasury") return null;
   return exclusion.reason;
 }
 

--- a/shared/lib/selector/version.ts
+++ b/shared/lib/selector/version.ts
@@ -3,4 +3,4 @@
  *
  * Bump when weights, exclusion rules, or deterministic engine behavior change.
  */
-export const SELECTOR_VERSION = "selector-v1.8";
+export const SELECTOR_VERSION = "selector-v1.9";


### PR DESCRIPTION
### Motivation
- The relaxed fallback previously reconsidered any row whose exclusion reason was not in an incomplete blocklist, allowing profile- and input-driven exclusions (depeg counts, APY floor, custody/decentralization constraints, etc.) to re-enter recommendations when the normal shortlist was empty. 
- This behavior could violate user-specified safety constraints and produce misleading low-confidence recommendations for strict routes.

### Description
- Replace the permissive blocklist with an explicit allowlist (`RELAXED_FALLBACK_ALLOWED_REASONS`) that currently contains only the `peg-score-floor` reason and refuse other exclusions from being relaxed. 
- Ensure Treasury profile never uses the relaxed fallback even for peg-score relaxation. 
- Add a regression test to assert that APY-floor and input-driven exclusions (`decentralization-required-violation`, `custody-onchain-only-violation`, `yield-native-only-violation`) are not reintroduced by the fallback. 
- Bump the selector version to `selector-v1.9` and update Picker docs to document the narrowed fallback contract.

### Testing
- `npx vitest run shared/lib/selector/__tests__/engine.test.ts` — tests passed. 
- `npx vitest run shared/lib/selector` — full selector test suite passed. 
- `npm run check:selector-banned-phrases` — banned-phrase lint passed. 
- `npm run check:worker-boundary` and `npm run check:shared-cycles` — repository boundary/cycle checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe0e3483329aaa77dcb643ee73)