### PR TITLE
Fix timeline: report worst PYS drop in yield digest summaries

### DIFF
--- a/src/lib/__tests__/tape-digest.test.ts
+++ b/src/lib/__tests__/tape-digest.test.ts
@@ -94,6 +94,45 @@ describe("digestByDay (back-compat)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// class summaries
+// ---------------------------------------------------------------------------
+
+describe("yield class summary", () => {
+  it("reports the worst PYS drop from projector-style positive deltas", () => {
+    const events = sortDesc([
+      makeEvent(NOW_MS - 1, "yield.warning_emitted", { coinId: "usdt" }),
+      makeEvent(NOW_MS - 2, "yield.pys_dropped", {
+        coinId: "usdt",
+        payload: { delta: 12 },
+      }),
+      makeEvent(NOW_MS - 3, "yield.pys_dropped", {
+        coinId: "usdt",
+        payload: { delta: 25 },
+      }),
+    ]);
+
+    const [today] = digestByDay(events, NOW_MS);
+    const yieldClass = today!.classes.find((c) => c.classSlug === "yield")!;
+
+    expect(yieldClass.summary).toBe("1 warning · 2 PYS drops · worst -25 pts · usdt ×3");
+  });
+
+  it("keeps rendering legacy signed negative PYS deltas as drops", () => {
+    const events = sortDesc([
+      makeEvent(NOW_MS - 1, "yield.pys_dropped", {
+        coinId: "usdt",
+        payload: { delta: -18 },
+      }),
+    ]);
+
+    const [today] = digestByDay(events, NOW_MS);
+    const yieldClass = today!.classes.find((c) => c.classSlug === "yield")!;
+
+    expect(yieldClass.summary).toBe("1 PYS drop · worst -18 pts · usdt");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // digestPage parity with digestByDay
 // ---------------------------------------------------------------------------
 

--- a/src/lib/tape-digest.ts
+++ b/src/lib/tape-digest.ts
@@ -124,19 +124,22 @@ function severityForBand(band: string): number {
 function yieldSummary(events: readonly TapeEvent[]): string {
   let warnings = 0;
   let drops = 0;
-  let worstDrop = 0;
+  let worstDropMagnitude = 0;
   for (const e of events) {
     if (e.type === "yield.warning_emitted") warnings += 1;
     else if (e.type === "yield.pys_dropped") {
       drops += 1;
       const delta = e.payload?.delta;
-      if (typeof delta === "number" && delta < worstDrop) worstDrop = delta;
+      if (typeof delta === "number") {
+        const dropMagnitude = Math.abs(delta);
+        if (dropMagnitude > worstDropMagnitude) worstDropMagnitude = dropMagnitude;
+      }
     }
   }
   const parts: string[] = [];
   if (warnings > 0) parts.push(`${warnings} warning${warnings === 1 ? "" : "s"}`);
   if (drops > 0) parts.push(`${drops} PYS drop${drops === 1 ? "" : "s"}`);
-  if (worstDrop < 0) parts.push(`worst ${Math.round(worstDrop)} pts`);
+  if (worstDropMagnitude > 0) parts.push(`worst -${Math.round(worstDropMagnitude)} pts`);
   const tickers = formatTopTickers(events);
   return [parts.join(" · "), tickers].filter(Boolean).join(" · ");
 }


### PR DESCRIPTION
### Motivation
- The yield digest summary code assumed `payload.delta` was negative and therefore never highlighted projector-style positive PYS drop deltas (projectors store `delta = prevScore - newScore`, which is positive for a drop), causing the collapsed-day recap to omit the intended `worst -X pts` line.
- The change aims to preserve existing detailed event rendering while restoring correct collapsed digest recaps for both projector-style positive deltas and legacy signed negative deltas.

### Description
- Update `yieldSummary` in `src/lib/tape-digest.ts` to treat `payload.delta` as a drop magnitude by using `Math.abs(delta)` and tracking the largest magnitude as `worstDropMagnitude`, then render `worst -<N> pts` when present.
- Keep support for legacy signed negative deltas by using absolute value for magnitude computation so either sign will be summarized consistently.
- Add regression tests in `src/lib/__tests__/tape-digest.test.ts` that assert projector-style positive deltas produce `worst -<N> pts` and that legacy negative deltas continue to render correctly.

### Testing
- Ran `npx vitest run src/lib/__tests__/tape-digest.test.ts --reporter=verbose` and the modified tape-digest test suite passed (all tests in the file succeeded).
- Ran `npm test -- --run src/lib/__tests__/tape-digest.test.ts` and observed the suite pass (14/14 tests passed in the run).
- Ran full typecheck with `npm run typecheck` and it completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe22308332ac97c0d50b5e654a)