### PR TITLE
fix(detail-page): keep dependency context available

### DIFF
--- a/src/components/stablecoin-detail/__tests__/contagion-snapshot.test.tsx
+++ b/src/components/stablecoin-detail/__tests__/contagion-snapshot.test.tsx
@@ -2,17 +2,9 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  ReportCard,
-  ReportCardGrade,
-  ReportCardsResponse,
-} from "@shared/types";
+import type { ReportCard, ReportCardGrade, ReportCardsResponse } from "@shared/types";
 
-const {
-  useReportCardsMock,
-  useStablecoinsMock,
-  useLogosMock,
-} = vi.hoisted(() => ({
+const { useReportCardsMock, useStablecoinsMock, useLogosMock } = vi.hoisted(() => ({
   useReportCardsMock: vi.fn(),
   useStablecoinsMock: vi.fn(),
   useLogosMock: vi.fn(),
@@ -138,10 +130,7 @@ describe("ContagionSnapshot", () => {
   it("renders the variantRelationshipCard prop and the contagion graph chrome when edges exist", () => {
     useReportCardsMock.mockReturnValue({
       data: makeReportCardsResponse(
-        [
-          makeCard("usde-ethena", "USDe"),
-          makeCard("usdc-circle", "USDC"),
-        ],
+        [makeCard("usde-ethena", "USDe"), makeCard("usdc-circle", "USDC")],
         [{ from: "usde-ethena", to: "usdc-circle", weight: 0.8, type: "collateral" }],
       ),
     });
@@ -163,10 +152,7 @@ describe("ContagionSnapshot", () => {
   it("honors hasCollateralUsage by rendering the CollateralUsageSection", () => {
     useReportCardsMock.mockReturnValue({
       data: makeReportCardsResponse(
-        [
-          makeCard("usde-ethena", "USDe"),
-          makeCard("usdc-circle", "USDC"),
-        ],
+        [makeCard("usde-ethena", "USDe"), makeCard("usdc-circle", "USDC")],
         [{ from: "usde-ethena", to: "usdc-circle", weight: 0.8, type: "collateral" }],
       ),
     });
@@ -175,7 +161,9 @@ describe("ContagionSnapshot", () => {
       <ContagionSnapshot
         stablecoinId="usdc-circle"
         hasCollateralUsage
-        collateralUsageEntries={[{ coin: { id: "usde-ethena", name: "Ethena USDe", symbol: "USDe" }, weight: 0.8, type: "collateral" }]}
+        collateralUsageEntries={[
+          { coin: { id: "usde-ethena", name: "Ethena USDe", symbol: "USDe" }, weight: 0.8, type: "collateral" },
+        ]}
       />,
     );
 
@@ -196,5 +184,42 @@ describe("ContagionSnapshot", () => {
     useReportCardsMock.mockReturnValue({ data: undefined });
     const { container } = render(<ContagionSnapshot stablecoinId="usde-ethena" />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders right-column dependency context when report cards data is missing", () => {
+    useReportCardsMock.mockReturnValue({ data: undefined });
+
+    render(
+      <ContagionSnapshot
+        stablecoinId="usde-ethena"
+        variantRelationshipCard={<div data-testid="variant-card">VARIANT</div>}
+        hasCollateralUsage
+        collateralUsageEntries={[
+          { coin: { id: "usdtb-ethena", name: "Ethena USDtb", symbol: "USDtb" }, weight: 0.6, type: "collateral" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Dependency Context")).toBeTruthy();
+    expect(screen.getByTestId("variant-card").textContent).toBe("VARIANT");
+    expect(screen.getByTestId("collateral-usage-mock").textContent).toBe("collateral-usage:usdtb-ethena");
+    expect(screen.queryByTestId("contagion-graph-mock")).toBeNull();
+  });
+
+  it("renders right-column dependency context when the report-card focus entry is missing", () => {
+    useReportCardsMock.mockReturnValue({
+      data: makeReportCardsResponse([makeCard("usdc-circle", "USDC")], []),
+    });
+
+    render(
+      <ContagionSnapshot
+        stablecoinId="usde-ethena"
+        variantRelationshipCard={<div data-testid="variant-card">VARIANT</div>}
+      />,
+    );
+
+    expect(screen.getByText("Dependency Context")).toBeTruthy();
+    expect(screen.getByTestId("variant-card").textContent).toBe("VARIANT");
+    expect(screen.queryByTestId("contagion-graph-mock")).toBeNull();
   });
 });

--- a/src/components/stablecoin-detail/contagion-snapshot.tsx
+++ b/src/components/stablecoin-detail/contagion-snapshot.tsx
@@ -18,17 +18,14 @@ interface ContagionSnapshotProps {
 
 const DETAIL_NODE_LIMIT = 500;
 
-const ContagionGraph = dynamic(
-  () => import("@/components/contagion-graph").then((mod) => mod.ContagionGraph),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex min-h-[22rem] items-center justify-center rounded-xl border border-border/60 bg-card/40 text-sm text-muted-foreground">
-        Loading dependency graph...
-      </div>
-    ),
-  },
-);
+const ContagionGraph = dynamic(() => import("@/components/contagion-graph").then((mod) => mod.ContagionGraph), {
+  ssr: false,
+  loading: () => (
+    <div className="flex min-h-[22rem] items-center justify-center rounded-xl border border-border/60 bg-card/40 text-sm text-muted-foreground">
+      Loading dependency graph...
+    </div>
+  ),
+});
 
 export function ContagionSnapshot({
   stablecoinId,
@@ -39,26 +36,25 @@ export function ContagionSnapshot({
   const { data: rc } = useReportCards();
   const { data: list } = useStablecoins();
   const { data: logos } = useLogos();
-  if (!rc?.cards || !list?.peggedAssets) return null;
-  const focus = rc.cards.find((c) => c.id === stablecoinId);
-  if (!focus) return null;
-  const edges = rc.dependencyGraph?.edges ?? [];
-  const liveCardIds = new Set(rc.cards.filter((c) => !c.isDefunct).map((c) => c.id));
-  const hasContagion = edges.some(
-    (e) =>
-      liveCardIds.has(e.from)
-      && liveCardIds.has(e.to)
-      && (e.from === stablecoinId || e.to === stablecoinId),
-  );
   const hasVariantCard = Boolean(variantRelationshipCard);
   const hasRightColumn = hasVariantCard || Boolean(hasCollateralUsage);
+  const focus = rc?.cards?.find((c) => c.id === stablecoinId);
+  const edges = focus ? (rc?.dependencyGraph?.edges ?? []) : [];
+  const liveCardIds = new Set(rc?.cards?.filter((c) => !c.isDefunct).map((c) => c.id) ?? []);
+  const hasContagion = Boolean(
+    focus &&
+    list?.peggedAssets &&
+    edges.some(
+      (e) => liveCardIds.has(e.from) && liveCardIds.has(e.to) && (e.from === stablecoinId || e.to === stablecoinId),
+    ),
+  );
 
   if (!hasContagion && !hasRightColumn) {
     return null;
   }
 
   const mcapMap = new Map<string, number>();
-  for (const coin of list.peggedAssets) {
+  for (const coin of list?.peggedAssets ?? []) {
     mcapMap.set(coin.id, getCirculatingRaw(coin));
   }
 
@@ -74,11 +70,7 @@ export function ContagionSnapshot({
   );
 
   const isSplit = hasContagion && hasRightColumn;
-  const layoutClass = isSplit
-    ? "grid gap-6 lg:grid-cols-2"
-    : hasContagion
-      ? undefined
-      : "mx-auto max-w-2xl";
+  const layoutClass = isSplit ? "grid gap-6 lg:grid-cols-2" : hasContagion ? undefined : "mx-auto max-w-2xl";
 
   return (
     <section className="pharos-card-shell px-4 py-4 sm:px-5 sm:py-5">
@@ -86,7 +78,7 @@ export function ContagionSnapshot({
       <div className={layoutClass}>
         {hasContagion ? (
           <ContagionGraph
-            cards={rc.cards}
+            cards={rc?.cards ?? []}
             dependencyEdges={edges}
             mcapMap={mcapMap}
             logos={logos}


### PR DESCRIPTION
### Motivation

- A prior refactor nested the variant relationship card and collateral usage UI inside `ContagionSnapshot` but returned early when report-card or list graph data was unavailable, which suppressed right-column dependency context during report-card outages or when the focus card is missing.

### Description

- Compute `hasRightColumn` and the variant/collateral rendering decision before gating on report-card graph prerequisites so right-column content can render independently from the contagion graph in `src/components/stablecoin-detail/contagion-snapshot.tsx`.
- Limit the contagion `ContagionGraph` to render only when the report-card/list prerequisites and focus card are present, and make list accesses null-safe (`list?.peggedAssets ?? []`).
- Minor formatting change to the dynamic `ContagionGraph` import to keep loading UI behavior unchanged.
- Add regression tests to `src/components/stablecoin-detail/__tests__/contagion-snapshot.test.tsx` that assert the right-column (variant card and `CollateralUsageSection`) renders when report-card data is missing or when the focus entry is absent.

### Testing

- Ran the focused Vitest suite with `npx vitest run src/components/stablecoin-detail/__tests__/contagion-snapshot.test.tsx --environment jsdom` and all tests passed.
- Verified TypeScript with `npm run typecheck` which completed successfully.
- Linted the changed files with `npx eslint ... --max-warnings=0` and the check passed.
- Confirmed formatting with `npx prettier --write` and ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff107883329ce778584f6112da)