### PR TITLE
fix(screener): include range filter boundaries

### DIFF
--- a/src/app/screener/screener-filters.test.ts
+++ b/src/app/screener/screener-filters.test.ts
@@ -134,6 +134,32 @@ describe("applyFilters", () => {
     expect(result.map((r) => r.id).sort()).toEqual(["eurs-stasis", "newcoin"]);
   });
 
+  it("includes rows exactly on DEWS range boundaries", () => {
+    const filters: ScreenerFilters = { ...SCREENER_FILTER_DEFAULTS, dewsMin: 40, dewsMax: 100 };
+    const result = applyFilters([
+      makeRow({ id: "below-min", dewsScore: 39 }),
+      makeRow({ id: "at-min", dewsScore: 40 }),
+      makeRow({ id: "inside", dewsScore: 75 }),
+      makeRow({ id: "at-default-max", dewsScore: 100 }),
+      makeRow({ id: "unrated", dewsScore: null }),
+    ], filters);
+
+    expect(result.map((r) => r.id)).toEqual(["at-min", "inside", "at-default-max"]);
+  });
+
+  it("includes rows exactly on supply range boundaries", () => {
+    const filters: ScreenerFilters = { ...SCREENER_FILTER_DEFAULTS, supplyMin: 100, supplyMax: 200 };
+    const result = applyFilters([
+      makeRow({ id: "below-min", supplyUsd: 99 }),
+      makeRow({ id: "at-min", supplyUsd: 100 }),
+      makeRow({ id: "inside", supplyUsd: 150 }),
+      makeRow({ id: "at-max", supplyUsd: 200 }),
+      makeRow({ id: "above-max", supplyUsd: 201 }),
+    ], filters);
+
+    expect(result.map((r) => r.id)).toEqual(["at-min", "inside", "at-max"]);
+  });
+
   it("filters by mechanism (multi-select)", () => {
     const filters: ScreenerFilters = { ...SCREENER_FILTER_DEFAULTS, mechanisms: ["cdp"] };
     const result = applyFilters(rows, filters);

--- a/src/app/screener/screener-filters.ts
+++ b/src/app/screener/screener-filters.ts
@@ -289,7 +289,7 @@ function passesRange(
 ): boolean {
   if (!active) return true;
   if (value == null) return false;
-  return value > minValue && value < maxValue;
+  return value >= minValue && value <= maxValue;
 }
 
 function passesMinimum(value: number | null | undefined, minValue: number): boolean {


### PR DESCRIPTION
### Motivation
- A recent refactor made the generic range helper use strict greater-than/less-than checks, which caused active numeric filters (DEWS and supply) to exclude rows whose values exactly matched the configured minimum or maximum, breaking expected inclusive behavior and user-facing correctness.

### Description
- Update the shared range helper `passesRange()` in `src/app/screener/screener-filters.ts` to use inclusive comparisons (`>=` / `<=`) so boundary values pass when a range is active.
- Add two focused regression tests in `src/app/screener/screener-filters.test.ts` that assert DEWS and supply filters include rows exactly at `min` and `max` bounds.
- Keep existing semantics for unrated values and default-range behavior unchanged so only the boundary-equality bug is fixed.

### Testing
- Ran the screener test suite with `npx vitest run src/app/screener/screener-filters.test.ts --reporter=verbose` and the run completed successfully with all tests passing (`55 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff16c88332b6ddca173aa882c8)