### PR TITLE
Fix tape projector timestamp watermark skips

### DIFF
--- a/worker/src/lib/tape-projectors/__tests__/mint-burn.test.ts
+++ b/worker/src/lib/tape-projectors/__tests__/mint-burn.test.ts
@@ -93,6 +93,24 @@ describe("mint_burn projector", () => {
     expect(id1).toEqual(id2);
   });
 
+  it("expands a full batch to include all rows at the cutoff timestamp before advancing", async () => {
+    const rows = [
+      makeFlow({ id: "ethereum-0xa-0", timestamp: SEC }),
+      makeFlow({ id: "ethereum-0xb-0", timestamp: SEC }),
+      makeFlow({ id: "ethereum-0xc-0", timestamp: SEC }),
+    ];
+    const db = mockD1([
+      { match: "FROM cache WHERE key", rows: [] },
+      { match: MATCH_FETCH_FLOWS, matchBinds: [0, 10_000_000, 2], rows: rows.slice(0, 2) },
+      { match: MATCH_FETCH_FLOWS, matchBinds: [0, SEC, 10_000_000], rows },
+    ]) as MockD1Database;
+
+    const result = await projectMintBurnLargeFlows(db, { maxRows: 2 });
+
+    expect(result.advanced).toBe(SEC);
+    expect(extractInsertBindsForType(db, "mint_burn.large_mint")).toHaveLength(3);
+  });
+
   it("emits nothing on an empty source", async () => {
     const db = mockD1(withRows([])) as MockD1Database;
     await projectMintBurnLargeFlows(db);

--- a/worker/src/lib/tape-projectors/__tests__/yield.test.ts
+++ b/worker/src/lib/tape-projectors/__tests__/yield.test.ts
@@ -220,6 +220,25 @@ describe("yield.warning_emitted projector", () => {
     expect(result.projected).toBe(0);
     expect(extractInsertBindsForType(db, "yield.warning_emitted")).toHaveLength(0);
   });
+
+  it("expands a full timestamp batch before advancing the warning cursor", async () => {
+    const rows = [
+      { stablecoin_id: "coin-a", source_key: "src-a", recorded_at: SEC, warning_signals: JSON.stringify(["reward-heavy"]) },
+      { stablecoin_id: "coin-b", source_key: "src-b", recorded_at: SEC, warning_signals: JSON.stringify(["reward-heavy"]) },
+      { stablecoin_id: "coin-c", source_key: "src-c", recorded_at: SEC, warning_signals: JSON.stringify(["reward-heavy"]) },
+    ];
+    const db = mockD1([
+      { match: MATCH_CACHE, rows: [] },
+      { match: MATCH_FETCH_HISTORY, matchBinds: [0, 2], rows: rows.slice(0, 2) },
+      { match: MATCH_FETCH_HISTORY, matchBinds: [0, SEC], rows },
+      { match: MATCH_PRIOR_HISTORY, rows: [] },
+    ]) as MockD1Database;
+
+    const result = await projectYieldWarningEmitted(db, { maxRows: 2 });
+
+    expect(result.advanced).toBe(SEC);
+    expect(extractInsertBindsForType(db, "yield.warning_emitted")).toHaveLength(3);
+  });
 });
 
 describe("yield.pys_dropped projector", () => {

--- a/worker/src/lib/tape-projectors/dews.ts
+++ b/worker/src/lib/tape-projectors/dews.ts
@@ -65,7 +65,18 @@ async function fetchSamplesSince(
                  LIMIT ?`;
   const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
   const result = await db.prepare(sql).bind(...binds).all<StressSignalRow>();
-  return result.results ?? [];
+  const rows = result.results ?? [];
+  if (rows.length < limit) return rows;
+
+  const cutoff = rows[rows.length - 1]?.computed_at;
+  if (cutoff == null) return rows;
+  const expandedUntil = until == null ? cutoff : Math.min(until, cutoff);
+  const expandedSql = `SELECT stablecoin_id, computed_at, score, band
+                         FROM stress_signals
+                         WHERE computed_at > ? AND computed_at <= ?
+                         ORDER BY computed_at ASC, stablecoin_id ASC`;
+  const expanded = await db.prepare(expandedSql).bind(since, expandedUntil).all<StressSignalRow>();
+  return expanded.results ?? [];
 }
 
 /**

--- a/worker/src/lib/tape-projectors/mint-burn.ts
+++ b/worker/src/lib/tape-projectors/mint-burn.ts
@@ -80,7 +80,23 @@ async function fetchLargeFlows(
     ? [since, until, NOTICE_USD, limit]
     : [since, NOTICE_USD, limit];
   const result = await db.prepare(sql).bind(...binds).all<MintBurnSourceRow>();
-  return result.results ?? [];
+  const rows = result.results ?? [];
+  if (rows.length < limit) return rows;
+
+  const cutoff = rows[rows.length - 1]?.timestamp;
+  if (cutoff == null) return rows;
+  const expandedUntil = until == null ? cutoff : Math.min(until, cutoff);
+  const expandedSql = `SELECT id, stablecoin_id, symbol, chain_id, direction, amount_usd,
+                              counterparty, timestamp, flow_type, burn_type
+                         FROM mint_burn_events
+                         WHERE timestamp > ? AND timestamp <= ?
+                           AND amount_usd IS NOT NULL
+                           AND amount_usd >= ?
+                           AND (flow_type IS NULL OR flow_type != 'bridge_transfer')
+                           AND (direction = 'mint' OR burn_type IS NULL OR burn_type != 'review_required')
+                         ORDER BY timestamp ASC, id ASC`;
+  const expanded = await db.prepare(expandedSql).bind(since, expandedUntil, NOTICE_USD).all<MintBurnSourceRow>();
+  return expanded.results ?? [];
 }
 
 function chainLabel(chainId: string): string {

--- a/worker/src/lib/tape-projectors/yield.ts
+++ b/worker/src/lib/tape-projectors/yield.ts
@@ -100,11 +100,23 @@ async function fetchYieldHistorySince(
   const sql = `SELECT stablecoin_id, source_key, recorded_at, warning_signals
                  FROM yield_history
                  WHERE is_best = 1 AND recorded_at > ?${untilClause}
-                 ORDER BY stablecoin_id ASC, recorded_at ASC
+                 ORDER BY recorded_at ASC, stablecoin_id ASC
                  LIMIT ?`;
   const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
   const result = await db.prepare(sql).bind(...binds).all<YieldHistoryRow>();
-  return result.results ?? [];
+  const rows = result.results ?? [];
+  if (rows.length < limit) return rows;
+
+  const cutoff = rows[rows.length - 1]?.recorded_at;
+  if (cutoff == null) return rows;
+  const expandedUntil = until == null ? cutoff : Math.min(until, cutoff);
+  const expandedUntilClause = " AND recorded_at <= ?";
+  const expandedSql = `SELECT stablecoin_id, source_key, recorded_at, warning_signals
+                         FROM yield_history
+                         WHERE is_best = 1 AND recorded_at > ?${expandedUntilClause}
+                         ORDER BY recorded_at ASC, stablecoin_id ASC`;
+  const expanded = await db.prepare(expandedSql).bind(since, expandedUntil).all<YieldHistoryRow>();
+  return expanded.results ?? [];
 }
 
 /**
@@ -156,14 +168,18 @@ export async function projectYieldWarningEmitted(
   const rows = await fetchYieldHistorySince(db, since, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
 
+  rows.sort((a, b) => (
+    a.stablecoin_id === b.stablecoin_id
+      ? a.recorded_at - b.recorded_at
+      : a.stablecoin_id.localeCompare(b.stablecoin_id)
+  ));
   const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
   const priorByCoin = await fetchPriorWarningSignals(db, distinctCoinIds, since);
 
   const events: TapeEventInsert[] = [];
   let maxCursor = since;
 
-  // Rows are ordered by stablecoin_id ASC, recorded_at ASC. Walk per-coin and
-  // emit when net-new signals appear vs. the running snapshot.
+  // Walk per-coin and emit when net-new signals appear vs. the running snapshot.
   let currentCoin: string | null = null;
   let prevSignals: string[] = [];
   for (const row of rows) {
@@ -258,11 +274,23 @@ async function fetchYieldDecisionsSince(
   const sql = `SELECT stablecoin_id, selected_source_key, selected_score, created_at
                  FROM yield_source_decisions
                  WHERE created_at > ?${untilClause}
-                 ORDER BY stablecoin_id ASC, created_at ASC
+                 ORDER BY created_at ASC, stablecoin_id ASC
                  LIMIT ?`;
   const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
   const result = await db.prepare(sql).bind(...binds).all<YieldDecisionRow>();
-  return result.results ?? [];
+  const rows = result.results ?? [];
+  if (rows.length < limit) return rows;
+
+  const cutoff = rows[rows.length - 1]?.created_at;
+  if (cutoff == null) return rows;
+  const expandedUntil = until == null ? cutoff : Math.min(until, cutoff);
+  const expandedUntilClause = " AND created_at <= ?";
+  const expandedSql = `SELECT stablecoin_id, selected_source_key, selected_score, created_at
+                         FROM yield_source_decisions
+                         WHERE created_at > ?${expandedUntilClause}
+                         ORDER BY created_at ASC, stablecoin_id ASC`;
+  const expanded = await db.prepare(expandedSql).bind(since, expandedUntil).all<YieldDecisionRow>();
+  return expanded.results ?? [];
 }
 
 async function fetchPriorPysScores(
@@ -308,6 +336,11 @@ export async function projectYieldPysDropped(
   const rows = await fetchYieldDecisionsSince(db, since, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
 
+  rows.sort((a, b) => (
+    a.stablecoin_id === b.stablecoin_id
+      ? a.created_at - b.created_at
+      : a.stablecoin_id.localeCompare(b.stablecoin_id)
+  ));
   const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
   const priorByCoin = await fetchPriorPysScores(db, distinctCoinIds, since);
 


### PR DESCRIPTION
### Motivation
- Several tape projectors (DEWS, yield, mint/burn) could silently drop source rows when a `LIMIT` cut through a cohort of rows sharing the same timestamp or when rows for different coins sorted late were omitted, because watermarks were advanced using only a timestamp dimension. 
- The goal is to make watermark progression safe for limited batches so timeline events are not permanently skipped while preserving the projector semantics (per-coin diffs and idempotency).

### Description
- Expand full batches at the SQL layer for the relational projectors by detecting when a `LIMIT` was hit and re-querying to include every source row at the cutoff timestamp for `stress_signals`, `yield_history`, `yield_source_decisions`, and `mint_burn_events` (added cutoff-expansion logic in `worker/src/lib/tape-projectors/dews.ts`, `worker/src/lib/tape-projectors/yield.ts`, and `worker/src/lib/tape-projectors/mint-burn.ts`).
- For the yield projectors, read ordered by timestamp first (`ORDER BY recorded_at ASC` / `ORDER BY created_at ASC`) to compute a safe cutoff, and then re-sort the in-memory rows by `stablecoin_id ASC, timestamp ASC` before performing the per-coin diffing so transition detection is unchanged.
- Preserve existing watermark behavior (timestamp-only watermarks where appropriate) but ensure the watermark is only advanced after the projector includes the entire timestamp cohort, preventing omitted rows at or below the advanced timestamp.
- Add regression tests that exercise the cutoff expansion behavior for `yield.warning_emitted` and `mint_burn.large_flow` projectors to guard against future regressions (tests added/updated under `worker/src/lib/tape-projectors/__tests__`).

### Testing
- Ran the focused projector unit tests: `npx vitest run worker/src/lib/tape-projectors/__tests__/dews.test.ts worker/src/lib/tape-projectors/__tests__/yield.test.ts worker/src/lib/tape-projectors/__tests__/mint-burn.test.ts`, and all tests passed.
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which completed successfully.
- New regression tests confirming cutoff expansion behavior were added and validated by the above test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe3f0083329e0d19ca920c84b5)