### PR TITLE
fix(yield): preserve fallback benchmark provenance

### DIFF
--- a/src/app/yield/client.tsx
+++ b/src/app/yield/client.tsx
@@ -60,11 +60,12 @@ export function YieldClient() {
     [searchParams],
   );
   const viewModel = useMemo<YieldViewModel>(
-    () => buildYieldViewModel(rankings, urlParams, {
-      benchmarks: data?.benchmarks ?? data?.provenance?.benchmarks ?? null,
-      fallbackBenchmark: data?.provenance?.benchmark ?? null,
-      watchlistIds: watchlist.idSet,
-    }),
+    () =>
+      buildYieldViewModel(rankings, urlParams, {
+        benchmarks: data?.benchmarks ?? data?.provenance?.benchmarks ?? null,
+        fallbackBenchmark: data?.provenance?.benchmark ?? null,
+        watchlistIds: watchlist.idSet,
+      }),
     [data?.benchmarks, data?.provenance?.benchmark, data?.provenance?.benchmarks, rankings, urlParams, watchlist.idSet],
   );
   const visibleRows = viewModel.visibleRows;
@@ -76,10 +77,11 @@ export function YieldClient() {
   }, []);
 
   const sourceBoardModel = useMemo(
-    () => buildYieldSourceBoardModel(visibleRows, {
-      benchmarks: data?.benchmarks ?? data?.provenance?.benchmarks ?? null,
-      fallbackBenchmark: data?.provenance?.benchmark ?? null,
-    }),
+    () =>
+      buildYieldSourceBoardModel(visibleRows, {
+        benchmarks: data?.benchmarks ?? data?.provenance?.benchmarks ?? null,
+        fallbackBenchmark: data?.provenance?.benchmark ?? null,
+      }),
     [data?.benchmarks, data?.provenance?.benchmark, data?.provenance?.benchmarks, visibleRows],
   );
 
@@ -89,8 +91,13 @@ export function YieldClient() {
   const currencyCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const option of viewModel.options.peg) {
-      if (option.value === "all" || option.value === "non-usd"
-        || option.value === "aud-cad" || option.value === "other") continue;
+      if (
+        option.value === "all" ||
+        option.value === "non-usd" ||
+        option.value === "aud-cad" ||
+        option.value === "other"
+      )
+        continue;
       counts[option.value] = option.count;
     }
     return counts;
@@ -107,9 +114,12 @@ export function YieldClient() {
     });
   }, [replaceParams, viewModel.invalidParamKeys, viewModel.normalizedParams]);
 
