### PR TITLE
Fix detail hero infrastructure badge nesting

### DIFF
--- a/src/components/stablecoin-detail/hero-card-identity.tsx
+++ b/src/components/stablecoin-detail/hero-card-identity.tsx
@@ -211,20 +211,20 @@ function HeroClassificationLine({
 
   if (stackedSegments) {
     return (
-      <p className="text-xs text-muted-foreground">
+      <div className="text-xs text-muted-foreground">
         {sentenceNode}
-        <span className="mt-1 flex w-full min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        <div className="mt-1 flex w-full min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
           {taxonomyNodes}
-        </span>
-      </p>
+        </div>
+      </div>
     );
   }
 
   return (
-    <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
       {sentenceNode}
       {taxonomyNodes}
-    </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Motivation
- A `InfrastructureBadge` component renders a `<div>` while `HeroClassificationLine` previously used a `<p>` wrapper and inserted those badges inside it, producing invalid `<p><div>` nesting that can trigger React hydration errors for detail pages with infrastructures. 
- The change aims to fix the markup to avoid browser parser repairs and hydration mismatches while preserving the visual layout.

### Description
- Replace the paragraph wrappers in `HeroClassificationLine` with `div` containers so block-level `InfrastructureBadge` elements are not rendered inside `<p>` elements. 
- Preserve the existing flex/wrapping classes and layout for both the `stackedSegments` (mobile/stacked) and default desktop flows. 
- Modified file: `src/components/stablecoin-detail/hero-card-identity.tsx`.

### Testing
- Ran `npm run typecheck` and the TypeScript checks passed. 
- Ran `npx eslint src/components/stablecoin-detail/hero-card-identity.tsx --max-warnings=0` and no lint warnings/errors were reported. 
- Ran `git diff --check` to ensure no whitespace/markup issues and it reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff08448332970818862b93df5c)