### PR TITLE
Guard getCuratedAnnotations against prototype-reserved keys

### DIFF
--- a/shared/data/annotations/__tests__/curated-annotations.test.ts
+++ b/shared/data/annotations/__tests__/curated-annotations.test.ts
@@ -63,6 +63,12 @@ describe("curated-annotations", () => {
     expect(getCuratedAnnotations("does-not-exist")).toEqual([]);
   });
 
+  it("returns an empty array for prototype-reserved coin ids", () => {
+    expect(getCuratedAnnotations("__proto__")).toEqual([]);
+    expect(getCuratedAnnotations("constructor")).toEqual([]);
+    expect(getCuratedAnnotations("toString")).toEqual([]);
+  });
+
   it("returns the same reference each call (stable EMPTY)", () => {
     const a = getCuratedAnnotations("does-not-exist");
     const b = getCuratedAnnotations("also-not-exist");

--- a/shared/data/annotations/curated-annotations.ts
+++ b/shared/data/annotations/curated-annotations.ts
@@ -1894,5 +1894,9 @@ export const CURATED_ANNOTATIONS: Record<string, readonly ChartAnnotation[]> = {
 const EMPTY: readonly ChartAnnotation[] = [];
 
 export function getCuratedAnnotations(stablecoinId: string): readonly ChartAnnotation[] {
+  if (!Object.prototype.hasOwnProperty.call(CURATED_ANNOTATIONS, stablecoinId)) {
+    return EMPTY;
+  }
+
   return CURATED_ANNOTATIONS[stablecoinId] ?? EMPTY;
 }


### PR DESCRIPTION
### Motivation
- CURATED_ANNOTATIONS is a plain object and bracket-lookup can return inherited Object.prototype members for keys like `__proto__`, `constructor`, or `toString`, which can make consumers that assume an iterable (e.g., `useChartAnnotations`) throw a `TypeError` instead of receiving an empty list.

### Description
- Add an own-property guard in `getCuratedAnnotations()` using `Object.prototype.hasOwnProperty.call(CURATED_ANNOTATIONS, stablecoinId)` to return the shared `EMPTY` array for absent or prototype-reserved keys.
- Add a regression unit test asserting `getCuratedAnnotations("__proto__")`, `getCuratedAnnotations("constructor")`, and `getCuratedAnnotations("toString")` return `[]`.
- Modified files: `shared/data/annotations/curated-annotations.ts` and `shared/data/annotations/__tests__/curated-annotations.test.ts`.

### Testing
- Ran `npx vitest run shared/data/annotations/__tests__/curated-annotations.test.ts` and the targeted suite passed with 1 file and 8 tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fee7448332a72beb65560a7a39)