-  const handleFilterChange = useCallback((key: string, value: string) => {
-    setParam(key, value);
-  }, [setParam]);
+  const handleFilterChange = useCallback(
+    (key: string, value: string) => {
+      setParam(key, value);
+    },
+    [setParam],
+  );
 
   const handleClearFilters = useCallback(() => {
     replaceParams((params) => {
@@ -205,9 +215,7 @@ export function YieldClient() {
             >
               <p className="font-medium">{warning.message}</p>
               {warning.reasons && warning.reasons.length > 0 ? (
-                <p className="mt-1 text-xs text-amber-900/80 dark:text-amber-100/80">
-                  {warning.reasons.join(", ")}
-                </p>
+                <p className="mt-1 text-xs text-amber-900/80 dark:text-amber-100/80">{warning.reasons.join(", ")}</p>
               ) : null}
             </div>
           ))}
@@ -230,9 +238,15 @@ export function YieldClient() {
                 >
                   <h3 className="mb-2 text-base font-semibold tracking-tight text-foreground">Top yield this week</h3>
                   <div className="flex items-center gap-2">
-                    <StablecoinLogo src={logos?.[exhibitTiles.topYield.id]} name={exhibitTiles.topYield.name} size={20} />
+                    <StablecoinLogo
+                      src={logos?.[exhibitTiles.topYield.id]}
+                      name={exhibitTiles.topYield.name}
+                      size={20}
+                    />
                     <span className="font-semibold text-foreground">{exhibitTiles.topYield.symbol}</span>
-                    <span className="hidden truncate text-xs text-muted-foreground sm:inline">{exhibitTiles.topYield.name}</span>
+                    <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+                      {exhibitTiles.topYield.name}
+                    </span>
                   </div>
                   <p className="mt-1 font-mono text-xl font-semibold tabular-nums text-foreground">
                     {formatPercent(exhibitTiles.topYield.apy30d)}
@@ -254,9 +268,15 @@ export function YieldClient() {
                 >
                   <h3 className="mb-2 text-base font-semibold tracking-tight text-foreground">Most stable A+ yield</h3>
                   <div className="flex items-center gap-2">
-                    <StablecoinLogo src={logos?.[exhibitTiles.mostStable.id]} name={exhibitTiles.mostStable.name} size={20} />
+                    <StablecoinLogo
+                      src={logos?.[exhibitTiles.mostStable.id]}
+                      name={exhibitTiles.mostStable.name}
+                      size={20}
+                    />
                     <span className="font-semibold text-foreground">{exhibitTiles.mostStable.symbol}</span>
-                    <span className="text-xs font-medium text-emerald-700 dark:text-emerald-400">{exhibitTiles.mostStable.safetyGrade}</span>
+                    <span className="text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                      {exhibitTiles.mostStable.safetyGrade}
+                    </span>
                   </div>
                   <p className="mt-1 font-mono text-xl font-semibold tabular-nums text-foreground">
                     {formatPercent(exhibitTiles.mostStable.apy30d)}
@@ -276,9 +296,15 @@ export function YieldClient() {
                 >
                   <h3 className="mb-2 text-base font-semibold tracking-tight text-foreground">Largest market</h3>
                   <div className="flex items-center gap-2">
-                    <StablecoinLogo src={logos?.[exhibitTiles.largestMarket.id]} name={exhibitTiles.largestMarket.name} size={20} />
+                    <StablecoinLogo
+                      src={logos?.[exhibitTiles.largestMarket.id]}
+                      name={exhibitTiles.largestMarket.name}
+                      size={20}
+                    />
                     <span className="font-semibold text-foreground">{exhibitTiles.largestMarket.symbol}</span>
-                    <span className="hidden truncate text-xs text-muted-foreground sm:inline">{exhibitTiles.largestMarket.name}</span>
+                    <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+                      {exhibitTiles.largestMarket.name}
+                    </span>
                   </div>
                   <p className="mt-1 font-mono text-xl font-semibold tabular-nums text-foreground">
                     {formatCurrency(exhibitTiles.largestMarket.sourceTvlUsd!)} TVL
@@ -294,10 +320,7 @@ export function YieldClient() {
 
         {visibleRows.length > 0 ? (
           <section aria-label="Yield vs Safety landscape" className="order-2 space-y-3">
-            <YieldRiskBudgetSlider
-              stops={viewModel.riskBudget.stops}
-              onSelect={handleApplyRiskBudget}
-            />
+            <YieldRiskBudgetSlider stops={viewModel.riskBudget.stops} onSelect={handleApplyRiskBudget} />
             <YieldScatterPlot
               rankings={visibleRows}
               benchmarkRate={stats.referenceBenchmark?.rate ?? data.riskFreeRate}
@@ -350,9 +373,7 @@ export function YieldClient() {
                     <button
                       key={suggestion.filterKey}
                       type="button"
-                      onClick={() =>
-                        handleFilterChange(suggestion.filterKey, suggestion.targetValue ?? "all")
-                      }
+                      onClick={() => handleFilterChange(suggestion.filterKey, suggestion.targetValue ?? "all")}
                       className="pharos-focus-ring inline-flex min-h-9 items-center gap-1.5 rounded-full border border-border/70 bg-background/70 px-3 text-xs font-medium text-foreground transition-colors hover:bg-muted"
                     >
                       <span>{suggestion.label}</span>
@@ -369,6 +390,7 @@ export function YieldClient() {
             <>
               <ReferenceRatesStrip
                 benchmarks={data.benchmarks ?? data.provenance?.benchmarks ?? null}
+                fallbackBenchmark={data.provenance?.benchmark ?? null}
                 poolInputMeta={data.provenance?.dlPools ?? null}
                 safetySnapshot={data.provenance?.safetySnapshot ?? null}
                 currencyCounts={currencyCounts}

--- a/src/app/yield/reference-rates-strip.test.tsx
+++ b/src/app/yield/reference-rates-strip.test.tsx
@@ -3,11 +3,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { ReferenceRatesStrip } from "@/app/yield/reference-rates-strip";
-import type {
-  YieldBenchmarkRegistry,
-  YieldSafetySnapshotMeta,
-  YieldSourceInputMeta,
-} from "@shared/types";
+import type { YieldBenchmarkRegistry, YieldSafetySnapshotMeta, YieldSourceInputMeta } from "@shared/types";
 
 function makeBenchmark(currency: string, key: string, label: string, rate: number, recordDate: string) {
   return {
@@ -54,16 +50,14 @@ describe("ReferenceRatesStrip", () => {
 
   it("renders the kicker, headline, lede, comparative table headers, and freshness footer", () => {
     render(
-      <ReferenceRatesStrip
-        benchmarks={benchmarks}
-        poolInputMeta={poolInputMeta}
-        safetySnapshot={safetySnapshot}
-      />,
+      <ReferenceRatesStrip benchmarks={benchmarks} poolInputMeta={poolInputMeta} safetySnapshot={safetySnapshot} />,
     );
 
     expect(screen.getByText("Reference rates")).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Risk-free benchmark per currency/i })).toBeTruthy();
-    expect(screen.getByText(/Each yield in the leaderboard is graded against the local risk-free benchmark/i)).toBeTruthy();
+    expect(
+      screen.getByText(/Each yield in the leaderboard is graded against the local risk-free benchmark/i),
+    ).toBeTruthy();
 
     const tableShell = screen.getByTestId("yield-reference-rates-table");
     expect(tableShell.getAttribute("data-table-id")).toBe("yield-reference-rates");
@@ -94,8 +88,28 @@ describe("ReferenceRatesStrip", () => {
     expect(within(usdRow).getByText("3M T-Bill")).toBeTruthy();
     expect(within(usdRow).getByText("2026-05-18")).toBeTruthy();
 
-    const eurRow = within(table).getAllByRole("row").find((r) => within(r).queryByText("EUR"));
+    const eurRow = within(table)
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("EUR"));
     expect(within(eurRow!).getByText("€")).toBeTruthy();
+  });
+
+  it("renders the fallback provenance benchmark when the optional registry is absent", () => {
+    render(
+      <ReferenceRatesStrip
+        benchmarks={null}
+        fallbackBenchmark={makeBenchmark("USD", "USD", "USD 3M T-Bill", 4.25, "2026-06-18")}
+        poolInputMeta={poolInputMeta}
+        safetySnapshot={safetySnapshot}
+      />,
+    );
+
+    const table = screen.getByRole("table", { name: "Per-currency reference rates" });
+    expect(within(table).getByText("USD")).toBeTruthy();
+    expect(within(table).getByText("4.25%")).toBeTruthy();
+    expect(within(table).getByText("3M T-Bill")).toBeTruthy();
+    expect(screen.getByText(/Pool input age 4m/i)).toBeTruthy();
+    expect(screen.getByText("91%")).toBeTruthy();
   });
 
   it("shows an em-dash for USD's spread and computes signed basis-point spreads for the others", () => {
@@ -107,30 +121,33 @@ describe("ReferenceRatesStrip", () => {
     expect(usdCells[3]!.textContent).toBe("—");
 
     // EUR rate 1.94 vs USD 3.68 → −174 bps
-    const eurRow = within(table).getAllByRole("row").find((r) => within(r).queryByText("EUR"));
+    const eurRow = within(table)
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("EUR"));
     expect(eurRow).toBeDefined();
     expect(within(eurRow!).getByText("−174 bps")).toBeTruthy();
 
     // AUD rate 4.35 vs USD 3.68 -> +67 bps
-    const audRow = within(table).getAllByRole("row").find((r) => within(r).queryByText("AUD"));
+    const audRow = within(table)
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("AUD"));
     expect(audRow).toBeDefined();
     expect(within(audRow!).getByText("+67 bps")).toBeTruthy();
   });
 
   it("renders the Tracked column with per-currency counts when currencyCounts is provided", () => {
-    render(
-      <ReferenceRatesStrip
-        benchmarks={benchmarks}
-        currencyCounts={{ USD: 25, EUR: 8, CHF: 1, AUD: 2 }}
-      />,
-    );
+    render(<ReferenceRatesStrip benchmarks={benchmarks} currencyCounts={{ USD: 25, EUR: 8, CHF: 1, AUD: 2 }} />);
 
     const table = screen.getByRole("table");
     expect(within(table).getByRole("columnheader", { name: "Tracked" })).toBeTruthy();
 
-    const usdRow = within(table).getAllByRole("row").find((r) => within(r).queryByText("USD"));
+    const usdRow = within(table)
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("USD"));
     expect(within(usdRow!).getByText("25")).toBeTruthy();
-    const eurRow = within(table).getAllByRole("row").find((r) => within(r).queryByText("EUR"));
+    const eurRow = within(table)
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("EUR"));
     expect(within(eurRow!).getByText("8")).toBeTruthy();
   });
 
@@ -154,9 +171,7 @@ describe("ReferenceRatesStrip", () => {
   });
 
   it("returns nothing when there are no inputs to display", () => {
-    const { container } = render(
-      <ReferenceRatesStrip benchmarks={null} poolInputMeta={null} safetySnapshot={null} />,
-    );
+    const { container } = render(<ReferenceRatesStrip benchmarks={null} poolInputMeta={null} safetySnapshot={null} />);
     expect(container.textContent).toBe("");
   });
 

--- a/src/app/yield/reference-rates-strip.tsx
+++ b/src/app/yield/reference-rates-strip.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  TableBody,
-  TableCell,
-  TableFrame,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
+import { TableBody, TableCell, TableFrame, TableHead, TableHeader, TableRow } from "@/components/table";
 import { getYieldBenchmarkDisplayLabel } from "@/lib/yield-benchmark";
 import { cn } from "@/lib/utils";
 import { formatPercent } from "@shared/lib/format";
@@ -22,6 +15,7 @@ import type {
 
 interface ReferenceRatesStripProps {
   benchmarks?: YieldBenchmarkRegistry | null;
+  fallbackBenchmark?: YieldBenchmarkMeta | null;
   poolInputMeta?: YieldSourceInputMeta | null;
   safetySnapshot?: YieldSafetySnapshotMeta | null;
   /** Count of tracked /yield rows per currency, keyed by 3-char ISO code. */
@@ -63,9 +57,12 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   PHP: "₱",
 };
 
-function getBenchmarkRows(benchmarks: YieldBenchmarkRegistry | null | undefined): BenchmarkRow[] {
-  if (!benchmarks) return [];
-  return Object.values(benchmarks)
+function getBenchmarkRows(
+  benchmarks: YieldBenchmarkRegistry | null | undefined,
+  fallbackBenchmark: YieldBenchmarkMeta | null | undefined,
+): BenchmarkRow[] {
+  const entries = benchmarks ? Object.values(benchmarks) : fallbackBenchmark ? [fallbackBenchmark] : [];
+  return entries
     .filter((b): b is YieldBenchmarkMeta => b != null)
     .map((b) => {
       const fullLabel = getYieldBenchmarkDisplayLabel(b);
@@ -73,9 +70,7 @@ function getBenchmarkRows(benchmarks: YieldBenchmarkRegistry | null | undefined)
       // Strip the leading currency token from the display label so the
       // table's currency column carries that identification, not the
       // benchmark-name column.
-      const benchmarkLabel = fullLabel.startsWith(`${currency} `)
-        ? fullLabel.slice(currency.length + 1)
-        : fullLabel;
+      const benchmarkLabel = fullLabel.startsWith(`${currency} `) ? fullLabel.slice(currency.length + 1) : fullLabel;
       return {
         key: b.key ?? fullLabel ?? currency,
         currency,
@@ -109,16 +104,16 @@ function formatPoolInputMode(meta: YieldSourceInputMeta): string {
 
 export function ReferenceRatesStrip({
   benchmarks,
+  fallbackBenchmark,
   poolInputMeta,
   safetySnapshot,
   currencyCounts,
 }: ReferenceRatesStripProps) {
-  const rows = getBenchmarkRows(benchmarks);
+  const rows = getBenchmarkRows(benchmarks, fallbackBenchmark);
   if (rows.length === 0 && !poolInputMeta && !safetySnapshot) return null;
 
   const safetyPct = safetySnapshot ? Math.round(safetySnapshot.coverageRatio * 100) : null;
-  const poolIsStale =
-    poolInputMeta?.ageSeconds != null && poolInputMeta.ageSeconds > POOL_STALE_THRESHOLD_SECONDS;
+  const poolIsStale = poolInputMeta?.ageSeconds != null && poolInputMeta.ageSeconds > POOL_STALE_THRESHOLD_SECONDS;
   const hasFreshnessRow = !!poolInputMeta || (safetySnapshot && safetyPct !== null);
   // USD is the implicit baseline: every other currency's risk-free rate is
   // compared against it. If USD isn't in the registry, the spread column
@@ -128,22 +123,16 @@ export function ReferenceRatesStrip({
 
   return (
     <TooltipProvider>
-      <section
-        aria-labelledby="yield-reference-rates-heading"
-        className="pharos-card-shell overflow-hidden"
-      >
+      <section aria-labelledby="yield-reference-rates-heading" className="pharos-card-shell overflow-hidden">
         <div className="space-y-4 px-4 py-4 sm:px-5">
           <div className="space-y-1">
             <p className="pharos-kicker">Reference rates</p>
-            <h2
-              id="yield-reference-rates-heading"
-              className="text-lg font-semibold tracking-tight text-foreground"
-            >
+            <h2 id="yield-reference-rates-heading" className="text-lg font-semibold tracking-tight text-foreground">
               Risk-free benchmark per currency
             </h2>
             <p className="text-sm text-muted-foreground">
-              Each yield in the leaderboard is graded against the local risk-free benchmark.
-              Excess yield is the spread above this rate.
+              Each yield in the leaderboard is graded against the local risk-free benchmark. Excess yield is the spread
+              above this rate.
             </p>
           </div>
 
@@ -218,9 +207,7 @@ export function ReferenceRatesStrip({
                       >
                         {isUsd || spreadBps === null ? "—" : formatSpread(spreadBps)}
                       </TableCell>
-                      <TableCell className="px-3 py-2 text-xs text-muted-foreground">
-                        {row.benchmarkLabel}
-                      </TableCell>
+                      <TableCell className="px-3 py-2 text-xs text-muted-foreground">{row.benchmarkLabel}</TableCell>
                       <TableCell className="py-2 pl-3 text-right font-mono text-xs tabular-nums text-muted-foreground/80">
                         {row.recordDate ?? "—"}
                       </TableCell>
@@ -234,12 +221,12 @@ export function ReferenceRatesStrip({
 
         {hasFreshnessRow ? (
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground sm:px-5">
-            <span className="font-medium uppercase tracking-[0.12em] text-muted-foreground/80">
-              Data freshness
-            </span>
+            <span className="font-medium uppercase tracking-[0.12em] text-muted-foreground/80">Data freshness</span>
             {poolInputMeta ? (
               <>
-                <span aria-hidden="true" className="text-muted-foreground/40">·</span>
+                <span aria-hidden="true" className="text-muted-foreground/40">
+                  ·
+                </span>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
@@ -261,7 +248,9 @@ export function ReferenceRatesStrip({
             ) : null}
             {safetySnapshot && safetyPct !== null ? (
               <>
-                <span aria-hidden="true" className="text-muted-foreground/40">·</span>
+                <span aria-hidden="true" className="text-muted-foreground/40">
+                  ·
+                </span>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
@@ -274,7 +263,7 @@ export function ReferenceRatesStrip({
                   <TooltipContent className="max-w-[260px] text-xs">
                     {safetySnapshot.kind === "ok"
                       ? "Confidence-weighted source arbitration coverage across tracked rows."
-                      : safetySnapshot.reason ?? "Safety snapshot degraded."}
+                      : (safetySnapshot.reason ?? "Safety snapshot degraded.")}
                   </TooltipContent>
                 </Tooltip>
               </>


### PR DESCRIPTION
### Motivation
- A refactor passed only optional benchmark registries into the yield source UI, dropping display of valid payloads that include only the required `provenance.benchmark` field and no optional registry. 
- That change caused a transparency regression where the benchmark label/rate from `provenance.benchmark` would not appear in the Reference Rates / Trust band UI. 

### Description
- Pass the single provenance benchmark into the reference-rates UI by adding a `fallbackBenchmark` prop where the registry is optional and threading `data.provenance?.benchmark` from the `/yield` client into `ReferenceRatesStrip`. 
- Update `ReferenceRatesStrip` to accept `fallbackBenchmark` and render the fallback benchmark when the optional `YieldBenchmarkRegistry` is absent by treating it as a single-entry source. 
- Add a regression test `src/app/yield/reference-rates-strip.test.tsx` that verifies the fallback benchmark renders when `benchmarks` is `null` and `provenance.benchmark` is present. 

### Testing
- Ran `npx vitest run src/app/yield/reference-rates-strip.test.tsx`, and the scoped tests passed. 
- Ran `npm run typecheck` (project-configured typecheck) and it passed. 
- Ran `npx prettier --check` on the touched files and it passed. 
- Ran a raw `npx tsc --noEmit --pretty false` over the whole repo which failed due to unrelated, pre-existing repository-wide type/test issues outside this change, so validation used the scoped project checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe088c833298e8b11c9cc1cbba)