### PR TITLE
fix(tape): use composite (timestamp,stablecoin) cursors for DEWS and yield projectors

### DIFF
--- a/worker/src/lib/tape-event-store.ts
+++ b/worker/src/lib/tape-event-store.ts
@@ -12,6 +12,15 @@ function tapeProjectorCursorKey(eventClass: string): string {
 export async function getProjectorWatermark(db: D1Database, eventClass: string): Promise<number> {
   const row = await getCache(db, tapeProjectorCursorKey(eventClass));
   if (!row) return 0;
+  if (row.value.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(row.value) as { timestamp?: unknown };
+      const timestamp = Number(parsed.timestamp);
+      return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : 0;
+    } catch {
+      return 0;
+    }
+  }
   const parsed = Number(row.value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
@@ -24,6 +33,54 @@ export async function setProjectorWatermark(
 ): Promise<void> {
   if (!Number.isFinite(value) || value <= 0) return;
   await setCache(db, tapeProjectorCursorKey(eventClass), String(Math.floor(value)));
+}
+
+export interface ProjectorCompositeCursor {
+  timestamp: number;
+  stablecoinId: string;
+}
+
+/** Read a timestamp + stablecoin cursor, with backward compatibility for numeric watermarks. */
+export async function getProjectorCompositeCursor(
+  db: D1Database,
+  eventClass: string,
+): Promise<ProjectorCompositeCursor> {
+  const row = await getCache(db, tapeProjectorCursorKey(eventClass));
+  if (!row) return { timestamp: 0, stablecoinId: "" };
+  if (!row.value.startsWith("{")) {
+    const timestamp = Number(row.value);
+    return {
+      timestamp: Number.isFinite(timestamp) && timestamp > 0 ? timestamp : 0,
+      stablecoinId: "",
+    };
+  }
+  try {
+    const parsed = JSON.parse(row.value) as { timestamp?: unknown; stablecoinId?: unknown };
+    const timestamp = Number(parsed.timestamp);
+    return {
+      timestamp: Number.isFinite(timestamp) && timestamp > 0 ? timestamp : 0,
+      stablecoinId: typeof parsed.stablecoinId === "string" ? parsed.stablecoinId : "",
+    };
+  } catch {
+    return { timestamp: 0, stablecoinId: "" };
+  }
+}
+
+/** Write a timestamp + stablecoin cursor for timestamp-ordered snapshot projectors. */
+export async function setProjectorCompositeCursor(
+  db: D1Database,
+  eventClass: string,
+  value: ProjectorCompositeCursor,
+): Promise<void> {
+  if (!Number.isFinite(value.timestamp) || value.timestamp <= 0) return;
+  await setCache(
+    db,
+    tapeProjectorCursorKey(eventClass),
+    JSON.stringify({
+      timestamp: Math.floor(value.timestamp),
+      stablecoinId: value.stablecoinId,
+    }),
+  );
 }
 
 /**

--- a/worker/src/lib/tape-projectors/__tests__/dews.test.ts
+++ b/worker/src/lib/tape-projectors/__tests__/dews.test.ts
@@ -4,7 +4,7 @@ import { projectDewsEscalated, projectDewsDeescalated, projectDewsBandTransition
 
 const SEC = 1_700_000_000;
 
-const MATCH_FETCH_SAMPLES = "WHERE computed_at > ?";
+const MATCH_FETCH_SAMPLES = "computed_at > ? OR (computed_at = ? AND stablecoin_id > ?)";
 const MATCH_PRIOR_BAND = "MAX(computed_at) as max_at";
 
 function extractInsertBinds(db: MockD1Database): unknown[][] {
@@ -238,5 +238,27 @@ describe("dews projector", () => {
     expect(result.projected).toBe(0);
     expect(extractInsertBindsForType(db, "dews.escalated")).toHaveLength(0);
     expect(extractInsertBindsForType(db, "dews.deescalated")).toHaveLength(0);
+  });
+
+  it("persists a composite timestamp/coin cursor from timestamp-ordered scans", async () => {
+    const db = mockD1(
+      baseTables([
+        { stablecoin_id: "a-issuer", computed_at: SEC, score: 10, band: "CALM" },
+        { stablecoin_id: "b-issuer", computed_at: SEC, score: 60, band: "WARNING" },
+      ]),
+    ) as MockD1Database;
+
+    await projectDewsBandTransitions(db, { maxRows: 2 });
+
+    const sampleScan = db.getHistory().find((entry) => entry.sql.includes(MATCH_FETCH_SAMPLES));
+    expect(sampleScan?.sql).toContain("ORDER BY computed_at ASC, stablecoin_id ASC");
+    const cacheWrites = db
+      .getHistory()
+      .filter((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"));
+    expect(cacheWrites).toHaveLength(2);
+    expect(JSON.parse(cacheWrites[0]!.binds[1] as string)).toEqual({
+      timestamp: SEC,
+      stablecoinId: "b-issuer",
+    });
   });
 });

--- a/worker/src/lib/tape-projectors/__tests__/yield.test.ts
+++ b/worker/src/lib/tape-projectors/__tests__/yield.test.ts
@@ -7,9 +7,9 @@ const SEC = 1_700_000_000;
 // Substring matchers — the mock-d1 helper does a substring search against the
 // raw SQL emitted by the projector, so each pattern only has to be unique
 // enough to disambiguate the projector's two queries.
-const MATCH_FETCH_HISTORY = "is_best = 1 AND recorded_at > ?";
+const MATCH_FETCH_HISTORY = "recorded_at > ? OR (recorded_at = ? AND stablecoin_id > ?)";
 const MATCH_PRIOR_HISTORY = "MAX(recorded_at) as max_at";
-const MATCH_FETCH_DECISIONS = "WHERE created_at > ?";
+const MATCH_FETCH_DECISIONS = "created_at > ? OR (created_at = ? AND stablecoin_id > ?)";
 const MATCH_PRIOR_DECISIONS = "MAX(created_at) as max_at";
 const MATCH_CACHE = "FROM cache WHERE key";
 
@@ -220,6 +220,37 @@ describe("yield.warning_emitted projector", () => {
     expect(result.projected).toBe(0);
     expect(extractInsertBindsForType(db, "yield.warning_emitted")).toHaveLength(0);
   });
+
+  it("persists a composite timestamp/coin cursor from timestamp-ordered warning scans", async () => {
+    const db = mockD1(
+      historyTables([
+        {
+          stablecoin_id: "a-issuer",
+          source_key: "aave-v3:a",
+          recorded_at: SEC,
+          warning_signals: JSON.stringify(["yield-spike"]),
+        },
+        {
+          stablecoin_id: "b-issuer",
+          source_key: "aave-v3:b",
+          recorded_at: SEC,
+          warning_signals: JSON.stringify(["yield-spike"]),
+        },
+      ], [], 0),
+    ) as MockD1Database;
+
+    await projectYieldWarningEmitted(db, { maxRows: 2 });
+
+    const historyScan = db.getHistory().find((entry) => entry.sql.includes(MATCH_FETCH_HISTORY));
+    expect(historyScan?.sql).toContain("ORDER BY recorded_at ASC, stablecoin_id ASC");
+    const cacheWrite = db
+      .getHistory()
+      .find((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"));
+    expect(JSON.parse(cacheWrite?.binds[1] as string)).toEqual({
+      timestamp: SEC,
+      stablecoinId: "b-issuer",
+    });
+  });
 });
 
 describe("yield.pys_dropped projector", () => {
@@ -363,5 +394,36 @@ describe("yield.pys_dropped projector", () => {
     const result = await projectYieldPysDropped(db);
     expect(result.projected).toBe(0);
     expect(extractInsertBindsForType(db, "yield.pys_dropped")).toHaveLength(0);
+  });
+
+  it("persists a composite timestamp/coin cursor from timestamp-ordered PYS scans", async () => {
+    const db = mockD1(
+      decisionTables([
+        {
+          stablecoin_id: "a-issuer",
+          selected_source_key: "aave-v3:a",
+          selected_score: 80,
+          created_at: SEC,
+        },
+        {
+          stablecoin_id: "b-issuer",
+          selected_source_key: "aave-v3:b",
+          selected_score: 80,
+          created_at: SEC,
+        },
+      ], [], 0),
+    ) as MockD1Database;
+
+    await projectYieldPysDropped(db, { maxRows: 2 });
+
+    const decisionScan = db.getHistory().find((entry) => entry.sql.includes(MATCH_FETCH_DECISIONS));
+    expect(decisionScan?.sql).toContain("ORDER BY created_at ASC, stablecoin_id ASC");
+    const cacheWrite = db
+      .getHistory()
+      .find((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"));
+    expect(JSON.parse(cacheWrite?.binds[1] as string)).toEqual({
+      timestamp: SEC,
+      stablecoinId: "b-issuer",
+    });
   });
 });

--- a/worker/src/lib/tape-projectors/dews.ts
+++ b/worker/src/lib/tape-projectors/dews.ts
@@ -10,14 +10,16 @@
  * coin.
  *
  * Algorithm:
- *   1. Read all rows with `computed_at > watermark` (ordered by coin, time).
+ *   1. Read rows after the persisted `(computed_at, stablecoin_id)` cursor
+ *      (ordered by source timestamp, then coin, for safe limited batches).
  *   2. For each coin in the batch, look up its most recent sample BEFORE the
  *      watermark to seed the "previous band" for the batch's first row.
  *   3. Walk samples per coin and emit one event for each band change.
  *
  * Idempotency: `sourceRowId` is `<coinId>:<computed_at>:<newBand>`, and the
  * `tape_events` unique index on `(source_table, source_row_id, transition)`
- * absorbs duplicates. Watermark advancement keeps the scan cheap on re-runs.
+ * absorbs duplicates. Composite cursor advancement keeps the scan cheap on
+ * re-runs without skipping same-timestamp rows.
  */
 import { TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import { DEPEG_DEWS_METHODOLOGY_VERSION } from "@shared/lib/depeg-dews-version";
@@ -26,9 +28,10 @@ import { THREAT_BAND_ORDER, isThreatBand, type ThreatBand } from "@shared/lib/cl
 import { buildTapeEventId, deriveIssuerId } from "../tape-event-helpers";
 import { buildInClause, chunkArray } from "../db";
 import {
-  getProjectorWatermark,
+  getProjectorCompositeCursor,
   insertTapeEvents,
-  setProjectorWatermark,
+  setProjectorCompositeCursor,
+  type ProjectorCompositeCursor,
 } from "../tape-event-store";
 import type { TapeEventInsert } from "../tape-event-types";
 import type { TapeEventSeverity } from "@shared/types/tape-event";
@@ -54,16 +57,19 @@ const BAND_SEVERITY: Record<ThreatBand, TapeEventSeverity> = {
 async function fetchSamplesSince(
   db: D1Database,
   since: number,
+  sinceStablecoinId: string,
   until: number | null,
   limit: number,
 ): Promise<StressSignalRow[]> {
   const untilClause = until != null ? " AND computed_at <= ?" : "";
   const sql = `SELECT stablecoin_id, computed_at, score, band
                  FROM stress_signals
-                 WHERE computed_at > ?${untilClause}
+                 WHERE (computed_at > ? OR (computed_at = ? AND stablecoin_id > ?))${untilClause}
                  ORDER BY computed_at ASC, stablecoin_id ASC
                  LIMIT ?`;
-  const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
+  const binds: unknown[] = until != null
+    ? [since, since, sinceStablecoinId, until, limit]
+    : [since, since, sinceStablecoinId, limit];
   const result = await db.prepare(sql).bind(...binds).all<StressSignalRow>();
   return result.results ?? [];
 }
@@ -77,9 +83,11 @@ async function fetchPriorBands(
   db: D1Database,
   coinIds: string[],
   since: number,
+  inclusive: boolean = true,
 ): Promise<Map<string, StressSignalRow>> {
   const map = new Map<string, StressSignalRow>();
   if (coinIds.length === 0 || since <= 0) return map;
+  const op = inclusive ? "<=" : "<";
 
   for (const chunk of chunkArray([...new Set(coinIds)])) {
     const inClause = buildInClause(chunk);
@@ -91,7 +99,7 @@ async function fetchPriorBands(
              SELECT stablecoin_id, MAX(computed_at) as max_at
              FROM stress_signals
              WHERE stablecoin_id IN (${inClause.sql})
-               AND computed_at <= ?
+               AND computed_at ${op} ?
              GROUP BY stablecoin_id
            ) latest
              ON s.stablecoin_id = latest.stablecoin_id
@@ -104,6 +112,45 @@ async function fetchPriorBands(
     }
   }
   return map;
+}
+
+async function fetchPriorBandsForCursor(
+  db: D1Database,
+  rows: StressSignalRow[],
+  cursor: ProjectorCompositeCursor,
+): Promise<Map<string, StressSignalRow>> {
+  const firstByCoin = new Map<string, StressSignalRow>();
+  for (const row of rows) {
+    if (!firstByCoin.has(row.stablecoin_id)) firstByCoin.set(row.stablecoin_id, row);
+  }
+  const inclusiveCoinIds: string[] = [];
+  const exclusiveCoinIds: string[] = [];
+  for (const [coinId, row] of firstByCoin) {
+    if (cursor.stablecoinId && row.computed_at === cursor.timestamp) {
+      exclusiveCoinIds.push(coinId);
+    } else {
+      inclusiveCoinIds.push(coinId);
+    }
+  }
+  const priorByCoin = await fetchPriorBands(db, inclusiveCoinIds, cursor.timestamp);
+  const exclusivePriorByCoin = await fetchPriorBands(db, exclusiveCoinIds, cursor.timestamp, false);
+  for (const [coinId, row] of exclusivePriorByCoin) priorByCoin.set(coinId, row);
+  return priorByCoin;
+}
+
+function lastSampleCursor(rows: StressSignalRow[], fallback: ProjectorCompositeCursor): ProjectorCompositeCursor {
+  const last = rows[rows.length - 1];
+  return last
+    ? { timestamp: last.computed_at, stablecoinId: last.stablecoin_id }
+    : fallback;
+}
+
+function minCompositeCursor(
+  a: ProjectorCompositeCursor,
+  b: ProjectorCompositeCursor,
+): ProjectorCompositeCursor {
+  if (a.timestamp !== b.timestamp) return a.timestamp < b.timestamp ? a : b;
+  return a.stablecoinId <= b.stablecoinId ? a : b;
 }
 
 interface BandTransition {
@@ -202,34 +249,33 @@ async function projectDewsByVariant(
 ): Promise<ProjectorResult> {
   const cursorKey = variant === "escalated" ? "dews.escalated" : "dews.deescalated";
   const { since, until, limit, dryRun } = await resolveProjectorOptions(db, cursorKey, options);
+  const persistedCursor = options?.since == null
+    ? await getProjectorCompositeCursor(db, cursorKey)
+    : { timestamp: since, stablecoinId: "" };
 
-  const rows = await fetchSamplesSince(db, since, until, limit);
+  const rows = await fetchSamplesSince(db, since, persistedCursor.stablecoinId, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
+  const advancedCursor = lastSampleCursor(rows, persistedCursor);
+  const maxCursor = advancedCursor.timestamp;
   rows.sort((a, b) => (
     a.stablecoin_id === b.stablecoin_id
       ? a.computed_at - b.computed_at
       : a.stablecoin_id.localeCompare(b.stablecoin_id)
   ));
 
-  const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
-  const priorByCoin = await fetchPriorBands(db, distinctCoinIds, since);
+  const priorByCoin = await fetchPriorBandsForCursor(db, rows, persistedCursor);
 
   const transitions = classifyTransitions(rows, priorByCoin);
   const wanted = transitions.filter((t) => t.direction === variant);
 
   const events = wanted.map(buildEvent);
 
-  let maxCursor = since;
-  for (const row of rows) {
-    if (row.computed_at > maxCursor) maxCursor = row.computed_at;
-  }
-
   if (!dryRun) {
     if (events.length > 0) await insertTapeEvents(db, events);
     // Advance the watermark even when nothing transitioned, so we do not
     // re-scan the same snapshot rows next run.
     if (options?.since == null && options?.until == null) {
-      await setProjectorWatermark(db, cursorKey, maxCursor);
+      await setProjectorCompositeCursor(db, cursorKey, advancedCursor);
     }
   }
   return { projected: events.length, advanced: dryRun ? null : maxCursor };
@@ -265,37 +311,36 @@ export async function projectDewsBandTransitions(
   options?: ProjectorOptions,
 ): Promise<ProjectorResult> {
   // Seed from the older of the two cursors so neither variant skips a window.
-  const escWatermark = await getProjectorWatermark(db, "dews.escalated");
-  const deescWatermark = await getProjectorWatermark(db, "dews.deescalated");
-  const since = options?.since ?? Math.min(escWatermark, deescWatermark);
+  const escCursor = await getProjectorCompositeCursor(db, "dews.escalated");
+  const deescCursor = await getProjectorCompositeCursor(db, "dews.deescalated");
+  const cursor = options?.since == null
+    ? minCompositeCursor(escCursor, deescCursor)
+    : { timestamp: options.since, stablecoinId: "" };
+  const since = cursor.timestamp;
   const until = options?.until ?? null;
   const limit = options?.maxRows ?? DEFAULT_BATCH_LIMIT;
   const dryRun = options?.dryRun === true;
 
-  const rows = await fetchSamplesSince(db, since, until, limit);
+  const rows = await fetchSamplesSince(db, since, cursor.stablecoinId, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
+  const advancedCursor = lastSampleCursor(rows, cursor);
+  const maxCursor = advancedCursor.timestamp;
   rows.sort((a, b) => (
     a.stablecoin_id === b.stablecoin_id
       ? a.computed_at - b.computed_at
       : a.stablecoin_id.localeCompare(b.stablecoin_id)
   ));
 
-  const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
-  const priorByCoin = await fetchPriorBands(db, distinctCoinIds, since);
+  const priorByCoin = await fetchPriorBandsForCursor(db, rows, cursor);
 
   const transitions = classifyTransitions(rows, priorByCoin);
   const events = transitions.map(buildEvent);
 
-  let maxCursor = since;
-  for (const row of rows) {
-    if (row.computed_at > maxCursor) maxCursor = row.computed_at;
-  }
-
   if (!dryRun) {
     if (events.length > 0) await insertTapeEvents(db, events);
     if (options?.since == null && options?.until == null) {
-      await setProjectorWatermark(db, "dews.escalated", maxCursor);
-      await setProjectorWatermark(db, "dews.deescalated", maxCursor);
+      await setProjectorCompositeCursor(db, "dews.escalated", advancedCursor);
+      await setProjectorCompositeCursor(db, "dews.deescalated", advancedCursor);
     }
   }
   return { projected: events.length, advanced: dryRun ? null : maxCursor };

--- a/worker/src/lib/tape-projectors/yield.ts
+++ b/worker/src/lib/tape-projectors/yield.ts
@@ -18,7 +18,9 @@
  *
  * Idempotency: sourceRowId encodes the source-row timestamp + event class,
  * which is unique per generation/coin, so re-runs are absorbed by the
- * tape_events (source_table, source_row_id, transition) unique index.
+ * tape_events (source_table, source_row_id, transition) unique index. Snapshot
+ * scans persist a `(timestamp, stablecoin_id)` cursor so limited batches can
+ * resume within same-timestamp groups without skipping later coins.
  */
 import { TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import { YIELD_METHODOLOGY_VERSION } from "@shared/lib/methodology-versions/yield-methodology";
@@ -27,8 +29,10 @@ import type { TapeEventSeverity } from "@shared/types/tape-event";
 import { buildTapeEventId, deriveIssuerId } from "../tape-event-helpers";
 import { buildInClause, chunkArray } from "../db";
 import {
+  getProjectorCompositeCursor,
   insertTapeEvents,
-  setProjectorWatermark,
+  setProjectorCompositeCursor,
+  type ProjectorCompositeCursor,
 } from "../tape-event-store";
 import type { TapeEventInsert } from "../tape-event-types";
 import { resolveProjectorOptions, type ProjectorOptions, type ProjectorResult } from "./types";
@@ -93,16 +97,20 @@ interface YieldHistoryRow {
 async function fetchYieldHistorySince(
   db: D1Database,
   since: number,
+  sinceStablecoinId: string,
   until: number | null,
   limit: number,
 ): Promise<YieldHistoryRow[]> {
   const untilClause = until != null ? " AND recorded_at <= ?" : "";
   const sql = `SELECT stablecoin_id, source_key, recorded_at, warning_signals
                  FROM yield_history
-                 WHERE is_best = 1 AND recorded_at > ?${untilClause}
-                 ORDER BY stablecoin_id ASC, recorded_at ASC
+                 WHERE is_best = 1
+                   AND (recorded_at > ? OR (recorded_at = ? AND stablecoin_id > ?))${untilClause}
+                 ORDER BY recorded_at ASC, stablecoin_id ASC
                  LIMIT ?`;
-  const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
+  const binds: unknown[] = until != null
+    ? [since, since, sinceStablecoinId, until, limit]
+    : [since, since, sinceStablecoinId, limit];
   const result = await db.prepare(sql).bind(...binds).all<YieldHistoryRow>();
   return result.results ?? [];
 }
@@ -116,9 +124,11 @@ async function fetchPriorWarningSignals(
   db: D1Database,
   coinIds: string[],
   since: number,
+  inclusive: boolean = true,
 ): Promise<Map<string, string[]>> {
   const map = new Map<string, string[]>();
   if (coinIds.length === 0 || since <= 0) return map;
+  const op = inclusive ? "<=" : "<";
   for (const chunk of chunkArray([...new Set(coinIds)])) {
     const inClause = buildInClause(chunk);
     const rows = await db
@@ -130,7 +140,7 @@ async function fetchPriorWarningSignals(
              FROM yield_history
              WHERE stablecoin_id IN (${inClause.sql})
                AND is_best = 1
-               AND recorded_at <= ?
+               AND recorded_at ${op} ?
              GROUP BY stablecoin_id
            ) latest
              ON yh.stablecoin_id = latest.stablecoin_id
@@ -146,21 +156,64 @@ async function fetchPriorWarningSignals(
   return map;
 }
 
+async function fetchPriorWarningSignalsForCursor(
+  db: D1Database,
+  rows: YieldHistoryRow[],
+  cursor: ProjectorCompositeCursor,
+): Promise<Map<string, string[]>> {
+  const firstByCoin = new Map<string, YieldHistoryRow>();
+  for (const row of rows) {
+    if (!firstByCoin.has(row.stablecoin_id)) firstByCoin.set(row.stablecoin_id, row);
+  }
+  const inclusiveCoinIds: string[] = [];
+  const exclusiveCoinIds: string[] = [];
+  for (const [coinId, row] of firstByCoin) {
+    if (cursor.stablecoinId && row.recorded_at === cursor.timestamp) {
+      exclusiveCoinIds.push(coinId);
+    } else {
+      inclusiveCoinIds.push(coinId);
+    }
+  }
+  const priorByCoin = await fetchPriorWarningSignals(db, inclusiveCoinIds, cursor.timestamp);
+  const exclusivePriorByCoin = await fetchPriorWarningSignals(db, exclusiveCoinIds, cursor.timestamp, false);
+  for (const [coinId, signals] of exclusivePriorByCoin) priorByCoin.set(coinId, signals);
+  return priorByCoin;
+}
+
+function lastCursor<T extends { stablecoin_id: string }>(
+  rows: T[],
+  timestampFor: (row: T) => number,
+  fallback: ProjectorCompositeCursor,
+): ProjectorCompositeCursor {
+  const last = rows[rows.length - 1];
+  return last
+    ? { timestamp: timestampFor(last), stablecoinId: last.stablecoin_id }
+    : fallback;
+}
+
 export async function projectYieldWarningEmitted(
   db: D1Database,
   options?: ProjectorOptions,
 ): Promise<ProjectorResult> {
   const cursorKey = "yield.warning_emitted";
   const { since, until, limit, dryRun } = await resolveProjectorOptions(db, cursorKey, options);
+  const persistedCursor = options?.since == null
+    ? await getProjectorCompositeCursor(db, cursorKey)
+    : { timestamp: since, stablecoinId: "" };
 
-  const rows = await fetchYieldHistorySince(db, since, until, limit);
+  const rows = await fetchYieldHistorySince(db, since, persistedCursor.stablecoinId, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
+  const advancedCursor = lastCursor(rows, (row) => row.recorded_at, persistedCursor);
+  const maxCursor = advancedCursor.timestamp;
+  rows.sort((a, b) => (
+    a.stablecoin_id === b.stablecoin_id
+      ? a.recorded_at - b.recorded_at
+      : a.stablecoin_id.localeCompare(b.stablecoin_id)
+  ));
 
-  const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
-  const priorByCoin = await fetchPriorWarningSignals(db, distinctCoinIds, since);
+  const priorByCoin = await fetchPriorWarningSignalsForCursor(db, rows, persistedCursor);
 
   const events: TapeEventInsert[] = [];
-  let maxCursor = since;
 
   // Rows are ordered by stablecoin_id ASC, recorded_at ASC. Walk per-coin and
   // emit when net-new signals appear vs. the running snapshot.
@@ -171,8 +224,6 @@ export async function projectYieldWarningEmitted(
       currentCoin = row.stablecoin_id;
       prevSignals = priorByCoin.get(currentCoin) ?? [];
     }
-    if (row.recorded_at > maxCursor) maxCursor = row.recorded_at;
-
     const currentSignals = parseSignals(row.warning_signals);
     if (currentSignals.length === 0) {
       prevSignals = currentSignals;
@@ -233,7 +284,7 @@ export async function projectYieldWarningEmitted(
   if (!dryRun) {
     if (events.length > 0) await insertTapeEvents(db, events);
     if (options?.since == null && options?.until == null) {
-      await setProjectorWatermark(db, cursorKey, maxCursor);
+      await setProjectorCompositeCursor(db, cursorKey, advancedCursor);
     }
   }
   return { projected: events.length, advanced: dryRun ? null : maxCursor };
@@ -251,16 +302,19 @@ interface YieldDecisionRow {
 async function fetchYieldDecisionsSince(
   db: D1Database,
   since: number,
+  sinceStablecoinId: string,
   until: number | null,
   limit: number,
 ): Promise<YieldDecisionRow[]> {
   const untilClause = until != null ? " AND created_at <= ?" : "";
   const sql = `SELECT stablecoin_id, selected_source_key, selected_score, created_at
                  FROM yield_source_decisions
-                 WHERE created_at > ?${untilClause}
-                 ORDER BY stablecoin_id ASC, created_at ASC
+                 WHERE (created_at > ? OR (created_at = ? AND stablecoin_id > ?))${untilClause}
+                 ORDER BY created_at ASC, stablecoin_id ASC
                  LIMIT ?`;
-  const binds: unknown[] = until != null ? [since, until, limit] : [since, limit];
+  const binds: unknown[] = until != null
+    ? [since, since, sinceStablecoinId, until, limit]
+    : [since, since, sinceStablecoinId, limit];
   const result = await db.prepare(sql).bind(...binds).all<YieldDecisionRow>();
   return result.results ?? [];
 }
@@ -269,9 +323,11 @@ async function fetchPriorPysScores(
   db: D1Database,
   coinIds: string[],
   since: number,
+  inclusive: boolean = true,
 ): Promise<Map<string, number | null>> {
   const map = new Map<string, number | null>();
   if (coinIds.length === 0 || since <= 0) return map;
+  const op = inclusive ? "<=" : "<";
   for (const chunk of chunkArray([...new Set(coinIds)])) {
     const inClause = buildInClause(chunk);
     const rows = await db
@@ -282,7 +338,7 @@ async function fetchPriorPysScores(
              SELECT stablecoin_id, MAX(created_at) as max_at
              FROM yield_source_decisions
              WHERE stablecoin_id IN (${inClause.sql})
-               AND created_at <= ?
+               AND created_at ${op} ?
              GROUP BY stablecoin_id
            ) latest
              ON ysd.stablecoin_id = latest.stablecoin_id
@@ -298,22 +354,53 @@ async function fetchPriorPysScores(
   return map;
 }
 
+async function fetchPriorPysScoresForCursor(
+  db: D1Database,
+  rows: YieldDecisionRow[],
+  cursor: ProjectorCompositeCursor,
+): Promise<Map<string, number | null>> {
+  const firstByCoin = new Map<string, YieldDecisionRow>();
+  for (const row of rows) {
+    if (!firstByCoin.has(row.stablecoin_id)) firstByCoin.set(row.stablecoin_id, row);
+  }
+  const inclusiveCoinIds: string[] = [];
+  const exclusiveCoinIds: string[] = [];
+  for (const [coinId, row] of firstByCoin) {
+    if (cursor.stablecoinId && row.created_at === cursor.timestamp) {
+      exclusiveCoinIds.push(coinId);
+    } else {
+      inclusiveCoinIds.push(coinId);
+    }
+  }
+  const priorByCoin = await fetchPriorPysScores(db, inclusiveCoinIds, cursor.timestamp);
+  const exclusivePriorByCoin = await fetchPriorPysScores(db, exclusiveCoinIds, cursor.timestamp, false);
+  for (const [coinId, score] of exclusivePriorByCoin) priorByCoin.set(coinId, score);
+  return priorByCoin;
+}
+
 export async function projectYieldPysDropped(
   db: D1Database,
   options?: ProjectorOptions,
 ): Promise<ProjectorResult> {
   const cursorKey = "yield.pys_dropped";
   const { since, until, limit, dryRun } = await resolveProjectorOptions(db, cursorKey, options);
+  const persistedCursor = options?.since == null
+    ? await getProjectorCompositeCursor(db, cursorKey)
+    : { timestamp: since, stablecoinId: "" };
 
-  const rows = await fetchYieldDecisionsSince(db, since, until, limit);
+  const rows = await fetchYieldDecisionsSince(db, since, persistedCursor.stablecoinId, until, limit);
   if (rows.length === 0) return { projected: 0, advanced: null };
+  const advancedCursor = lastCursor(rows, (row) => row.created_at, persistedCursor);
+  const maxCursor = advancedCursor.timestamp;
+  rows.sort((a, b) => (
+    a.stablecoin_id === b.stablecoin_id
+      ? a.created_at - b.created_at
+      : a.stablecoin_id.localeCompare(b.stablecoin_id)
+  ));
 
-  const distinctCoinIds = Array.from(new Set(rows.map((r) => r.stablecoin_id)));
-  const priorByCoin = await fetchPriorPysScores(db, distinctCoinIds, since);
+  const priorByCoin = await fetchPriorPysScoresForCursor(db, rows, persistedCursor);
 
   const events: TapeEventInsert[] = [];
-  let maxCursor = since;
-
   let currentCoin: string | null = null;
   let prevScore: number | null = null;
   for (const row of rows) {
@@ -321,8 +408,6 @@ export async function projectYieldPysDropped(
       currentCoin = row.stablecoin_id;
       prevScore = priorByCoin.get(currentCoin) ?? null;
     }
-    if (row.created_at > maxCursor) maxCursor = row.created_at;
-
     const newScore = row.selected_score;
     if (newScore == null || !Number.isFinite(newScore)) {
       // Carry prevScore unchanged — a null score does not reset the baseline.
@@ -380,7 +465,7 @@ export async function projectYieldPysDropped(
   if (!dryRun) {
     if (events.length > 0) await insertTapeEvents(db, events);
     if (options?.since == null && options?.until == null) {
-      await setProjectorWatermark(db, cursorKey, maxCursor);
+      await setProjectorCompositeCursor(db, cursorKey, advancedCursor);
     }
   }
   return { projected: events.length, advanced: dryRun ? null : maxCursor };


### PR DESCRIPTION
### Motivation
- Prevent snapshot projectors from advancing a scalar timestamp watermark past unprocessed rows when a limited `LIMIT`-truncated batch contains only early-sorted stablecoin IDs at a recent timestamp, which caused permanent skips for later coins at equal/older timestamps.
- Keep existing numeric watermark compatibility while enabling safe resume semantics inside same-timestamp groups for snapshot-style sources like `stress_signals`, `yield_history`, and `yield_source_decisions`.

### Description
- Add a backward-compatible composite cursor type and helpers: `ProjectorCompositeCursor`, `getProjectorCompositeCursor`, and `setProjectorCompositeCursor` in `worker/src/lib/tape-event-store.ts` so cursors can store `{ timestamp, stablecoinId }` while still reading old numeric values.
- Change DEWS and yield projectors to page in timestamp order (then `stablecoin_id`) by adding a compound WHERE predicate `(ts > ? OR (ts = ? AND stablecoin_id > ?))` and `ORDER BY <timestamp> ASC, stablecoin_id ASC`, accepting a `sinceStablecoinId` parameter so limited batches resume at the right coin within a timestamp.
- Compute and persist a composite cursor based on the last returned row (`{ timestamp, stablecoinId }`) and use it when seeding prior-state lookups; implement `fetchPrior*ForCursor` helpers to correctly choose inclusive vs exclusive prior-row queries for coins that share the persisted timestamp.
- Update unit tests to assert the new timestamp-first SQL patterns and add focused regression tests that verify composite cursor writes for DEWS and both yield projectors.

### Testing
- Ran the affected projector test suites with `npx vitest run worker/src/lib/tape-projectors/__tests__/dews.test.ts worker/src/lib/tape-projectors/__tests__/yield.test.ts`, and all tests passed (`26 passed`).
- Verified TypeScript build with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe002883328c9ce8843919ef7c)