### PR TITLE
fix(stablecoins): normalize injected frozen snapshots

### DIFF
--- a/worker/src/cron/sync-stablecoins/intake.ts
+++ b/worker/src/cron/sync-stablecoins/intake.ts
@@ -333,6 +333,7 @@ export async function loadStablecoinsIntake(
   assets = mergeFrozenSnapshots(assets, FROZEN_SNAPSHOTS);
   const injected = assets.length - beforeFrozenInjection;
   if (injected > 0) {
+    normalizeChainCirculating(assets);
     console.log(`[sync-stablecoins] Injected ${injected} frozen-snapshot row(s)`);
   }
 


### PR DESCRIPTION
### Motivation
- A frozen snapshot (e.g. EUROe) can contain DefiLlama "peg-bucket" objects in `chainCirculating.*` which must be converted to numeric totals before the stablecoins cache is validated, and the pipeline previously ran `normalizeChainCirculating()` before frozen-snapshot injection so injected rows could remain unnormalized and fail schema validation, blocking cache publication.

### Description
- After `mergeFrozenSnapshots()` injects any frozen rows, call `normalizeChainCirculating(assets)` so captured peg-bucket objects are converted to numeric `chainCirculating` values; change applied in `worker/src/cron/sync-stablecoins/intake.ts`.

### Testing
- Ran `npm run check:frozen-invariants` and it passed.
- Ran `npx vitest run worker/src/cron/__tests__/sync-stablecoins-stages.test.ts` and `npx vitest run worker/src/cron/__tests__/sync-stablecoins.test.ts` and both test suites passed.
- Ran `cd worker && npx tsc --noEmit` (typecheck) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe0fd083328426888273649a75)