### PR TITLE
Fix missing non-USD fiat peg symbols

### DIFF
--- a/shared/lib/__tests__/format.test.ts
+++ b/shared/lib/__tests__/format.test.ts
@@ -23,6 +23,7 @@ import {
   formatEventDate,
   formatPegDeviation,
   formatNativePrice,
+  pegCurrencySymbol,
   formatPercentChange,
   formatSupply,
   formatTrackingSpanDays,
@@ -526,6 +527,20 @@ describe("formatTrackingSpanSeconds", () => {
   });
 });
 
+describe("pegCurrencySymbol", () => {
+  it("returns distinct symbols for every supported fiat peg shown in non-USD peg badges", () => {
+    expect(pegCurrencySymbol("KRW")).toBe("₩");
+    expect(pegCurrencySymbol("INR")).toBe("₹");
+    expect(pegCurrencySymbol("MYR")).toBe("RM");
+    expect(pegCurrencySymbol("HKD")).toBe("HK$");
+    expect(pegCurrencySymbol("VND")).toBe("₫");
+  });
+
+  it("falls back to USD for unknown peg currency values", () => {
+    expect(pegCurrencySymbol("UNKNOWN")).toBe("$");
+  });
+});
+
 describe("formatNativePrice", () => {
   it("formats USD-pegged price as USD", () => {
     expect(formatNativePrice(1.0001, "USD", 1)).toBe("$1.0001");
@@ -535,6 +550,14 @@ describe("formatNativePrice", () => {
     const result = formatNativePrice(1.10, "EUR", 1.10);
     expect(result).toContain("1.0000");
     expect(result).not.toBe("N/A");
+  });
+
+  it("formats supported non-USD fiat pegs with their native symbols", () => {
+    expect(formatNativePrice(1300, "KRW", 1300)).toBe("₩1.0000");
+    expect(formatNativePrice(83, "INR", 83)).toBe("₹1.0000");
+    expect(formatNativePrice(4.7, "MYR", 4.7)).toBe("RM1.0000");
+    expect(formatNativePrice(7.8, "HKD", 7.8)).toBe("HK$1.0000");
+    expect(formatNativePrice(25000, "VND", 25000)).toBe("₫1.0000");
   });
 
   it("returns N/A for nullish or invalid values", () => {

--- a/shared/lib/format.ts
+++ b/shared/lib/format.ts
@@ -1,6 +1,7 @@
 import { DAY_SECONDS, HOUR_SECONDS, SECONDS_PER_MINUTE } from "./time-constants";
 import { BPS_PER_UNIT } from "./math";
 import { isFiniteNumber } from "./type-guards";
+import type { PegCurrency } from "../types/core";
 export { formatCompactUsdShort, formatCompactUsdShortLowerK } from "./format-compact-usd-short";
 
 /** Abbreviate a number into tier suffixes (T/B/M/K) with configurable decimals and prefix. */
@@ -55,10 +56,10 @@ function trimTrailingZeros(value: string): string {
   return value.replace(/(\.\d*?[1-9])0+$/u, "$1").replace(/\.0+$/u, "");
 }
 
-const PEG_CURRENCY_SYMBOLS: Record<string, string> = {
+const PEG_CURRENCY_SYMBOLS: Record<PegCurrency, string> & Record<string, string> = {
   USD: "$", EUR: "€", GBP: "£", CHF: "₣", BRL: "R$", RUB: "₽", JPY: "¥",
-  IDR: "Rp", SGD: "S$", TRY: "₺", AUD: "A$", ZAR: "R",
-  CAD: "C$", CNY: "¥", CNH: "¥", PHP: "₱", MXN: "MX$", UAH: "₴", ARS: "AR$",
+  KRW: "₩", IDR: "Rp", INR: "₹", MYR: "RM", SGD: "S$", HKD: "HK$", TRY: "₺", AUD: "A$", ZAR: "R",
+  CAD: "C$", CNY: "¥", CNH: "¥", PHP: "₱", MXN: "MX$", VND: "₫", UAH: "₴", ARS: "AR$",
   KGS: "som", NGN: "₦", XOF: "CFA ",
   GOLD: "$", SILVER: "$", VAR: "$", OTHER: "$",
 };


### PR DESCRIPTION
### Motivation
- The hero "Tracks 1.00" badge and native-price formatting used `pegCurrencySymbol()` which fell back to `$` for peg currencies that were missing from the symbol table, causing valid non-USD pegs (e.g. `KRW`, `INR`, `MYR`, `HKD`, `VND`) to display incorrectly.

### Description
- Add missing fiat symbols for `KRW`, `INR`, `MYR`, `HKD`, and `VND` to the peg symbol table in `shared/lib/format.ts` so non-USD hero badges and `formatNativePrice()` render the correct native symbol.
- Type the symbol map against `PegCurrency` so future additions to the peg enum will require a symbol at typecheck time (`Record<PegCurrency, string> & Record<string, string>`), while preserving the existing unknown-currency fallback.
- Add focused tests in `shared/lib/__tests__/format.test.ts` to cover `pegCurrencySymbol()` for the added pegs, the unknown-currency fallback, and `formatNativePrice()` behavior for the added pegs.

### Testing
- Ran the focused unit tests with `npm test -- --run shared/lib/__tests__/format.test.ts` and the test file passed (all tests green).
- Ran repository checks `npm run check:worker-boundary` and `npm run check:shared-cycles` which succeeded with no blocking errors.
- Ran TypeScript typecheck with `npm run typecheck` which passed, enforcing the new typed symbol map.
- Ran `npm run check:shared-types-imports` which passed and confirmed no shared-types import issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe176c83328f3ac6a68a3d86eb)