### PR TITLE
fix(yield): require published scalingFactor for PYS breakdown attribution

### DIFF
--- a/src/app/stablecoin/[id]/yield/client.tsx
+++ b/src/app/stablecoin/[id]/yield/client.tsx
@@ -69,11 +69,13 @@ function StablecoinYieldDetailHeader({
   logoSrc,
   ranking,
   sourceRiskDrivers,
+  scalingFactor,
 }: {
   staticCoin: StablecoinStaticMeta;
   logoSrc?: string;
   ranking: YieldRanking | null;
   sourceRiskDrivers: readonly YieldSourceRiskDriver[];
+  scalingFactor: number | null;
 }) {
   const pysBreakdown = ranking
     ? computePysBreakdown(
@@ -112,7 +114,7 @@ function StablecoinYieldDetailHeader({
           </div>
         </div>
 
-        {ranking && pysBreakdown ? (
+        {ranking && pysBreakdown && scalingFactor !== null ? (
           <div className="rounded-2xl border border-border/60 bg-background/45 px-4 py-3 sm:min-w-[280px]">
             <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Pharos Yield Score
@@ -133,6 +135,7 @@ function StablecoinYieldDetailHeader({
               grade={ranking.safetyGrade}
               safetyScore={ranking.safetyScore}
               sourceRiskDrivers={sourceRiskDrivers}
+              scalingFactor={scalingFactor}
             />
           </div>
         ) : null}
@@ -269,7 +272,7 @@ export default function YieldAnalysisClient({ id, staticCoin, logoSrc }: YieldAn
     return (
       <div className="space-y-6">
         {backLink}
-        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} />
+        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} scalingFactor={null} />
         <Skeleton className="h-[420px] w-full rounded-xl" />
         <Skeleton className="h-[260px] w-full rounded-xl" />
       </div>
@@ -280,7 +283,7 @@ export default function YieldAnalysisClient({ id, staticCoin, logoSrc }: YieldAn
     return (
       <div className="space-y-6">
         {backLink}
-        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} />
+        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} scalingFactor={null} />
         <QueryErrorNotice
           error={rankingsQuery.error instanceof Error ? rankingsQuery.error : null}
           hasData={false}
@@ -293,7 +296,7 @@ export default function YieldAnalysisClient({ id, staticCoin, logoSrc }: YieldAn
     return (
       <div className="space-y-6">
         {backLink}
-        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} />
+        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} scalingFactor={null} />
         <EmptyStateCard
           title="Pre-launch — no yield data yet"
           message={`${staticCoin.name} is in pre-launch tracking. Yield history will appear here once the stablecoin is live and the cron has observed source data.`}
@@ -311,7 +314,7 @@ export default function YieldAnalysisClient({ id, staticCoin, logoSrc }: YieldAn
     return (
       <div className="space-y-6">
         {backLink}
-        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} />
+        <StablecoinYieldDetailHeader staticCoin={staticCoin} logoSrc={logoSrc} ranking={null} sourceRiskDrivers={[]} scalingFactor={null} />
         <EmptyStateCard title="No yield data available" message={reason} />
       </div>
     );
@@ -334,6 +337,7 @@ export default function YieldAnalysisClient({ id, staticCoin, logoSrc }: YieldAn
         logoSrc={logoSrc}
         ranking={ranking}
         sourceRiskDrivers={sourceExplorer?.sourceRiskDrivers ?? []}
+        scalingFactor={rankingsQuery.data?.scalingFactor ?? null}
       />
 
       {apyChangeAttribution ? (

--- a/src/app/yield/client.tsx
+++ b/src/app/yield/client.tsx
@@ -328,6 +328,7 @@ export function YieldClient() {
               logos={logos ?? {}}
               riskFreeRate={data.riskFreeRate}
               medianApy={data.medianApy ?? 0}
+              scalingFactor={data.scalingFactor}
               emptyMessage={viewModel.emptyState.description}
               filterSummary={{
                 visibleCount: visibleRows.length,

--- a/src/components/__tests__/pys-breakdown.test.tsx
+++ b/src/components/__tests__/pys-breakdown.test.tsx
@@ -32,6 +32,7 @@ function baseProps(overrides: Partial<PysBreakdownProps> = {}): PysBreakdownProp
     grade: "A",
     safetyScore: 90,
     sourceRiskDrivers: [],
+    scalingFactor: 1,
     ...overrides,
   };
 }

--- a/src/components/__tests__/yield-instrument-board.test.tsx
+++ b/src/components/__tests__/yield-instrument-board.test.tsx
@@ -83,6 +83,7 @@ function renderBoard(
         logos={{}}
         riskFreeRate={3.5}
         medianApy={4}
+        scalingFactor={1}
         pageStartIndex={0}
         sortKey="pys"
         sortDirection="desc"
@@ -203,6 +204,7 @@ describe("YieldInstrumentBoard", () => {
           logos={{}}
           riskFreeRate={3.5}
           medianApy={4}
+          scalingFactor={1}
           pageStartIndex={0}
           sortKey="pys"
           sortDirection="desc"

--- a/src/components/pys-breakdown.tsx
+++ b/src/components/pys-breakdown.tsx
@@ -39,9 +39,8 @@ export interface PysBreakdownProps {
   safetyScore: number | null;
   sourceRiskDrivers: readonly YieldSourceRiskDriver[];
   pysNullReason?: YieldPysNullReason | null;
-  // WHY: Callers may not yet pass scalingFactor; deltas are computed against
-  // scaling=1 in that case, which is the conservative approximation.
-  scalingFactor?: number;
+  // WHY: neutralize-and-rescore deltas must use the same scale as the published PYS.
+  scalingFactor: number;
   sourceRiskScore?: number | null;
 }
 
@@ -226,7 +225,7 @@ function PysBreakdownBody(props: Omit<PysBreakdownProps, "pysNullReason">) {
   const consistencyPct = Math.round(sustainabilityMult * 100);
   const benchmarkRefLabel = benchmarkLabel ?? "benchmark";
 
-  const effectiveScalingFactor = typeof scalingFactor === "number" && scalingFactor > 0 ? scalingFactor : 1;
+  const effectiveScalingFactor = scalingFactor;
   const apyVarianceScore = Math.max(0, Math.min(1, 1 - sustainabilityMult));
   const benchmarkRate = benchmarkSpread === null ? null : apy30d - benchmarkSpread;
   const neutralizeComponents: NeutralizeInput = {

--- a/src/components/yield-detail-section-model.ts
+++ b/src/components/yield-detail-section-model.ts
@@ -41,6 +41,7 @@ export interface YieldDetailSectionReadyModel {
     benchmarkAdjustment: number;
     benchmarkSpread: number | null;
     effectiveYield: number;
+    scalingFactor: number;
     sourceRiskPenalty: number;
     yieldEfficiency: number;
     sustainabilityMult: number;
@@ -112,17 +113,20 @@ export function useYieldDetailSectionModel(stablecoinId: string): YieldDetailSec
     return { status: "error", shouldHaveYieldData, error: error instanceof Error ? error : null };
   }
 
-  if (!ranking) {
+  if (!ranking || !data) {
     return { status: "unavailable", shouldHaveYieldData };
   }
 
-  const pysBreakdown = computePysBreakdown(
-    ranking.apy30d,
-    ranking.safetyScore,
-    ranking.yieldStability,
-    ranking.benchmarkRate,
-    ranking.sourceRisk?.sourceRiskPenalty ?? null,
-  );
+  const pysBreakdown = {
+    ...computePysBreakdown(
+      ranking.apy30d,
+      ranking.safetyScore,
+      ranking.yieldStability,
+      ranking.benchmarkRate,
+      ranking.sourceRisk?.sourceRiskPenalty ?? null,
+    ),
+    scalingFactor: data.scalingFactor,
+  };
   const pysColor = getPysColor(ranking.pharosYieldScore);
   const stabilityValue = ranking.yieldStability !== null ? formatPercentFromRatio(ranking.yieldStability, 0) : "—";
   const dataSourceMeta = getYieldDataSourceMeta(ranking.dataSource);

--- a/src/components/yield-detail-section.tsx
+++ b/src/components/yield-detail-section.tsx
@@ -247,6 +247,7 @@ export default function YieldDetailSection({ stablecoinId }: YieldDetailSectionP
             grade={view.ranking.safetyGrade}
             safetyScore={view.ranking.safetyScore}
             sourceRiskDrivers={view.sourceRiskDrivers}
+            scalingFactor={view.pysBreakdown.scalingFactor}
           />
           {view.ranking.provenance?.usedDefaultSafety ? (
             <p className="mt-0.5 text-[11px] text-amber-700 dark:text-amber-300">Default safety inputs</p>

--- a/src/components/yield-instrument-board.tsx
+++ b/src/components/yield-instrument-board.tsx
@@ -195,6 +195,7 @@ interface YieldInstrumentRowProps {
   logo?: string;
   riskFreeRate: number;
   medianApy: number;
+  scalingFactor: number;
   expanded: boolean;
   isCompared: boolean;
   compareDisabled: boolean;
@@ -210,6 +211,7 @@ function YieldInstrumentRowBase({
   logo,
   riskFreeRate,
   medianApy,
+  scalingFactor,
   expanded,
   isCompared,
   compareDisabled,
@@ -223,15 +225,17 @@ function YieldInstrumentRowBase({
   const pysColor = getPysColor(row.pharosYieldScore);
   const labels = formatYieldRowLabels(row);
   const breakdown = useMemo(
-    () =>
-      computePysBreakdown(
+    () => ({
+      ...computePysBreakdown(
         row.apy30d,
         safetyScore,
         row.yieldStability,
         row.benchmarkRate,
         row.sourceRisk?.sourceRiskPenalty ?? null,
       ),
-    [row.apy30d, row.benchmarkRate, row.sourceRisk?.sourceRiskPenalty, row.yieldStability, safetyScore],
+      scalingFactor,
+    }),
+    [row.apy30d, row.benchmarkRate, row.sourceRisk?.sourceRiskPenalty, row.yieldStability, safetyScore, scalingFactor],
   );
   const confidenceTier = row.provenance?.confidenceTier ?? null;
   const confidenceStyle = confidenceTier ? YIELD_SOURCE_CONFIDENCE_STYLES[confidenceTier] : null;
@@ -507,6 +511,7 @@ interface YieldInstrumentBoardProps {
   logos: Record<string, string>;
   riskFreeRate: number;
   medianApy: number;
+  scalingFactor: number;
   pageStartIndex: number;
   sortKey: YieldTableSortKey;
   sortDirection: "asc" | "desc";
@@ -530,6 +535,7 @@ export function YieldInstrumentBoard({
   logos,
   riskFreeRate,
   medianApy,
+  scalingFactor,
   pageStartIndex,
   sortKey,
   sortDirection,
@@ -617,6 +623,7 @@ export function YieldInstrumentBoard({
               logo={logos[row.id]}
               riskFreeRate={riskFreeRate}
               medianApy={medianApy}
+              scalingFactor={scalingFactor}
               expanded={expandedId === row.id}
               isCompared={compareHas(row.id)}
               compareDisabled={!compareHas(row.id) && !compareCanAdd}

--- a/src/components/yield-leaderboard-row-parts.tsx
+++ b/src/components/yield-leaderboard-row-parts.tsx
@@ -28,6 +28,7 @@ import type { YieldViewModelRow } from "@/lib/yield-view-model";
 // per-metric rendering, tooltips, and accessible labels.
 
 type PysBreakdownValues = {
+  scalingFactor: number;
   adjustedRiskPenalty: number;
   benchmarkAdjustment: number;
   benchmarkSpread: number | null;
@@ -167,6 +168,7 @@ export function YieldPysValue({
               grade={grade}
               safetyScore={safetyScore}
               sourceRiskDrivers={sourceRiskDrivers}
+              scalingFactor={breakdown.scalingFactor}
             />
           </TooltipContent>
         </Tooltip>

--- a/src/components/yield-leaderboard.tsx
+++ b/src/components/yield-leaderboard.tsx
@@ -152,11 +152,20 @@ interface YieldLeaderboardProps {
   logos: Record<string, string>;
   riskFreeRate: number;
   medianApy: number;
+  scalingFactor: number;
   emptyMessage?: string;
   filterSummary?: YieldLeaderboardFilterSummary;
 }
 
-export function YieldLeaderboard({ rows, logos, riskFreeRate, medianApy, emptyMessage, filterSummary }: YieldLeaderboardProps) {
+export function YieldLeaderboard({
+  rows,
+  logos,
+  riskFreeRate,
+  medianApy,
+  scalingFactor,
+  emptyMessage,
+  filterSummary,
+}: YieldLeaderboardProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [sheetRankingId, setSheetRankingId] = useState<string | null>(null);
   const [compareDrawerOpen, setCompareDrawerOpen] = useState(false);
@@ -266,6 +275,7 @@ export function YieldLeaderboard({ rows, logos, riskFreeRate, medianApy, emptyMe
           logos={logos}
           riskFreeRate={riskFreeRate}
           medianApy={medianApy}
+          scalingFactor={scalingFactor}
           pageStartIndex={pageStartIndex}
           sortKey={sortKey}
           sortDirection={sortDirection}


### PR DESCRIPTION
### Motivation
- Per-factor PYS deltas are computed via neutralize-and-rescore and must use the same `scalingFactor` as the API-computed PYS to avoid misattributing score movement. 
- The `PysBreakdown` component accepted an optional `scalingFactor` and fell back to `1`, while production callers omitted the prop and the API publishes a different scale. 
- This caused displayed deltas to compare scores on different scales (penalties could appear beneficial), so the UI must consume the published API scaling factor.

### Description
- Make `PysBreakdown.props.scalingFactor` required and remove the fallback-to-`1` so neutralize-and-rescore uses the provided scale. 
- Thread the API `scalingFactor` through the main yield flows by plumbing `data.scalingFactor` from the rankings API into `YieldLeaderboard` → `YieldInstrumentBoard` and into the stablecoin yield detail header/model. 
- Expose `pysBreakdown.scalingFactor` in the detail-section model and pass it to the inline `PysBreakdown` renderer. 
- Update focused test fixtures to provide explicit `scalingFactor` values and adjust types/shape where needed (small type updates to breakdown model and component props).

### Testing
- Ran full type-check with `npm run typecheck`, which completed successfully. 
- Ran targeted Vitest suites with `npx vitest run src/components/__tests__/pys-breakdown.test.tsx src/components/__tests__/yield-instrument-board.test.tsx src/components/__tests__/yield-detail-section.test.tsx` and all tests passed. 
- Verified the three modified test files executed cleanly (total 52 tests passed in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fee2d883329cb08c19339dca67)