### PR TITLE
fix(tape): preserve null-coin freeze identity

### DIFF
--- a/src/lib/__tests__/tape-collapse.test.ts
+++ b/src/lib/__tests__/tape-collapse.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { collapseByCoinClass } from "@/lib/tape-collapse";
+import type { TapeEvent, TapeEventSeverity } from "@shared/types/tape-event";
+
+let idSeq = 0;
+function makeEvent(type: string, overrides: Partial<TapeEvent> = {}): TapeEvent {
+  idSeq += 1;
+  return {
+    id: `ev-${idSeq}`,
+    type,
+    severity: "info" as TapeEventSeverity,
+    ts: Date.UTC(2026, 4, 21, 12, 0, 0) - idSeq,
+    endsAt: null,
+    coinId: null,
+    issuerId: null,
+    pegCurrency: null,
+    chain: "Ethereum",
+    title: "",
+    summary: "",
+    payload: {},
+    sourceTable: "test",
+    sourceRowId: `row-${idSeq}`,
+    transition: "snapshot",
+    sourceUrl: null,
+    methodologyVersion: null,
+    ...overrides,
+  };
+}
+
+describe("collapseByCoinClass", () => {
+  it("keeps null-coin freeze subtypes and stablecoins distinct on the same chain", () => {
+    const blockedUsdt = makeEvent("freeze.blocked", {
+      severity: "notice",
+      payload: { stablecoin: "USDT" },
+    });
+    const destroyedUsdc = makeEvent("freeze.destroyed", {
+      severity: "critical",
+      payload: { stablecoin: "USDC" },
+    });
+
+    const collapsed = collapseByCoinClass([blockedUsdt, destroyedUsdc]);
+
+    expect(collapsed).toHaveLength(2);
+    expect(collapsed.map((entry) => entry.key)).toEqual([
+      "chain:Ethereum:freeze.blocked:stablecoin:USDT",
+      "chain:Ethereum:freeze.destroyed:stablecoin:USDC",
+    ]);
+    expect(collapsed.map((entry) => entry.count)).toEqual([1, 1]);
+  });
+
+  it("still collapses repeated null-coin events for the same chain, subtype, and stablecoin", () => {
+    const first = makeEvent("freeze.blocked", {
+      payload: { stablecoin: "USDT" },
+    });
+    const second = makeEvent("freeze.blocked", {
+      payload: { stablecoin: "USDT" },
+    });
+
+    const collapsed = collapseByCoinClass([first, second]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]!.key).toBe("chain:Ethereum:freeze.blocked:stablecoin:USDT");
+    expect(collapsed[0]!.count).toBe(2);
+    expect(collapsed[0]!.event).toBe(first);
+  });
+
+  it("preserves the existing coin-and-class collapse for attributed events", () => {
+    const opened = makeEvent("depeg.opened", { coinId: "usdc", chain: null });
+    const closed = makeEvent("depeg.closed", { coinId: "usdc", chain: null });
+
+    const collapsed = collapseByCoinClass([opened, closed]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]!.key).toBe("usdc:depeg");
+    expect(collapsed[0]!.count).toBe(2);
+  });
+});

--- a/src/lib/tape-collapse.ts
+++ b/src/lib/tape-collapse.ts
@@ -25,12 +25,17 @@ export function collapseByCoinClass(events: ReadonlyArray<TapeEvent>): Collapsed
   for (const event of events) {
     const cls = eventClassSlug(event.type);
     // Events with no coin attribution (e.g., USDT freeze.blocked rows from the
-    // blacklist projector) still share a chain — group those so a single busy
-    // chain doesn't flood the strip with one row per blacklist tx.
+    // blacklist projector) still share a chain — group repeated rows without
+    // merging different freeze subtypes or stablecoin identities.
+    const stablecoin = event.payload?.stablecoin;
+    const nullCoinIdentity =
+      typeof stablecoin === "string" && stablecoin.trim()
+        ? `${event.type}:stablecoin:${stablecoin}`
+        : event.type;
     const key = event.coinId
       ? `${event.coinId}:${cls}`
       : event.chain
-        ? `chain:${event.chain}:${cls}`
+        ? `chain:${event.chain}:${nullCoinIdentity}`
         : `event:${event.id}`;
     const existingIdx = indexByKey.get(key);
     if (existingIdx != null) {


### PR DESCRIPTION
### Motivation
- The chain-based collapse key for null-coin tape events collapsed different freeze subtypes and stablecoins (e.g., `freeze.blocked` vs `freeze.destroyed`, USDT vs USDC) into one representative row, causing newer low-severity events to hide older higher-severity ones in UI summaries.

### Description
- Change collapse key generation in `src/lib/tape-collapse.ts` so null-coin/chain entries include the full event subtype and the `payload.stablecoin` when present (`${event.type}:stablecoin:${stablecoin}`) instead of using only the broad class slug, preserving distinct freeze identities while still collapsing repeated identical rows.
- Preserve existing behavior for attributed events by keeping the `coinId:${eventClass}` key path unchanged for events with `coinId` set.
- Add regression tests in `src/lib/__tests__/tape-collapse.test.ts` that verify distinct same-chain null-coin freeze subtypes/stablecoins remain separate, repeated identical null-coin rows still collapse, and attributed coin/class collapse remains unchanged.

### Testing
- Ran `npm run test -- src/lib/__tests__/tape-collapse.test.ts src/lib/__tests__/tape-digest.test.ts` and all tests passed.
- Ran `npm run typecheck` and the TypeScript checks succeeded with no errors.
- Ran `npm run lint -- src/lib/tape-collapse.ts src/lib/__tests__/tape-collapse.test.ts` and the lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff3370833283327bce43e0315e)