### PR TITLE
fix(yield): tolerate pending D1 rollout schema

### DIFF
--- a/worker/src/api/__tests__/yield-history.test.ts
+++ b/worker/src/api/__tests__/yield-history.test.ts
@@ -89,6 +89,20 @@ describe("handleYieldHistory", () => {
     expect(body.methodology).toHaveProperty("version");
   });
 
+  it("falls back to legacy yield_history schema when publish snapshot columns are absent", async () => {
+    const db = mockD1([
+      { match: "best-window */", rows: [], throwError: new Error("D1_ERROR: no such column: pys_at_publish") },
+      { match: "legacy-schema", rows: [row] },
+    ]);
+
+    const res = await handleYieldHistory(db, new URL("https://x/api/yield-history?stablecoin=usdt-tether"));
+    const body = (await res.json()) as { history: Array<Record<string, unknown>> };
+
+    expect(res.status).toBe(200);
+    expect(body.history).toHaveLength(1);
+    expect(db.getHistory().some((entry) => entry.sql.includes("legacy-schema"))).toBe(true);
+  });
+
   it("parses a production-shaped v7.48 old history payload through the schema and handler", async () => {
     expect(YieldHistoryResponseSchema.parse(v748HistoryPayload).publication).toBeUndefined();
     expect(YieldHistoryResponseSchema.parse(v748HistoryPayload).history[0]?.sourceRisk).toBeUndefined();

--- a/worker/src/api/__tests__/yield-source-decisions.test.ts
+++ b/worker/src/api/__tests__/yield-source-decisions.test.ts
@@ -41,7 +41,7 @@ describe("handleYieldSourceDecisions", () => {
     const { request, url } = buildRequest("?limit=26");
 
     const response = await handleYieldSourceDecisions({ db, url, request, trustedAdmin: true });
-    const body = await response.json() as { error: string };
+    const body = (await response.json()) as { error: string };
 
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
@@ -49,11 +49,10 @@ describe("handleYieldSourceDecisions", () => {
     expect(db.getHistory()).toEqual([]);
   });
 
-  it("filters generation and decision rows by generation, state, and stablecoin", async () => {
+  it("falls back when decision retention and public alternatives migrations are absent", async () => {
     const db = mockD1([
       {
         match: "FROM yield_publication_generations",
-        matchBinds: ["yield-1772000000", "yield-1772000000", "published", "published", 10],
         rows: [
           {
             generation_id: "yield-1772000000",
@@ -61,21 +60,25 @@ describe("handleYieldSourceDecisions", () => {
             state: "published",
             cache_key: "yield-rankings",
             ranking_updated_at: 1_772_000_000,
-            ranking_count: 125,
-            source_row_count: 180,
-            best_row_count: 125,
-            decision_count: 125,
+            ranking_count: 1,
+            source_row_count: 1,
+            best_row_count: 1,
+            decision_count: 1,
             published_at: 1_772_000_003,
             failed_at: null,
             failure_reason: null,
-            metadata_json: JSON.stringify({ rowsRejected: 3, sourceSwitches: 2 }),
+            metadata_json: null,
             created_at: 1_772_000_000,
           },
         ],
       },
       {
-        match: "FROM yield_source_decisions",
-        matchBinds: ["usdc-circle", "yield-1772000000", "yield-1772000000", "published", "published", 5],
+        match: "d.retention_reason",
+        rows: [],
+        throwError: new Error("D1_ERROR: no such column: d.retention_reason"),
+      },
+      {
+        match: "stablecoin-decisions:legacy-schema",
         rows: [
           {
             generation_id: "yield-1772000000",
@@ -86,27 +89,93 @@ describe("handleYieldSourceDecisions", () => {
             selected_apy_30d: 4.7,
             selected_score: 82.5,
             selected_reason: "Curated source selected",
-            previous_best_source_key: "price-derived:legacy",
-            source_switch: 1,
-            rejected_count: 1,
-            alternatives_json: JSON.stringify([
-              {
-                sourceKey: "defillama:auto",
-                rejected: true,
-                reason: "rejected: divergent lower-confidence source",
-              },
-            ]),
+            previous_best_source_key: null,
+            source_switch: 0,
+            rejected_count: 0,
+            alternatives_json: "[]",
             created_at: 1_772_000_000,
+            retention_reason: null,
           },
         ],
       },
-    ], { requireMatch: true });
-    const { request, url } = buildRequest(
-      "?generationId=yield-1772000000&state=published&stablecoin=usdc-circle",
-    );
+      {
+        match: "FROM yield_source_decision_alternatives",
+        rows: [],
+        throwError: new Error("D1_ERROR: no such table: yield_source_decision_alternatives"),
+      },
+    ]);
+    const { request, url } = buildRequest("?stablecoin=usdc-circle&includePublicAlternatives=1");
 
     const response = await handleYieldSourceDecisions({ db, url, request, trustedAdmin: true });
-    const body = await response.json() as {
+    const body = (await response.json()) as {
+      decisions: Array<{ retentionReason?: string | null; publicAlternatives?: unknown[] }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.decisions[0]?.retentionReason).toBeNull();
+    expect(body.decisions[0]?.publicAlternatives).toEqual([]);
+    expect(db.getHistory().some((entry) => entry.sql.includes("legacy-schema"))).toBe(true);
+  });
+
+  it("filters generation and decision rows by generation, state, and stablecoin", async () => {
+    const db = mockD1(
+      [
+        {
+          match: "FROM yield_publication_generations",
+          matchBinds: ["yield-1772000000", "yield-1772000000", "published", "published", 10],
+          rows: [
+            {
+              generation_id: "yield-1772000000",
+              started_at: 1_772_000_000,
+              state: "published",
+              cache_key: "yield-rankings",
+              ranking_updated_at: 1_772_000_000,
+              ranking_count: 125,
+              source_row_count: 180,
+              best_row_count: 125,
+              decision_count: 125,
+              published_at: 1_772_000_003,
+              failed_at: null,
+              failure_reason: null,
+              metadata_json: JSON.stringify({ rowsRejected: 3, sourceSwitches: 2 }),
+              created_at: 1_772_000_000,
+            },
+          ],
+        },
+        {
+          match: "FROM yield_source_decisions",
+          matchBinds: ["usdc-circle", "yield-1772000000", "yield-1772000000", "published", "published", 5],
+          rows: [
+            {
+              generation_id: "yield-1772000000",
+              stablecoin_id: "usdc-circle",
+              selected_source_key: "defillama:best",
+              selected_confidence_tier: "curated",
+              selected_data_source: "defillama",
+              selected_apy_30d: 4.7,
+              selected_score: 82.5,
+              selected_reason: "Curated source selected",
+              previous_best_source_key: "price-derived:legacy",
+              source_switch: 1,
+              rejected_count: 1,
+              alternatives_json: JSON.stringify([
+                {
+                  sourceKey: "defillama:auto",
+                  rejected: true,
+                  reason: "rejected: divergent lower-confidence source",
+                },
+              ]),
+              created_at: 1_772_000_000,
+            },
+          ],
+        },
+      ],
+      { requireMatch: true },
+    );
+    const { request, url } = buildRequest("?generationId=yield-1772000000&state=published&stablecoin=usdc-circle");
+
+    const response = await handleYieldSourceDecisions({ db, url, request, trustedAdmin: true });
+    const body = (await response.json()) as {
       filters: Record<string, unknown>;
       generations: Array<Record<string, unknown>>;
       decisions: Array<{
@@ -197,7 +266,7 @@ describe("handleYieldSourceDecisions", () => {
     const { request, url } = buildRequest("?stablecoin=usdc-circle&includePublicAlternatives=1");
 
     const response = await handleYieldSourceDecisions({ db, url, request, trustedAdmin: true });
-    const body = await response.json() as {
+    const body = (await response.json()) as {
       filters: { includePublicAlternatives: boolean };
       decisions: Array<{
         retentionReason: string | null;
@@ -220,50 +289,53 @@ describe("handleYieldSourceDecisions", () => {
   });
 
   it("returns compact generation summaries without raw evidence blobs", async () => {
-    const db = mockD1([
-      {
-        match: "FROM yield_publication_generations",
-        matchBinds: [null, null, null, null, 2],
-        rows: [
-          {
-            generation_id: "yield-1772003600",
-            started_at: 1_772_003_600,
-            state: "failed",
-            cache_key: "yield-rankings",
-            ranking_updated_at: null,
-            ranking_count: null,
-            source_row_count: 10,
-            best_row_count: 5,
-            decision_count: 0,
-            published_at: null,
-            failed_at: 1_772_003_650,
-            failure_reason: "schema-invalid",
-            metadata_json: "{not-json",
-            created_at: 1_772_003_600,
-          },
-          {
-            generation_id: "yield-1772000000",
-            started_at: 1_772_000_000,
-            state: "published",
-            cache_key: "yield-rankings",
-            ranking_updated_at: 1_772_000_000,
-            ranking_count: 100,
-            source_row_count: 150,
-            best_row_count: 100,
-            decision_count: 100,
-            published_at: 1_772_000_010,
-            failed_at: null,
-            failure_reason: null,
-            metadata_json: null,
-            created_at: 1_772_000_000,
-          },
-        ],
-      },
-    ], { requireMatch: true });
+    const db = mockD1(
+      [
+        {
+          match: "FROM yield_publication_generations",
+          matchBinds: [null, null, null, null, 2],
+          rows: [
+            {
+              generation_id: "yield-1772003600",
+              started_at: 1_772_003_600,
+              state: "failed",
+              cache_key: "yield-rankings",
+              ranking_updated_at: null,
+              ranking_count: null,
+              source_row_count: 10,
+              best_row_count: 5,
+              decision_count: 0,
+              published_at: null,
+              failed_at: 1_772_003_650,
+              failure_reason: "schema-invalid",
+              metadata_json: "{not-json",
+              created_at: 1_772_003_600,
+            },
+            {
+              generation_id: "yield-1772000000",
+              started_at: 1_772_000_000,
+              state: "published",
+              cache_key: "yield-rankings",
+              ranking_updated_at: 1_772_000_000,
+              ranking_count: 100,
+              source_row_count: 150,
+              best_row_count: 100,
+              decision_count: 100,
+              published_at: 1_772_000_010,
+              failed_at: null,
+              failure_reason: null,
+              metadata_json: null,
+              created_at: 1_772_000_000,
+            },
+          ],
+        },
+      ],
+      { requireMatch: true },
+    );
     const { request, url } = buildRequest("?limit=2");
 
     const response = await handleYieldSourceDecisions({ db, url, request, trustedAdmin: true });
-    const body = await response.json() as {
+    const body = (await response.json()) as {
       filters: { decisionLimit: number };
       generations: Array<Record<string, unknown>>;
       decisions: unknown[];

--- a/worker/src/api/yield-history.ts
+++ b/worker/src/api/yield-history.ts
@@ -8,11 +8,8 @@ import {
 } from "../lib/api-utils";
 import { CACHE_PROFILES } from "../lib/constants";
 import { getCache } from "../lib/db-cache";
-import {
-  buildOnChainSourceKey,
-  isOnChainBootstrapYieldSeed,
-  parseYieldWarningSignals,
-} from "../lib/yield-utils";
+import { isMissingColumnError } from "../lib/db";
+import { buildOnChainSourceKey, isOnChainBootstrapYieldSeed, parseYieldWarningSignals } from "../lib/yield-utils";
 import { resolveYieldSourceUrl } from "../lib/yield-source-links";
 import { logMalformedJsonPath } from "../lib/json-decode-observability";
 import { parseYieldRankingsPublishedCutoff } from "../cron/yield-sync/cache";
@@ -147,12 +144,10 @@ function normalizeYieldSourceRisk(value: unknown): YieldSourceRisk | null {
   }
   if (
     hasOwn(value, "marketStatus") &&
-    (
-      value.marketStatus === "normal" ||
+    (value.marketStatus === "normal" ||
       value.marketStatus === "protected" ||
       value.marketStatus === "unhealthy" ||
-      value.marketStatus === "critical"
-    )
+      value.marketStatus === "critical")
   ) {
     sourceRisk.marketStatus = value.marketStatus;
     hasKnownField = true;
@@ -181,9 +176,7 @@ function buildSourceRiskLookupKey(generationId: string, stablecoinId: string, so
   return `${generationId}\u0000${stablecoinId}\u0000${sourceKey}`;
 }
 
-function buildYieldHistorySourceRiskLookup(
-  cached: { value: string } | null,
-): Map<string, YieldSourceRisk | null> {
+function buildYieldHistorySourceRiskLookup(cached: { value: string } | null): Map<string, YieldSourceRisk | null> {
   const lookup = new Map<string, YieldSourceRisk | null>();
   if (!cached) return lookup;
 
@@ -234,12 +227,14 @@ function parseYieldPublicationMetadata(
     const generationId = typeof publication.generationId === "string" ? publication.generationId : null;
     const status = publication.status === "published" ? "published" : null;
     if (!generationId || !status) return null;
-    const updatedAt = typeof publication.updatedAt === "number" && Number.isFinite(publication.updatedAt)
-      ? publication.updatedAt
-      : cached.updatedAt;
-    const cutoffAt = typeof publication.cutoffAt === "number" && Number.isFinite(publication.cutoffAt)
-      ? publication.cutoffAt
-      : updatedAt;
+    const updatedAt =
+      typeof publication.updatedAt === "number" && Number.isFinite(publication.updatedAt)
+        ? publication.updatedAt
+        : cached.updatedAt;
+    const cutoffAt =
+      typeof publication.cutoffAt === "number" && Number.isFinite(publication.cutoffAt)
+        ? publication.cutoffAt
+        : updatedAt;
     const schemaVersion =
       typeof publication.schemaVersion === "number" && Number.isFinite(publication.schemaVersion)
         ? Math.floor(publication.schemaVersion)
@@ -256,17 +251,13 @@ function parseYieldPublicationMetadata(
   }
 }
 
-function normalizeHistorySourceKey(
-  stablecoinId: string,
-  row: YieldHistoryRow,
-  mode: "best" | "source",
-): string {
+function normalizeHistorySourceKey(stablecoinId: string, row: YieldHistoryRow, mode: "best" | "source"): string {
   const sourceKey = row.source_key ?? "legacy-best";
   if (
-    mode === "best"
-    && stablecoinId === "lusd-liquity"
-    && row.data_source === "onchain"
-    && sourceKey === LEGACY_LUSD_BPROTOCOL_SOURCE_KEY
+    mode === "best" &&
+    stablecoinId === "lusd-liquity" &&
+    row.data_source === "onchain" &&
+    sourceKey === LEGACY_LUSD_BPROTOCOL_SOURCE_KEY
   ) {
     return buildOnChainSourceKey(stablecoinId);
   }
@@ -280,161 +271,204 @@ function normalizeHistorySourceKey(
  * - default mode (`best`) returns the historically selected best source rows
  * - `sourceKey=<key>` returns source-specific history for that key
  */
-export const handleYieldHistory = withErrorHandler("yield-history", async (
-  db: D1Database,
-  url: URL,
-): Promise<Response> => {
-  const parsed = parseStablecoinHistoryQuery(url, {
-    defaultDays: 90,
-    minDays: 1,
-    maxDays: 365,
-    rangePolicy: "reject",
-  });
-  if (parsed instanceof Response) {
-    return parsed;
-  }
-
-  const requestedMode = url.searchParams.get("mode")?.trim() ?? "best";
-  const sourceKey = url.searchParams.get("sourceKey")?.trim() ?? null;
-  const mode = sourceKey ? "source" : requestedMode;
-  if (mode !== "best" && mode !== "source") {
-    return errorResponse(400, "Invalid mode: expected 'best' or 'source'");
-  }
-  if (mode === "source" && !sourceKey) {
-    return errorResponse(400, "Missing ?sourceKey= parameter for source history mode");
-  }
-
-  const rankingsCache = await getCache(db, "yield-rankings");
-  const publication = parseYieldPublicationMetadata(rankingsCache);
-  const sourceRiskByHistoryKey = buildYieldHistorySourceRiskLookup(rankingsCache);
-  const publishedCutoffResult = parseYieldRankingsPublishedCutoff(rankingsCache);
-  const publishedCutoffLookup = publishedCutoffResult.status === "ok"
-    ? { timestamp: publishedCutoffResult.updatedAt, status: "ok" as const }
-    : await getLatestSuccessfulCronTimestampResult(db, "sync-yield-data");
-  const fallbackPublishedCutoff = rankingsCache?.updatedAt ?? 0;
-  const publishedCutoff = publishedCutoffResult.status === "ok"
-    ? (publication?.cutoffAt ?? publishedCutoffResult.updatedAt)
-    : publishedCutoffLookup.timestamp ?? fallbackPublishedCutoff;
-  const freshnessWarning = publishedCutoffLookup.status === "lookup_failed"
-    ? "Yield history freshness lookup failed; falling back to cache metadata."
-    : null;
-
-  if (publishedCutoffResult.status !== "ok") {
-    logMalformedJsonPath({
-      scope: "api",
-      owner: "yield-history",
-      context: "yield-rankings.updatedAt",
-      reason: publishedCutoffResult.status,
-      source: "cache:yield-rankings",
-      updatedAt: rankingsCache?.updatedAt ?? null,
-      extra: {
-        fallbackCutoff: publishedCutoff,
-        lookupStatus: publishedCutoffLookup.status,
-      },
+export const handleYieldHistory = withErrorHandler(
+  "yield-history",
+  async (db: D1Database, url: URL): Promise<Response> => {
+    const parsed = parseStablecoinHistoryQuery(url, {
+      defaultDays: 90,
+      minDays: 1,
+      maxDays: 365,
+      rangePolicy: "reject",
     });
-  }
+    if (parsed instanceof Response) {
+      return parsed;
+    }
 
-  const publicationFilter = "AND (publication_generation_id IS NULL OR publication_state = 'published')";
+    const requestedMode = url.searchParams.get("mode")?.trim() ?? "best";
+    const sourceKey = url.searchParams.get("sourceKey")?.trim() ?? null;
+    const mode = sourceKey ? "source" : requestedMode;
+    if (mode !== "best" && mode !== "source") {
+      return errorResponse(400, "Invalid mode: expected 'best' or 'source'");
+    }
+    if (mode === "source" && !sourceKey) {
+      return errorResponse(400, "Missing ?sourceKey= parameter for source history mode");
+    }
 
-  const sql = mode === "source"
-    ? `SELECT /* pharos:yield-history:source-window */
+    const rankingsCache = await getCache(db, "yield-rankings");
+    const publication = parseYieldPublicationMetadata(rankingsCache);
+    const sourceRiskByHistoryKey = buildYieldHistorySourceRiskLookup(rankingsCache);
+    const publishedCutoffResult = parseYieldRankingsPublishedCutoff(rankingsCache);
+    const publishedCutoffLookup =
+      publishedCutoffResult.status === "ok"
+        ? { timestamp: publishedCutoffResult.updatedAt, status: "ok" as const }
+        : await getLatestSuccessfulCronTimestampResult(db, "sync-yield-data");
+    const fallbackPublishedCutoff = rankingsCache?.updatedAt ?? 0;
+    const publishedCutoff =
+      publishedCutoffResult.status === "ok"
+        ? (publication?.cutoffAt ?? publishedCutoffResult.updatedAt)
+        : (publishedCutoffLookup.timestamp ?? fallbackPublishedCutoff);
+    const freshnessWarning =
+      publishedCutoffLookup.status === "lookup_failed"
+        ? "Yield history freshness lookup failed; falling back to cache metadata."
+        : null;
+
+    if (publishedCutoffResult.status !== "ok") {
+      logMalformedJsonPath({
+        scope: "api",
+        owner: "yield-history",
+        context: "yield-rankings.updatedAt",
+        reason: publishedCutoffResult.status,
+        source: "cache:yield-rankings",
+        updatedAt: rankingsCache?.updatedAt ?? null,
+        extra: {
+          fallbackCutoff: publishedCutoff,
+          lookupStatus: publishedCutoffLookup.status,
+        },
+      });
+    }
+
+    const publicationFilter = "AND (publication_generation_id IS NULL OR publication_state = 'published')";
+
+    const sql =
+      mode === "source"
+        ? `SELECT /* pharos:yield-history:source-window */
          recorded_at, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd, warning_signals, source_key, yield_source, yield_type, data_source, is_best, publication_generation_id, pys_at_publish, safety_at_publish, variance_at_publish
        FROM yield_history
        WHERE stablecoin_id = ? AND recorded_at >= ? AND recorded_at <= ? AND source_key = ?
        ${publicationFilter}
        ORDER BY recorded_at ASC`
-    : `SELECT /* pharos:yield-history:best-window */
+        : `SELECT /* pharos:yield-history:best-window */
          recorded_at, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd, warning_signals, source_key, yield_source, yield_type, data_source, is_best, publication_generation_id, pys_at_publish, safety_at_publish, variance_at_publish
        FROM yield_history
        WHERE stablecoin_id = ? AND recorded_at >= ? AND recorded_at <= ? AND is_best = 1
        ${publicationFilter}
        ORDER BY recorded_at ASC`;
 
-  const result = mode === "source"
-    ? await db.prepare(sql).bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff, sourceKey).all<YieldHistoryRow>()
-    : await db.prepare(sql).bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff).all<YieldHistoryRow>();
+    let result: D1Result<YieldHistoryRow>;
+    try {
+      result =
+        mode === "source"
+          ? await db
+              .prepare(sql)
+              .bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff, sourceKey)
+              .all<YieldHistoryRow>()
+          : await db.prepare(sql).bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff).all<YieldHistoryRow>();
+    } catch (error) {
+      if (!isMissingColumnError(error)) throw error;
+      const legacySql =
+        mode === "source"
+          ? `SELECT /* pharos:yield-history:source-window:legacy-schema */
+           recorded_at, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd, warning_signals, source_key, yield_source, yield_type, data_source, is_best, publication_generation_id, NULL AS pys_at_publish, NULL AS safety_at_publish, NULL AS variance_at_publish
+         FROM yield_history
+         WHERE stablecoin_id = ? AND recorded_at >= ? AND recorded_at <= ? AND source_key = ?
+         ${publicationFilter}
+         ORDER BY recorded_at ASC`
+          : `SELECT /* pharos:yield-history:best-window:legacy-schema */
+           recorded_at, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd, warning_signals, source_key, yield_source, yield_type, data_source, is_best, publication_generation_id, NULL AS pys_at_publish, NULL AS safety_at_publish, NULL AS variance_at_publish
+         FROM yield_history
+         WHERE stablecoin_id = ? AND recorded_at >= ? AND recorded_at <= ? AND is_best = 1
+         ${publicationFilter}
+         ORDER BY recorded_at ASC`;
+      result =
+        mode === "source"
+          ? await db
+              .prepare(legacySql)
+              .bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff, sourceKey)
+              .all<YieldHistoryRow>()
+          : await db
+              .prepare(legacySql)
+              .bind(parsed.stablecoinId, parsed.cutoff, publishedCutoff)
+              .all<YieldHistoryRow>();
+    }
 
-  let previousSourceKey: string | null = null;
-  const history = (result.results ?? [])
-    .filter((row) => (
-      !isSuppressedYieldHistoryRow(parsed.stablecoinId, row.source_key)
-      && !isOnChainBootstrapYieldSeed(row)
-    ))
-    .map((row) => {
-      const normalizedSourceKey = normalizeHistorySourceKey(parsed.stablecoinId, row, mode);
-      const sourceRiskKey = row.publication_generation_id
-        ? buildSourceRiskLookupKey(row.publication_generation_id, parsed.stablecoinId, normalizedSourceKey)
-        : null;
-      const hasSourceRisk = sourceRiskKey != null && sourceRiskByHistoryKey.has(sourceRiskKey);
-      const sourceRisk = sourceRiskKey != null ? sourceRiskByHistoryKey.get(sourceRiskKey) : undefined;
-      const sourceSwitch =
-        mode === "best" &&
-        previousSourceKey != null &&
-        previousSourceKey !== normalizedSourceKey;
-      previousSourceKey = normalizedSourceKey;
+    let previousSourceKey: string | null = null;
+    const history = (result.results ?? [])
+      .filter(
+        (row) => !isSuppressedYieldHistoryRow(parsed.stablecoinId, row.source_key) && !isOnChainBootstrapYieldSeed(row),
+      )
+      .map((row) => {
+        const normalizedSourceKey = normalizeHistorySourceKey(parsed.stablecoinId, row, mode);
+        const sourceRiskKey = row.publication_generation_id
+          ? buildSourceRiskLookupKey(row.publication_generation_id, parsed.stablecoinId, normalizedSourceKey)
+          : null;
+        const hasSourceRisk = sourceRiskKey != null && sourceRiskByHistoryKey.has(sourceRiskKey);
+        const sourceRisk = sourceRiskKey != null ? sourceRiskByHistoryKey.get(sourceRiskKey) : undefined;
+        const sourceSwitch = mode === "best" && previousSourceKey != null && previousSourceKey !== normalizedSourceKey;
+        previousSourceKey = normalizedSourceKey;
 
-      const pysAtPublish =
-        typeof row.pys_at_publish === "number" && Number.isFinite(row.pys_at_publish)
-          ? row.pys_at_publish
-          : row.pys_at_publish === null ? null : undefined;
-      const safetyAtPublish =
-        typeof row.safety_at_publish === "number" && Number.isFinite(row.safety_at_publish)
-          ? row.safety_at_publish
-          : row.safety_at_publish === null ? null : undefined;
-      const varianceAtPublish =
-        typeof row.variance_at_publish === "number" && Number.isFinite(row.variance_at_publish)
-          ? row.variance_at_publish
-          : row.variance_at_publish === null ? null : undefined;
+        const pysAtPublish =
+          typeof row.pys_at_publish === "number" && Number.isFinite(row.pys_at_publish)
+            ? row.pys_at_publish
+            : row.pys_at_publish === null
+              ? null
+              : undefined;
+        const safetyAtPublish =
+          typeof row.safety_at_publish === "number" && Number.isFinite(row.safety_at_publish)
+            ? row.safety_at_publish
+            : row.safety_at_publish === null
+              ? null
+              : undefined;
+        const varianceAtPublish =
+          typeof row.variance_at_publish === "number" && Number.isFinite(row.variance_at_publish)
+            ? row.variance_at_publish
+            : row.variance_at_publish === null
+              ? null
+              : undefined;
 
-      return {
-        date: row.recorded_at,
-        apy: row.apy,
-        apyBase: row.apy_base,
-        apyReward: row.apy_reward,
-        exchangeRate: row.exchange_rate,
-        sourceTvlUsd: row.source_tvl_usd,
-        warningSignals: parseYieldWarningSignals(row.warning_signals),
-        sourceKey: normalizedSourceKey,
-        yieldSource: row.yield_source,
-        yieldSourceUrl: resolveYieldSourceUrl({
-          stablecoinId: parsed.stablecoinId,
+        return {
+          date: row.recorded_at,
+          apy: row.apy,
+          apyBase: row.apy_base,
+          apyReward: row.apy_reward,
+          exchangeRate: row.exchange_rate,
+          sourceTvlUsd: row.source_tvl_usd,
+          warningSignals: parseYieldWarningSignals(row.warning_signals),
           sourceKey: normalizedSourceKey,
           yieldSource: row.yield_source,
+          yieldSourceUrl: resolveYieldSourceUrl({
+            stablecoinId: parsed.stablecoinId,
+            sourceKey: normalizedSourceKey,
+            yieldSource: row.yield_source,
+          }),
+          yieldType: row.yield_type,
+          dataSource: row.data_source,
+          isBest: row.is_best === 1,
+          publicationGenerationId: row.publication_generation_id ?? null,
+          ...(hasSourceRisk ? { sourceRisk: sourceRisk ?? null } : {}),
+          sourceSwitch,
+          ...(pysAtPublish !== undefined ? { pysAtPublish } : {}),
+          ...(safetyAtPublish !== undefined ? { safetyAtPublish } : {}),
+          ...(varianceAtPublish !== undefined ? { varianceAtPublish } : {}),
+        };
+      });
+
+    const latestHistoryTimestamp =
+      history.length > 0
+        ? Math.max(...history.map((row) => (typeof row.date === "number" ? row.date : 0)))
+        : publishedCutoff;
+
+    const current = history.length > 0 ? (history[history.length - 1] ?? null) : null;
+
+    return jsonFreshResponse(
+      {
+        current,
+        history,
+        ...(freshnessWarning ? { warning: freshnessWarning } : {}),
+        ...(publication ? { publication } : {}),
+        methodology: buildMethodologyEnvelope({
+          version: YIELD_METHODOLOGY_VERSION,
+          versionLabel: YIELD_METHODOLOGY_VERSION_LABEL,
+          currentVersion: YIELD_METHODOLOGY_VERSION,
+          currentVersionLabel: YIELD_METHODOLOGY_VERSION_LABEL,
+          changelogPath: YIELD_METHODOLOGY_CHANGELOG_PATH,
+          asOf: latestHistoryTimestamp,
         }),
-        yieldType: row.yield_type,
-        dataSource: row.data_source,
-        isBest: row.is_best === 1,
-        publicationGenerationId: row.publication_generation_id ?? null,
-        ...(hasSourceRisk ? { sourceRisk: sourceRisk ?? null } : {}),
-        sourceSwitch,
-        ...(pysAtPublish !== undefined ? { pysAtPublish } : {}),
-        ...(safetyAtPublish !== undefined ? { safetyAtPublish } : {}),
-        ...(varianceAtPublish !== undefined ? { varianceAtPublish } : {}),
-      };
-    });
-
-  const latestHistoryTimestamp = history.length > 0
-    ? Math.max(...history.map((row) => (typeof row.date === "number" ? row.date : 0)))
-    : publishedCutoff;
-
-  const current = history.length > 0 ? history[history.length - 1] ?? null : null;
-
-  return jsonFreshResponse({
-    current,
-    history,
-    ...(freshnessWarning ? { warning: freshnessWarning } : {}),
-    ...(publication ? { publication } : {}),
-    methodology: buildMethodologyEnvelope({
-      version: YIELD_METHODOLOGY_VERSION,
-      versionLabel: YIELD_METHODOLOGY_VERSION_LABEL,
-      currentVersion: YIELD_METHODOLOGY_VERSION,
-      currentVersionLabel: YIELD_METHODOLOGY_VERSION_LABEL,
-      changelogPath: YIELD_METHODOLOGY_CHANGELOG_PATH,
-      asOf: latestHistoryTimestamp,
-    }),
-  }, {
-    cacheControl: CACHE_PROFILES.slow,
-    updatedAt: latestHistoryTimestamp,
-    maxAgeSec: CRON_INTERVALS["sync-yield-data"],
-  });
-});
+      },
+      {
+        cacheControl: CACHE_PROFILES.slow,
+        updatedAt: latestHistoryTimestamp,
+        maxAgeSec: CRON_INTERVALS["sync-yield-data"],
+      },
+    );
+  },
+);

--- a/worker/src/api/yield-source-decisions.ts
+++ b/worker/src/api/yield-source-decisions.ts
@@ -1,4 +1,5 @@
 import { jsonResponse, parseIntParam, parseOptionalEnumParam } from "../lib/api-utils";
+import { isMissingColumnError, isMissingTableError } from "../lib/db";
 import { makeAdminRoute } from "../lib/route-wrappers";
 
 type GenerationState = "staged" | "published" | "failed";
@@ -111,10 +112,7 @@ function mapGeneration(row: YieldGenerationRow) {
   };
 }
 
-function mapDecision(
-  row: YieldSourceDecisionRow,
-  publicAlternatives?: YieldSourceDecisionAlternativeRow[],
-) {
+function mapDecision(row: YieldSourceDecisionRow, publicAlternatives?: YieldSourceDecisionAlternativeRow[]) {
   const parsedAlternatives = parseJsonValue(row.alternatives_json);
   const alternatives = Array.isArray(parsedAlternatives.value) ? parsedAlternatives.value : [];
   const alternativesMalformed =
@@ -188,9 +186,15 @@ async function loadStablecoinDecisions(
     includePublicAlternatives: boolean;
   },
 ) {
-  const rows = await db
-    .prepare(
-      `SELECT /* pharos:yield-source-decisions:stablecoin-decisions */
+  const decisionBinds = [
+    params.stablecoinId,
+    params.generationId,
+    params.generationId,
+    params.state,
+    params.state,
+    params.limit,
+  ] as const;
+  const decisionSql = `SELECT /* pharos:yield-source-decisions:stablecoin-decisions */
          d.generation_id, d.stablecoin_id, d.selected_source_key, d.selected_confidence_tier,
          d.selected_data_source, d.selected_apy_30d, d.selected_score, d.selected_reason,
          d.previous_best_source_key, d.source_switch, d.rejected_count, d.alternatives_json,
@@ -201,17 +205,33 @@ async function loadStablecoinDecisions(
          AND (? IS NULL OR d.generation_id = ?)
          AND (? IS NULL OR g.state = ?)
        ORDER BY g.started_at DESC, d.generation_id DESC
-       LIMIT ?`,
-    )
-    .bind(
-      params.stablecoinId,
-      params.generationId,
-      params.generationId,
-      params.state,
-      params.state,
-      params.limit,
-    )
-    .all<YieldSourceDecisionRow>();
+       LIMIT ?`;
+  let rows: D1Result<YieldSourceDecisionRow>;
+  try {
+    rows = await db
+      .prepare(decisionSql)
+      .bind(...decisionBinds)
+      .all<YieldSourceDecisionRow>();
+  } catch (error) {
+    if (!isMissingColumnError(error)) throw error;
+    rows = await db
+      .prepare(
+        `SELECT /* pharos:yield-source-decisions:stablecoin-decisions:legacy-schema */
+           d.generation_id, d.stablecoin_id, d.selected_source_key, d.selected_confidence_tier,
+           d.selected_data_source, d.selected_apy_30d, d.selected_score, d.selected_reason,
+           d.previous_best_source_key, d.source_switch, d.rejected_count, d.alternatives_json,
+           d.created_at, NULL AS retention_reason
+         FROM yield_source_decisions d
+         INNER JOIN yield_publication_generations g ON g.generation_id = d.generation_id
+         WHERE d.stablecoin_id = ?
+           AND (? IS NULL OR d.generation_id = ?)
+           AND (? IS NULL OR g.state = ?)
+         ORDER BY g.started_at DESC, d.generation_id DESC
+         LIMIT ?`,
+      )
+      .bind(...decisionBinds)
+      .all<YieldSourceDecisionRow>();
+  }
 
   const decisionRows = rows.results ?? [];
   if (decisionRows.length === 0) return [];
@@ -221,37 +241,38 @@ async function loadStablecoinDecisions(
     const generationIds = [...new Set(decisionRows.map((row) => row.generation_id))];
     if (generationIds.length > 0) {
       const placeholders = generationIds.map(() => "?").join(",");
-      const altRows = await db
-        .prepare(
-          `SELECT /* pharos:yield-source-decisions:public-alternatives */
-                  generation_id, stablecoin_id, alt_source_key, alt_yield_source,
-                  alt_apy30d_delta, rejection_reason_code, recorded_at
-           FROM yield_source_decision_alternatives
-           WHERE stablecoin_id = ? AND generation_id IN (${placeholders})
-           ORDER BY recorded_at DESC, alt_source_key ASC`,
-        )
-        .bind(params.stablecoinId, ...generationIds)
-        .all<YieldSourceDecisionAlternativeRow>();
-      const grouped = new Map<string, YieldSourceDecisionAlternativeRow[]>();
-      for (const alt of altRows.results ?? []) {
-        const list = grouped.get(alt.generation_id) ?? [];
-        list.push(alt);
-        grouped.set(alt.generation_id, list);
+      try {
+        const altRows = await db
+          .prepare(
+            `SELECT /* pharos:yield-source-decisions:public-alternatives */
+                    generation_id, stablecoin_id, alt_source_key, alt_yield_source,
+                    alt_apy30d_delta, rejection_reason_code, recorded_at
+             FROM yield_source_decision_alternatives
+             WHERE stablecoin_id = ? AND generation_id IN (${placeholders})
+             ORDER BY recorded_at DESC, alt_source_key ASC`,
+          )
+          .bind(params.stablecoinId, ...generationIds)
+          .all<YieldSourceDecisionAlternativeRow>();
+        const grouped = new Map<string, YieldSourceDecisionAlternativeRow[]>();
+        for (const alt of altRows.results ?? []) {
+          const list = grouped.get(alt.generation_id) ?? [];
+          list.push(alt);
+          grouped.set(alt.generation_id, list);
+        }
+        publicAlternativesByGeneration = grouped;
+      } catch (error) {
+        if (!isMissingTableError(error)) throw error;
       }
-      publicAlternativesByGeneration = grouped;
     }
   }
 
   return decisionRows.map((row) =>
     mapDecision(
       row,
-      params.includePublicAlternatives
-        ? publicAlternativesByGeneration.get(row.generation_id) ?? []
-        : undefined,
+      params.includePublicAlternatives ? (publicAlternativesByGeneration.get(row.generation_id) ?? []) : undefined,
     ),
   );
 }
-
 
 export const handleYieldSourceDecisions = makeAdminRoute<AdminRouteContext>(
   "route-yield-source-decisions",

--- a/worker/src/cron/__tests__/yield-publication.test.ts
+++ b/worker/src/cron/__tests__/yield-publication.test.ts
@@ -22,6 +22,7 @@ import {
   validateYieldRankingsPayloadForPublish,
 } from "../yield-sync/publication";
 import { publishYieldCoordinatorResults } from "../yield-sync/coordinator-persist";
+import { publishYieldRowsAtomically } from "../yield-sync/publication-atomic-batch";
 
 const MIGRATIONS_DIR = path.resolve(__dirname, "../../../migrations");
 
@@ -161,9 +162,7 @@ function buildPayloadWithObservedAt(sourceObservedAt: number, overrides: Partial
           sourceAgeSeconds: Math.max(0, startSec - sourceObservedAt),
           comparisonAnchorObservedAt,
           comparisonAnchorAgeSeconds:
-            comparisonAnchorObservedAt == null
-              ? null
-              : Math.max(0, startSec - comparisonAnchorObservedAt),
+            comparisonAnchorObservedAt == null ? null : Math.max(0, startSec - comparisonAnchorObservedAt),
           confidenceTier: source.confidenceTier,
           selectionMethod: "confidence-weighted" as const,
           selectionReason: "test",
@@ -220,52 +219,40 @@ describe("buildYieldRankingsPayloadFromEvaluatedSources", () => {
 
   it("does not add data-stale for healthy price-derived daily snapshots", () => {
     const thresholdSec = PRICE_DERIVED_STALE_THRESHOLD_MS / 1000;
-    const payload = buildPayloadWithObservedAt(
-      Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60,
-      {
-        dataSource: "price-derived",
-        sourceKey: "price-derived",
-      },
-    );
+    const payload = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60, {
+      dataSource: "price-derived",
+      sourceKey: "price-derived",
+    });
 
     expect(payload.rankings[0]?.warningSignals).not.toContain("data-stale");
   });
 
   it("still adds data-stale when price-derived snapshots miss the extended threshold", () => {
     const thresholdSec = PRICE_DERIVED_STALE_THRESHOLD_MS / 1000;
-    const payload = buildPayloadWithObservedAt(
-      Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec - 60,
-      {
-        dataSource: "price-derived",
-        sourceKey: "price-derived",
-      },
-    );
+    const payload = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec - 60, {
+      dataSource: "price-derived",
+      sourceKey: "price-derived",
+    });
 
     expect(payload.rankings[0]?.warningSignals).toContain("data-stale");
   });
 
   it("does not add data-stale for healthy supplemental protocol-api rows", () => {
     const thresholdSec = SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS / 1000;
-    const payload = buildPayloadWithObservedAt(
-      Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60,
-      {
-        dataSource: "protocol-api",
-        sourceKey: "protocol-api:pendle:ethereum:0xpool",
-      },
-    );
+    const payload = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60, {
+      dataSource: "protocol-api",
+      sourceKey: "protocol-api:pendle:ethereum:0xpool",
+    });
 
     expect(payload.rankings[0]?.warningSignals).not.toContain("data-stale");
   });
 
   it("adds data-stale once supplemental protocol-api rows miss their cadence window", () => {
     const thresholdSec = SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS / 1000;
-    const payload = buildPayloadWithObservedAt(
-      Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec - 60,
-      {
-        dataSource: "protocol-api",
-        sourceKey: "protocol-api:pendle:ethereum:0xpool",
-      },
-    );
+    const payload = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec - 60, {
+      dataSource: "protocol-api",
+      sourceKey: "protocol-api:pendle:ethereum:0xpool",
+    });
 
     expect(payload.rankings[0]?.warningSignals).toContain("data-stale");
   });
@@ -298,13 +285,10 @@ describe("buildYieldRankingsPayloadFromEvaluatedSources", () => {
 
   it("does not add data-stale for healthy supplemental onchain rows", () => {
     const thresholdSec = SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS / 1000;
-    const payload = buildPayloadWithObservedAt(
-      Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60,
-      {
-        dataSource: "onchain",
-        sourceKey: "aave-v3-onchain:ethereum:0xasset",
-      },
-    );
+    const payload = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec + 60, {
+      dataSource: "onchain",
+      sourceKey: "aave-v3-onchain:ethereum:0xasset",
+    });
 
     expect(payload.rankings[0]?.warningSignals).not.toContain("data-stale");
   });
@@ -636,7 +620,9 @@ describe("publishYieldCoordinatorResults", () => {
 
     expect(result.ok).toBe(false);
     const history = db.getHistory();
-    expect(history.some((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_publication_generations"))).toBe(true);
+    expect(history.some((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_publication_generations"))).toBe(
+      true,
+    );
     expect(history.some((entry) => entry.sql.includes("SET state = 'failed'"))).toBe(true);
     expect(history.some((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_data"))).toBe(false);
   });
@@ -662,7 +648,9 @@ describe("publishYieldCoordinatorResults", () => {
     expect(rows[0]?.publication_state).toBe("published");
     expect(history.some((entry) => entry.sql.includes("SET state = 'failed'"))).toBe(true);
     expect(
-      history.some((entry) => entry.sql.includes("UPDATE yield_history SET publication_state = ?") && entry.binds[0] === "failed"),
+      history.some(
+        (entry) => entry.sql.includes("UPDATE yield_history SET publication_state = ?") && entry.binds[0] === "failed",
+      ),
     ).toBe(true);
   });
 
@@ -683,7 +671,9 @@ describe("publishYieldCoordinatorResults", () => {
     expect(history.some((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_data"))).toBe(true);
     expect(history.some((entry) => entry.sql.includes("SET state = 'failed'"))).toBe(true);
     expect(
-      history.some((entry) => entry.sql.includes("UPDATE yield_data SET publication_state = ?") && entry.binds[0] === "failed"),
+      history.some(
+        (entry) => entry.sql.includes("UPDATE yield_data SET publication_state = ?") && entry.binds[0] === "failed",
+      ),
     ).toBe(true);
   });
 
@@ -735,19 +725,25 @@ describe("publishYieldCoordinatorResults", () => {
       dataSource: "price-derived",
     });
 
-    const result = await publishYieldCoordinatorResults(makePublishParams({
-      db,
-      evaluatedSources: [best, rejected, retained],
-      bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
-    }));
+    const result = await publishYieldCoordinatorResults(
+      makePublishParams({
+        db,
+        evaluatedSources: [best, rejected, retained],
+        bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
+      }),
+    );
 
     expect(result).toMatchObject({ ok: true });
-    const decisionInsert = db.getHistory().find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
+    const decisionInsert = db
+      .getHistory()
+      .find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
     const decisionRows = parseJsonBind<Array<{ alternatives_json: string }>>(decisionInsert);
     const alternativesJson = decisionRows[0]?.alternatives_json ?? "";
     expect(new TextEncoder().encode(alternativesJson).length).toBeLessThanOrEqual(4096);
     const alternatives = JSON.parse(alternativesJson) as Array<{ reason?: string; anomalies?: string[] }>;
-    expect(alternatives.some((alternative) => alternative.reason === "rejected: divergent lower-confidence source")).toBe(true);
+    expect(
+      alternatives.some((alternative) => alternative.reason === "rejected: divergent lower-confidence source"),
+    ).toBe(true);
     expect(alternatives.every((alternative) => (alternative.anomalies?.length ?? 0) <= 6)).toBe(true);
   });
 
@@ -765,8 +761,10 @@ describe("publishYieldCoordinatorResults", () => {
     const yieldDataInsert = history.find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_data"));
     const yieldHistoryInsert = history.find((entry) => entry.sql.includes("INSERT OR IGNORE INTO yield_history"));
     const cacheWrite = history.find((entry) => entry.sql.includes("INSERT INTO cache (key, value, updated_at)"));
-    const yieldRows = parseJsonBind<Array<{ publication_generation_id: string; publication_state: string }>>(yieldDataInsert);
-    const historyRows = parseJsonBind<Array<{ publication_generation_id: string; publication_state: string }>>(yieldHistoryInsert);
+    const yieldRows =
+      parseJsonBind<Array<{ publication_generation_id: string; publication_state: string }>>(yieldDataInsert);
+    const historyRows =
+      parseJsonBind<Array<{ publication_generation_id: string; publication_state: string }>>(yieldHistoryInsert);
     expect(yieldRows[0]).toMatchObject({
       publication_generation_id: "yield-1774526400",
       publication_state: "published",
@@ -867,12 +865,14 @@ describe("publishYieldCoordinatorResults", () => {
     expect(previewLedger?.alternatives.length).toBeLessThanOrEqual(2);
     expect(previewLedger?.sourceSwitch).toBe(true);
 
-    const result = await publishYieldCoordinatorResults(makePublishParams({
-      db,
-      previewRankingsPayload,
-      evaluatedSources: [best, altA, altB, altC],
-      bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
-    }));
+    const result = await publishYieldCoordinatorResults(
+      makePublishParams({
+        db,
+        previewRankingsPayload,
+        evaluatedSources: [best, altA, altB, altC],
+        bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
+      }),
+    );
     expect(result).toMatchObject({ ok: true });
 
     const history = db.getHistory();
@@ -887,11 +887,15 @@ describe("publishYieldCoordinatorResults", () => {
     const decisionRows = parseJsonBind<Array<{ retention_reason: string }>>(decisionInsert);
     expect(decisionRows[0]?.retention_reason).toBe("trend");
 
-    const alternativesInsert = history.find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decision_alternatives"));
-    const alternativeRows = parseJsonBind<Array<{
-      alt_source_key: string;
-      rejection_reason_code: string;
-    }>>(alternativesInsert);
+    const alternativesInsert = history.find((entry) =>
+      entry.sql.includes("INSERT OR REPLACE INTO yield_source_decision_alternatives"),
+    );
+    const alternativeRows = parseJsonBind<
+      Array<{
+        alt_source_key: string;
+        rejection_reason_code: string;
+      }>
+    >(alternativesInsert);
     expect(alternativeRows.length).toBeLessThanOrEqual(2);
     expect(alternativeRows.length).toBeGreaterThan(0);
     for (const row of alternativeRows) {
@@ -915,11 +919,13 @@ describe("publishYieldCoordinatorResults", () => {
     expect(yieldHistoryInsert?.sql).toContain("pys_at_publish");
     expect(yieldHistoryInsert?.sql).toContain("safety_at_publish");
     expect(yieldHistoryInsert?.sql).toContain("variance_at_publish");
-    const historyRows = parseJsonBind<Array<{
-      pys_at_publish: number | null;
-      safety_at_publish: number | null;
-      variance_at_publish: number | null;
-    }>>(yieldHistoryInsert);
+    const historyRows = parseJsonBind<
+      Array<{
+        pys_at_publish: number | null;
+        safety_at_publish: number | null;
+        variance_at_publish: number | null;
+      }>
+    >(yieldHistoryInsert);
     expect(historyRows[0]?.pys_at_publish).toBe(28);
     expect(historyRows[0]?.safety_at_publish).toBe(82);
     expect(historyRows[0]?.variance_at_publish).toBe(0.2);
@@ -930,7 +936,9 @@ describe("publishYieldCoordinatorResults", () => {
     const result = await publishYieldCoordinatorResults(makePublishParams({ db }));
     expect(result).toMatchObject({ ok: true });
 
-    const decisionInsert = db.getHistory().find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
+    const decisionInsert = db
+      .getHistory()
+      .find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
     const decisionRows = parseJsonBind<Array<{ retention_reason: string }>>(decisionInsert);
     expect(decisionRows[0]?.retention_reason).toBe("audit");
   });
@@ -955,14 +963,18 @@ describe("publishYieldCoordinatorResults", () => {
       anomalies: ["diverges-from-canonical"],
     });
 
-    const result = await publishYieldCoordinatorResults(makePublishParams({
-      db,
-      evaluatedSources: [best, rejected],
-      bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
-    }));
+    const result = await publishYieldCoordinatorResults(
+      makePublishParams({
+        db,
+        evaluatedSources: [best, rejected],
+        bestSourceKeyByCoin: new Map([[best.id, best.sourceKey]]),
+      }),
+    );
     expect(result).toMatchObject({ ok: true });
 
-    const decisionInsert = db.getHistory().find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
+    const decisionInsert = db
+      .getHistory()
+      .find((entry) => entry.sql.includes("INSERT OR REPLACE INTO yield_source_decisions"));
     const decisionRows = parseJsonBind<Array<{ retention_reason: string }>>(decisionInsert);
     expect(decisionRows[0]?.retention_reason).toBe("trend");
   });
@@ -1043,13 +1055,7 @@ describe("pruneYieldTables", () => {
         .prepare("SELECT generation_id FROM yield_source_decisions ORDER BY generation_id ASC")
         .all()
         .map((row) => (row as { generation_id: string }).generation_id);
-      expect(generations).toEqual([
-        "g-null-anomaly",
-        "g-null-higher",
-        "g-null-switch",
-        "g-old-trend",
-        "g-recent-null",
-      ]);
+      expect(generations).toEqual(["g-null-anomaly", "g-null-higher", "g-null-switch", "g-old-trend", "g-recent-null"]);
       const alternatives = sqlite
         .prepare("SELECT generation_id FROM yield_source_decision_alternatives ORDER BY generation_id ASC")
         .all()
@@ -1062,6 +1068,35 @@ describe("pruneYieldTables", () => {
 });
 
 describe("yield publication migration compatibility", () => {
+  it("retries atomic publication with legacy statements when new yield schema is absent", async () => {
+    const db = mockD1([
+      {
+        match: "pys_at_publish, safety_at_publish",
+        rows: [],
+        throwError: new Error("D1_ERROR: table yield_history has no column named pys_at_publish"),
+      },
+    ]);
+
+    const result = await publishYieldRowsAtomically(db, {
+      rankingsPayload: { stablecoins: [] },
+      startSec: 1_774_526_400,
+      generationId: "yield-1774526400",
+      yieldDataRows: [],
+      historyRows: [],
+      decisionRows: [],
+      decisionAlternativeRows: [],
+    });
+
+    expect(result).toEqual({ written: true, skippedBecauseNewer: false });
+    const history = db.getHistory();
+    expect(history.some((entry) => entry.sql.includes("pys_at_publish"))).toBe(true);
+    expect(
+      history.some(
+        (entry) => entry.sql.includes("INSERT OR IGNORE INTO yield_history") && !entry.sql.includes("pys_at_publish"),
+      ),
+    ).toBe(true);
+  });
+
   it("keeps old-worker yield_data and yield_history inserts valid after the additive migration", async () => {
     const { DatabaseSync } = await import("node:sqlite");
     const sqlite = new DatabaseSync(":memory:");

--- a/worker/src/cron/yield-sync/publication-atomic-batch.ts
+++ b/worker/src/cron/yield-sync/publication-atomic-batch.ts
@@ -1,4 +1,5 @@
 import { runWithOverloadRetry } from "../../lib/cron-lease";
+import { isMissingColumnError, isMissingTableError } from "../../lib/db";
 import type { CacheWriteResult } from "../../lib/db-cache";
 
 export async function publishYieldRowsAtomically(
@@ -16,18 +17,17 @@ export async function publishYieldRowsAtomically(
 ): Promise<CacheWriteResult> {
   const cacheValue = JSON.stringify(input.rankingsPayload);
   const cacheFreshGuard = "(SELECT updated_at FROM cache WHERE key = 'yield-rankings') = ?";
-  const results = await runWithOverloadRetry(() =>
-    db.batch([
-      db
-        .prepare(
-          `INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)
+  const buildStatements = (legacySchema: boolean): D1PreparedStatement[] => [
+    db
+      .prepare(
+        `INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)
            ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
            WHERE cache.updated_at <= excluded.updated_at`,
-        )
-        .bind("yield-rankings", cacheValue, input.startSec),
-      db
-        .prepare(
-          `INSERT OR REPLACE INTO yield_data (
+      )
+      .bind("yield-rankings", cacheValue, input.startSec),
+    db
+      .prepare(
+        `INSERT OR REPLACE INTO yield_data (
             stablecoin_id, source_key, symbol, current_apy, apy_base, apy_reward, apy_7d, apy_30d,
             yield_source, yield_type, source_pool, source_tvl_usd, data_source,
             safety_score, safety_grade, pharos_yield_score, yield_to_risk, excess_yield, yield_stability,
@@ -66,95 +66,149 @@ export async function publishYieldRowsAtomically(
             json_extract(value, '$.publication_state')
           FROM json_each(?)
           WHERE ${cacheFreshGuard}`,
-        )
-        .bind(JSON.stringify(input.yieldDataRows), input.startSec),
-      db
-        .prepare(
-          `INSERT OR IGNORE INTO yield_history (
-            stablecoin_id, source_key, recorded_at, is_best, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd,
-            data_source, warning_signals, yield_source, yield_type, publication_generation_id, publication_state,
-            pys_at_publish, safety_at_publish, variance_at_publish
-          )
-          SELECT
-            json_extract(value, '$.stablecoin_id'),
-            json_extract(value, '$.source_key'),
-            json_extract(value, '$.recorded_at'),
-            json_extract(value, '$.is_best'),
-            json_extract(value, '$.apy'),
-            json_extract(value, '$.apy_base'),
-            json_extract(value, '$.apy_reward'),
-            json_extract(value, '$.exchange_rate'),
-            json_extract(value, '$.source_tvl_usd'),
-            json_extract(value, '$.data_source'),
-            json_extract(value, '$.warning_signals'),
-            json_extract(value, '$.yield_source'),
-            json_extract(value, '$.yield_type'),
-            json_extract(value, '$.publication_generation_id'),
-            json_extract(value, '$.publication_state'),
-            json_extract(value, '$.pys_at_publish'),
-            json_extract(value, '$.safety_at_publish'),
-            json_extract(value, '$.variance_at_publish')
-          FROM json_each(?)
-          WHERE ${cacheFreshGuard}`,
-        )
-        .bind(JSON.stringify(input.historyRows), input.startSec),
-      db
-        .prepare(
-          `INSERT OR REPLACE INTO yield_source_decisions (
-            generation_id, stablecoin_id, selected_source_key, selected_confidence_tier,
-            selected_data_source, selected_apy_30d, selected_score, selected_reason,
-            previous_best_source_key, source_switch, rejected_count, alternatives_json, created_at,
-            retention_reason
-          )
-          SELECT
-            json_extract(value, '$.generation_id'),
-            json_extract(value, '$.stablecoin_id'),
-            json_extract(value, '$.selected_source_key'),
-            json_extract(value, '$.selected_confidence_tier'),
-            json_extract(value, '$.selected_data_source'),
-            json_extract(value, '$.selected_apy_30d'),
-            json_extract(value, '$.selected_score'),
-            json_extract(value, '$.selected_reason'),
-            json_extract(value, '$.previous_best_source_key'),
-            json_extract(value, '$.source_switch'),
-            json_extract(value, '$.rejected_count'),
-            json_extract(value, '$.alternatives_json'),
-            json_extract(value, '$.created_at'),
-            json_extract(value, '$.retention_reason')
-          FROM json_each(?)
-          WHERE ${cacheFreshGuard}`,
-        )
-        .bind(JSON.stringify(input.decisionRows), input.startSec),
-      db
-        .prepare(
-          `INSERT OR REPLACE INTO yield_source_decision_alternatives (
-            generation_id, stablecoin_id, alt_source_key, alt_yield_source,
-            alt_apy30d_delta, rejection_reason_code, recorded_at
-          )
-          SELECT
-            json_extract(value, '$.generation_id'),
-            json_extract(value, '$.stablecoin_id'),
-            json_extract(value, '$.alt_source_key'),
-            json_extract(value, '$.alt_yield_source'),
-            json_extract(value, '$.alt_apy30d_delta'),
-            json_extract(value, '$.rejection_reason_code'),
-            json_extract(value, '$.recorded_at')
-          FROM json_each(?)
-          WHERE ${cacheFreshGuard}`,
-        )
-        .bind(JSON.stringify(input.decisionAlternativeRows), input.startSec),
-      db
-        .prepare(
-          `UPDATE yield_publication_generations
+      )
+      .bind(JSON.stringify(input.yieldDataRows), input.startSec),
+    db
+      .prepare(
+        legacySchema
+          ? `INSERT OR IGNORE INTO yield_history (
+              stablecoin_id, source_key, recorded_at, is_best, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd,
+              data_source, warning_signals, yield_source, yield_type, publication_generation_id, publication_state
+            )
+            SELECT
+              json_extract(value, '$.stablecoin_id'),
+              json_extract(value, '$.source_key'),
+              json_extract(value, '$.recorded_at'),
+              json_extract(value, '$.is_best'),
+              json_extract(value, '$.apy'),
+              json_extract(value, '$.apy_base'),
+              json_extract(value, '$.apy_reward'),
+              json_extract(value, '$.exchange_rate'),
+              json_extract(value, '$.source_tvl_usd'),
+              json_extract(value, '$.data_source'),
+              json_extract(value, '$.warning_signals'),
+              json_extract(value, '$.yield_source'),
+              json_extract(value, '$.yield_type'),
+              json_extract(value, '$.publication_generation_id'),
+              json_extract(value, '$.publication_state')
+            FROM json_each(?)
+            WHERE ${cacheFreshGuard}`
+          : `INSERT OR IGNORE INTO yield_history (
+              stablecoin_id, source_key, recorded_at, is_best, apy, apy_base, apy_reward, exchange_rate, source_tvl_usd,
+              data_source, warning_signals, yield_source, yield_type, publication_generation_id, publication_state,
+              pys_at_publish, safety_at_publish, variance_at_publish
+            )
+            SELECT
+              json_extract(value, '$.stablecoin_id'),
+              json_extract(value, '$.source_key'),
+              json_extract(value, '$.recorded_at'),
+              json_extract(value, '$.is_best'),
+              json_extract(value, '$.apy'),
+              json_extract(value, '$.apy_base'),
+              json_extract(value, '$.apy_reward'),
+              json_extract(value, '$.exchange_rate'),
+              json_extract(value, '$.source_tvl_usd'),
+              json_extract(value, '$.data_source'),
+              json_extract(value, '$.warning_signals'),
+              json_extract(value, '$.yield_source'),
+              json_extract(value, '$.yield_type'),
+              json_extract(value, '$.publication_generation_id'),
+              json_extract(value, '$.publication_state'),
+              json_extract(value, '$.pys_at_publish'),
+              json_extract(value, '$.safety_at_publish'),
+              json_extract(value, '$.variance_at_publish')
+            FROM json_each(?)
+            WHERE ${cacheFreshGuard}`,
+      )
+      .bind(JSON.stringify(input.historyRows), input.startSec),
+    db
+      .prepare(
+        legacySchema
+          ? `INSERT OR REPLACE INTO yield_source_decisions (
+              generation_id, stablecoin_id, selected_source_key, selected_confidence_tier,
+              selected_data_source, selected_apy_30d, selected_score, selected_reason,
+              previous_best_source_key, source_switch, rejected_count, alternatives_json, created_at
+            )
+            SELECT
+              json_extract(value, '$.generation_id'),
+              json_extract(value, '$.stablecoin_id'),
+              json_extract(value, '$.selected_source_key'),
+              json_extract(value, '$.selected_confidence_tier'),
+              json_extract(value, '$.selected_data_source'),
+              json_extract(value, '$.selected_apy_30d'),
+              json_extract(value, '$.selected_score'),
+              json_extract(value, '$.selected_reason'),
+              json_extract(value, '$.previous_best_source_key'),
+              json_extract(value, '$.source_switch'),
+              json_extract(value, '$.rejected_count'),
+              json_extract(value, '$.alternatives_json'),
+              json_extract(value, '$.created_at')
+            FROM json_each(?)
+            WHERE ${cacheFreshGuard}`
+          : `INSERT OR REPLACE INTO yield_source_decisions (
+              generation_id, stablecoin_id, selected_source_key, selected_confidence_tier,
+              selected_data_source, selected_apy_30d, selected_score, selected_reason,
+              previous_best_source_key, source_switch, rejected_count, alternatives_json, created_at,
+              retention_reason
+            )
+            SELECT
+              json_extract(value, '$.generation_id'),
+              json_extract(value, '$.stablecoin_id'),
+              json_extract(value, '$.selected_source_key'),
+              json_extract(value, '$.selected_confidence_tier'),
+              json_extract(value, '$.selected_data_source'),
+              json_extract(value, '$.selected_apy_30d'),
+              json_extract(value, '$.selected_score'),
+              json_extract(value, '$.selected_reason'),
+              json_extract(value, '$.previous_best_source_key'),
+              json_extract(value, '$.source_switch'),
+              json_extract(value, '$.rejected_count'),
+              json_extract(value, '$.alternatives_json'),
+              json_extract(value, '$.created_at'),
+              json_extract(value, '$.retention_reason')
+            FROM json_each(?)
+            WHERE ${cacheFreshGuard}`,
+      )
+      .bind(JSON.stringify(input.decisionRows), input.startSec),
+    ...(legacySchema
+      ? []
+      : [
+          db
+            .prepare(
+              `INSERT OR REPLACE INTO yield_source_decision_alternatives (
+              generation_id, stablecoin_id, alt_source_key, alt_yield_source,
+              alt_apy30d_delta, rejection_reason_code, recorded_at
+            )
+            SELECT
+              json_extract(value, '$.generation_id'),
+              json_extract(value, '$.stablecoin_id'),
+              json_extract(value, '$.alt_source_key'),
+              json_extract(value, '$.alt_yield_source'),
+              json_extract(value, '$.alt_apy30d_delta'),
+              json_extract(value, '$.rejection_reason_code'),
+              json_extract(value, '$.recorded_at')
+            FROM json_each(?)
+            WHERE ${cacheFreshGuard}`,
+            )
+            .bind(JSON.stringify(input.decisionAlternativeRows), input.startSec),
+        ]),
+    db
+      .prepare(
+        `UPDATE yield_publication_generations
            SET state = 'published', published_at = ?, failed_at = NULL, failure_reason = NULL
            WHERE generation_id = ?
              AND ${cacheFreshGuard}`,
-        )
-        .bind(input.startSec, input.generationId, input.startSec),
-    ]),
-    3,
-    input.signal,
-  );
+      )
+      .bind(input.startSec, input.generationId, input.startSec),
+  ];
+
+  let results: D1Result<unknown>[];
+  try {
+    results = await runWithOverloadRetry(() => db.batch(buildStatements(false)), 3, input.signal);
+  } catch (error) {
+    if (!isMissingColumnError(error) && !isMissingTableError(error)) throw error;
+    results = await runWithOverloadRetry(() => db.batch(buildStatements(true)), 3, input.signal);
+  }
 
   return Number(results[0]?.meta?.changes ?? 0) > 0
     ? { written: true, skippedBecauseNewer: false }

--- a/worker/src/lib/db.ts
+++ b/worker/src/lib/db.ts
@@ -20,7 +20,8 @@ export function isMissingTableError(error: unknown): boolean {
 }
 
 export function isMissingColumnError(error: unknown): boolean {
-  return d1ErrorMessage(error).toLowerCase().includes("no such column");
+  const message = d1ErrorMessage(error).toLowerCase();
+  return message.includes("no such column") || message.includes("has no column named");
 }
 
 /** Execute D1 prepared statements in chunks to stay within the batch limit */
@@ -29,9 +30,7 @@ export async function batchExecute(
   stmts: D1PreparedStatement[],
   optionsOrChunkSize: number | BatchExecuteOptions = D1_BATCH_SIZE,
 ): Promise<number> {
-  const options = typeof optionsOrChunkSize === "number"
-    ? { chunkSize: optionsOrChunkSize }
-    : optionsOrChunkSize;
+  const options = typeof optionsOrChunkSize === "number" ? { chunkSize: optionsOrChunkSize } : optionsOrChunkSize;
   const chunkSize = options.chunkSize ?? D1_BATCH_SIZE;
   const signal = options.signal;
   if (!Number.isInteger(chunkSize) || chunkSize <= 0) {


### PR DESCRIPTION
### Motivation
- Recent additive D1 migrations added `pys_at_publish`/`safety_at_publish`/`variance_at_publish`, `retention_reason`, and `yield_source_decision_alternatives`, but the runtime immediately selected/inserted those columns/tables and would error if the migrations were not yet applied, causing availability failures during rollout skew.
- The change introduces defensive feature-detection to keep public/admin yield endpoints and the publication batch available when the database is still on the previous schema.

### Description
- Add a read-time fallback in `handleYieldHistory` to catch missing-column errors and re-run the `SELECT` using a `legacy-schema` projection that returns `NULL AS pys_at_publish`, `NULL AS safety_at_publish`, and `NULL AS variance_at_publish` so history queries succeed against older schemas. 
- Make `handleYieldSourceDecisions` resilient by catching missing `retention_reason` and missing `yield_source_decision_alternatives`, falling back to `NULL AS retention_reason` and treating absent alternatives as an empty set. 
- Update `publishYieldRowsAtomically` to build two statement sets and retry with legacy-compatible `INSERT`/`INSERT OR REPLACE` statements (omitting the new columns/table) when D1 reports missing columns or tables. 
- Broaden D1 error detection in `worker/src/lib/db.ts` to match both `no such column` and `has no column named` messages, and add focused unit tests covering the legacy fallbacks and atomic-publication retry path. 

### Testing
- Ran the focused Vitest suites with `npx vitest run worker/src/api/__tests__/yield-history.test.ts worker/src/api/__tests__/yield-source-decisions.test.ts worker/src/cron/__tests__/yield-publication.test.ts`, and all tests passed. 
- Ran the Worker typecheck with `npm run typecheck:worker` (`cd worker && npx tsc --noEmit`), and it succeeded. 
- Tests exercise the legacy-schema SELECT path, admin-decision fallback (missing column/table), and the publication atomic-batch retry with legacy statements, verifying behavior under schema rollout skew.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff4a208332b0d65c9e93a2cd9d)