### PR TITLE
fix(yield): guard compare logo lookups

### DIFF
--- a/src/components/__tests__/yield-compare-drawer.test.tsx
+++ b/src/components/__tests__/yield-compare-drawer.test.tsx
@@ -17,7 +17,11 @@ vi.mock("@/components/ui/sheet", () => ({
 }));
 
 vi.mock("@/components/stablecoin-logo", () => ({
-  StablecoinLogo: ({ name }: { name: string }) => <span data-testid="logo">{name}</span>,
+  StablecoinLogo: ({ name, src }: { name: string; src?: string }) => (
+    <span data-testid="logo" data-src={src ?? ""}>
+      {name}
+    </span>
+  ),
 }));
 
 function makeRow(overrides: Partial<YieldViewModelRow>): YieldViewModelRow {
@@ -85,6 +89,15 @@ describe("YieldCompareDrawer", () => {
 
     const placeholders = screen.getAllByText("Coin not in current view");
     expect(placeholders.length).toBeGreaterThan(0);
+  });
+
+  it("does not pass inherited logo properties as image sources", () => {
+    window.history.replaceState(null, "", "/yield/?compare=__proto__,usdc-circle");
+    render(<YieldCompareDrawer open onOpenChange={vi.fn()} rows={[usdc]} logos={{}} />);
+
+    expect(screen.getAllByText("__proto__").length).toBeGreaterThan(0);
+    expect(screen.getByText("USDC")).toBeTruthy();
+    expect(screen.getAllByTestId("logo")[0].getAttribute("data-src")).toBe("");
   });
 
   it("exposes a share link mirroring the current compare ids", () => {

--- a/src/components/__tests__/yield-compare-tray.test.tsx
+++ b/src/components/__tests__/yield-compare-tray.test.tsx
@@ -7,7 +7,11 @@ import { YieldCompareTray } from "@/components/yield-compare-tray";
 import type { YieldViewModelRow } from "@/lib/yield-view-model";
 
 vi.mock("@/components/stablecoin-logo", () => ({
-  StablecoinLogo: ({ name }: { name: string }) => <span data-testid="logo">{name}</span>,
+  StablecoinLogo: ({ name, src }: { name: string; src?: string }) => (
+    <span data-testid="logo" data-src={src ?? ""}>
+      {name}
+    </span>
+  ),
 }));
 
 function makeRow(id: string, symbol: string, name: string): YieldViewModelRow {
@@ -61,6 +65,13 @@ describe("YieldCompareTray", () => {
 
     fireEvent.click(compareButton);
     expect(onOpenDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pass inherited logo properties as image sources", () => {
+    window.history.replaceState(null, "", "/yield/?compare=__proto__");
+    render(<YieldCompareTray rows={rows} logos={{}} onOpenDrawer={vi.fn()} />);
+
+    expect(screen.getByTestId("logo").getAttribute("data-src")).toBe("");
   });
 
   it("Clear button removes all ids from the URL", () => {

--- a/src/components/yield-compare-drawer.tsx
+++ b/src/components/yield-compare-drawer.tsx
@@ -10,13 +10,14 @@ import { useYieldCompareSelection } from "@/hooks/use-yield-compare-selection";
 import { formatCurrency, formatPercent, formatScore } from "@shared/lib/format";
 import { YIELD_SOURCE_DEPTH_DEFINITIONS } from "@/lib/yield-source-risk";
 import { formatYieldWarningSignal } from "@/lib/yield-constants";
+import { getLogoSrc, type LogoMap } from "@/lib/logos";
 import type { YieldViewModelRow } from "@/lib/yield-view-model";
 
 interface YieldCompareDrawerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   rows: readonly YieldViewModelRow[];
-  logos: Record<string, string>;
+  logos: LogoMap;
 }
 
 interface CompareColumn {
@@ -141,7 +142,7 @@ export function YieldCompareDrawer({ open, onOpenChange, rows, logos }: YieldCom
                     className="h-auto border-b border-border/60 px-2 py-2 text-left align-bottom"
                   >
                     <div className="flex items-center gap-2">
-                      <StablecoinLogo src={logos[column.id]} name={name} size={20} />
+                      <StablecoinLogo src={getLogoSrc(logos, column.id)} name={name} size={20} />
                       <span className="font-medium text-foreground">{symbol}</span>
                       <button
                         type="button"

--- a/src/components/yield-compare-tray.tsx
+++ b/src/components/yield-compare-tray.tsx
@@ -2,11 +2,12 @@
 
 import { StablecoinLogo } from "@/components/stablecoin-logo";
 import { useYieldCompareSelection } from "@/hooks/use-yield-compare-selection";
+import { getLogoSrc, type LogoMap } from "@/lib/logos";
 import type { YieldViewModelRow } from "@/lib/yield-view-model";
 
 interface YieldCompareTrayProps {
   rows: readonly YieldViewModelRow[];
-  logos: Record<string, string>;
+  logos: LogoMap;
   onOpenDrawer: () => void;
 }
 
@@ -33,7 +34,7 @@ export function YieldCompareTray({ rows, logos, onOpenDrawer }: YieldCompareTray
             return (
               <StablecoinLogo
                 key={id}
-                src={logos[id]}
+                src={getLogoSrc(logos, id)}
                 name={row?.name ?? id}
                 size={22}
               />

--- a/src/lib/logos.ts
+++ b/src/lib/logos.ts
@@ -1,3 +1,13 @@
 import logos from "../../data/logos.json";
 
-export const logosById = logos as Record<string, string>;
+export type LogoMap = Record<string, string>;
+
+export const logosById = Object.freeze(
+  Object.assign(Object.create(null) as LogoMap, logos),
+);
+
+export function getLogoSrc(logos: LogoMap, id: string): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(logos, id)) return undefined;
+  const src = logos[id];
+  return typeof src === "string" ? src : undefined;
+}


### PR DESCRIPTION
### Motivation

- A URL-controlled `?compare=` id could be used to index the plain `logos` object and return inherited prototype properties (e.g. `__proto__`, `constructor`) as truthy values, which were forwarded to `StablecoinLogo` and ultimately `next/image` causing client-side rendering/warning failures.
- The change prevents untrusted query IDs from being treated as valid image sources and avoids availability/hydration issues while keeping the compare UX intact.

### Description

- Normalize the imported logo map to a null-prototype frozen map (`logosById`) and expose a typed `LogoMap` alias in `src/lib/logos.ts`.
- Add `getLogoSrc(logos, id)` which returns a string only when the id is an own property and the value is a string, otherwise `undefined`.
- Replace direct `logos[id]` indexing with `getLogoSrc(logos, id)` and use `LogoMap` in `src/components/yield-compare-tray.tsx` and `src/components/yield-compare-drawer.tsx` so compare IDs from the URL cannot flow inherited properties into the logo rendering path.
- Add regression tests to `src/components/__tests__/yield-compare-tray.test.tsx` and `src/components/__tests__/yield-compare-drawer.test.tsx` asserting that `?compare=__proto__` does not produce an image source.

### Testing

- Ran the targeted component tests with `npx vitest run src/components/__tests__/yield-compare-tray.test.tsx src/components/__tests__/yield-compare-drawer.test.tsx`, and they passed (all tests in those files succeeded).
- Ran type checking with `npm run typecheck` and it completed successfully.
- Ran ESLint on the modified files with `npx eslint ... --max-warnings=0` and there were no lint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe036083329b35e26e63954fb6)