### PR TITLE
fix(detail-charts): restore depeg peak annotations

### DIFF
--- a/src/hooks/__tests__/use-chart-annotations.test.tsx
+++ b/src/hooks/__tests__/use-chart-annotations.test.tsx
@@ -310,6 +310,43 @@ describe("useChartAnnotations", () => {
     expect(result.current.data.map((a) => a.label)).toEqual(["Depeg opened (kept)"]);
   });
 
+  it("keeps material depeg peak-worsened tape rows", () => {
+    isChartAnnotationsEnabledMock.mockReturnValue(true);
+    useApiQueryWithMetaMock.mockReturnValue({
+      data: {
+        events: [
+          tape({
+            id: "tape-peak-worsened",
+            type: "depeg.peak_worsened",
+            severity: "critical",
+            ts: Date.UTC(2023, 3, 11),
+            title: "Active depeg widened",
+            sourceUrl: "https://example.com/depeg-peak",
+          }),
+        ],
+        nextCursor: null,
+        total: 1,
+        totalExact: true,
+      },
+      isLoading: false,
+    });
+    getCuratedAnnotationsMock.mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      useChartAnnotations("test-coin", Date.UTC(2023, 0, 1), Date.UTC(2023, 5, 1)),
+    );
+
+    expect(result.current.data).toEqual([
+      {
+        ts: Date.UTC(2023, 3, 11),
+        kind: "depeg",
+        label: "Active depeg widened",
+        severity: "high",
+        href: "https://example.com/depeg-peak",
+      },
+    ]);
+  });
+
   it("sorts merged output by timestamp ascending", () => {
     isChartAnnotationsEnabledMock.mockReturnValue(true);
     useApiQueryWithMetaMock.mockReturnValue({

--- a/src/hooks/use-chart-annotations.ts
+++ b/src/hooks/use-chart-annotations.ts
@@ -59,6 +59,7 @@ const TAPE_EVENTS_LIMIT = 200;
  *
  * Only editorially significant tape kinds reach the chart overlay:
  *   - `depeg.opened` — rare, grade-impacting
+ *   - `depeg.peak_worsened` — active depeg widened materially
  *   - `methodology.*` — issued by us, low-volume
  *
  * `mint_burn.*` and `freeze.*` are intentionally NOT mapped. They fire often
@@ -74,7 +75,7 @@ const TAPE_EVENTS_LIMIT = 200;
  * editorial signal.
  */
 function mapWorkerKind(rowType: string): ChartAnnotationKind | null {
-  if (rowType === "depeg.opened") return "depeg";
+  if (rowType === "depeg.opened" || rowType === "depeg.peak_worsened") return "depeg";
   if (rowType.startsWith("methodology.")) return "methodology-change";
   return null;
 }


### PR DESCRIPTION
### Motivation
- A previous change limited frontend tape-to-chart mapping to `depeg.opened`, which inadvertently dropped backend `depeg.peak_worsened` events that indicate material worsening of an active depeg and can carry `warning`/`severe`/`critical` severity.
- The intent is to reduce visual noise (suppress `depeg.resolved` and low-severity rows) while preserving material signal such as peak-worsened events so readers see important worsening depegs on detail charts.

### Description
- Map `depeg.peak_worsened` to the existing chart kind `depeg` in `mapWorkerKind` so material peak-worsened tape rows are surfaced (`src/hooks/use-chart-annotations.ts`).
- Keep `depeg.resolved` suppressed and retain the existing severity filter that drops `info`/`notice` rows so noise-reduction behavior is preserved.
- Add a focused regression test that asserts a critical `depeg.peak_worsened` tape event becomes a `depeg` chart annotation with preserved `href` and high severity (`src/hooks/__tests__/use-chart-annotations.test.tsx`).

### Testing
- Ran the hook unit suite with `npx vitest run src/hooks/__tests__/use-chart-annotations.test.tsx`, and all tests passed (10 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516feb5b48332a0507c8d35051e5d)