### PR TITLE
fix(yield): keep risk budget slider visible on empty views

### DIFF
--- a/src/app/yield/client.test.tsx
+++ b/src/app/yield/client.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { YieldClient } from "./client";
+import { makeYieldProvenance, makeYieldRanking } from "@/test/fixtures/yield";
+import type { YieldRankingsResponse } from "@shared/types";
+
+const { useYieldRankingsMock, searchParamsMock, replaceParamsMock, setParamMock, pushMock } = vi.hoisted(() => ({
+  useYieldRankingsMock: vi.fn(),
+  searchParamsMock: new URLSearchParams(),
+  replaceParamsMock: vi.fn(),
+  setParamMock: vi.fn(),
+  pushMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/hooks/api-hooks", () => ({
+  useYieldRankings: useYieldRankingsMock,
+}));
+
+vi.mock("@/hooks/use-url-filters", () => ({
+  useUrlFilters: () => ({
+    searchParams: searchParamsMock,
+    replaceParams: replaceParamsMock,
+    setParam: setParamMock,
+  }),
+}));
+
+vi.mock("@/hooks/use-logos", () => ({
+  useLogos: () => ({ data: {} }),
+}));
+
+vi.mock("@/hooks/use-watchlist", () => ({
+  useWatchlist: () => ({ idSet: new Set<string>() }),
+}));
+
+vi.mock("@/components/yield-scatter-plot", () => ({
+  YieldScatterPlot: () => <div data-testid="yield-scatter-plot" />,
+}));
+
+vi.mock("@/components/yield-leaderboard", () => ({
+  YieldLeaderboard: () => <div data-testid="yield-leaderboard" />,
+}));
+
+vi.mock("@/app/yield/source-board", () => ({
+  YieldSourceBoard: () => <div data-testid="yield-source-board" />,
+}));
+
+vi.mock("@/app/yield/reference-rates-strip", () => ({
+  ReferenceRatesStrip: () => <div data-testid="reference-rates-strip" />,
+}));
+
+vi.mock("@/app/yield/coin-index", () => ({
+  YieldCoinIndex: () => <div data-testid="yield-coin-index" />,
+}));
+
+const rows = [
+  makeYieldRanking({
+    id: "usdc-circle",
+    symbol: "USDC",
+    name: "USD Coin",
+    safetyScore: 82,
+    sourceTvlUsd: 5_000_000,
+    provenance: makeYieldProvenance({ confidenceTier: "curated" }),
+  }),
+  makeYieldRanking({
+    id: "usdt-tether",
+    symbol: "USDT",
+    name: "Tether USD",
+    safetyScore: 60,
+    sourceTvlUsd: 10_000_000,
+    provenance: makeYieldProvenance({ confidenceTier: "discovered" }),
+  }),
+];
+
+function makeResponse(): YieldRankingsResponse {
+  return {
+    rankings: rows,
+    riskFreeRate: 4.25,
+    scalingFactor: 1,
+    medianApy: 5,
+    updatedAt: 1_776_000_000,
+    warnings: [],
+  };
+}
+
+describe("YieldClient", () => {
+  beforeEach(() => {
+    searchParamsMock.forEach((_, key) => searchParamsMock.delete(key));
+    useYieldRankingsMock.mockReturnValue({
+      data: makeResponse(),
+      meta: null,
+      isLoading: false,
+      error: null,
+      dataUpdatedAt: 1_776_000_000,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the risk budget slider available when filters hide every yield row", () => {
+    searchParamsMock.set("q", "zzzz-no-match");
+
+    render(<YieldClient />);
+
+    expect(screen.getByRole("slider", { name: "Risk tolerance" })).toBeTruthy();
+    expect(screen.queryByTestId("yield-scatter-plot")).toBeNull();
+  });
+
+  it("renders both the risk budget slider and scatter plot when yield rows are visible", () => {
+    render(<YieldClient />);
+
+    expect(screen.getByRole("slider", { name: "Risk tolerance" })).toBeTruthy();
+    expect(screen.getByTestId("yield-scatter-plot")).toBeTruthy();
+  });
+});

--- a/src/app/yield/client.tsx
+++ b/src/app/yield/client.tsx
@@ -292,12 +292,12 @@ export function YieldClient() {
           )}
         </section>
 
-        {visibleRows.length > 0 ? (
-          <section aria-label="Yield vs Safety landscape" className="order-2 space-y-3">
-            <YieldRiskBudgetSlider
-              stops={viewModel.riskBudget.stops}
-              onSelect={handleApplyRiskBudget}
-            />
+        <section aria-label="Yield vs Safety landscape" className="order-2 space-y-3">
+          <YieldRiskBudgetSlider
+            stops={viewModel.riskBudget.stops}
+            onSelect={handleApplyRiskBudget}
+          />
+          {visibleRows.length > 0 ? (
             <YieldScatterPlot
               rankings={visibleRows}
               benchmarkRate={stats.referenceBenchmark?.rate ?? data.riskFreeRate}
@@ -309,8 +309,8 @@ export function YieldClient() {
               onDotClick={handleNavigate}
               compact
             />
-          </section>
-        ) : null}
+          ) : null}
+        </section>
 
         <section className="order-3" aria-label="Yield filters">
           <YieldLeaderboardControls


### PR DESCRIPTION
### Motivation
- The risk-budget slider was rendered only inside the scatter-plot block guarded by `visibleRows.length > 0`, causing the slider to disappear when filters returned no rows and preventing users from recovering by relaxing risk settings.

### Description
- Render `YieldRiskBudgetSlider` outside the `visibleRows.length > 0` guard in `src/app/yield/client.tsx` so the slider remains available even when no yield rows match filters. 
- Keep the scatter plot hidden when `visibleRows` is empty by keeping `YieldScatterPlot` inside the `visibleRows.length > 0` conditional. 
- Add a focused client-render Vitest case at `src/app/yield/client.test.tsx` that asserts the slider remains present for an empty filtered view and that the scatter plot renders for populated views.

### Testing
- Ran unit tests with Vitest: `npm test -- --run src/app/yield/client.test.tsx src/components/__tests__/yield-risk-budget-slider.test.tsx` and all tests passed. 
- Type checking with `npm run typecheck` completed successfully. 
- Linting with `npx eslint src/app/yield/client.tsx src/app/yield/client.test.tsx --max-warnings=0` passed; Playwright-based screenshot attempts failed due to unavailable browser downloads (CDN 403) so visual capture was not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fde900833283a3b20a51aa7ee8)