### PR TITLE
Fix BRL SELIC benchmark annualization

### DIFF
--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -506,7 +506,7 @@ Yield Intelligence now uses a small benchmark registry instead of a single globa
 | `GBP` | GBP 3M compounded SONIA | Bank of England IADB SONIA Compounded Index `IUDZOS2` CSV | Annualized from the trailing 90-day index change; metadata source `boe-sonia-compounded-index`, fallback mode `gbp-sonia-compounded-index-failed` |
 | `JPY` | JPY overnight call (TONA proxy) | Bank of Japan Time-Series Data Search `STRDCLUCON` | Used as a TONA-equivalent proxy |
 | `MXN` | MXN CETES 28d | Banxico SIE API (series `SF43936`), then Etherfuse CETES current issuance fallback | `BANXICO_TOKEN` enables the official Banxico feed; when missing/failing, Etherfuse is marked `isFallback` and `isProxy`. CETES (Etherfuse) is itself a 28d CETES tokenization, so the spread is ~0% — see "Self-reference caveat" below |
-| `BRL` | BRL SELIC over | BCB SGS API (series `11`) | No auth required; daily |
+| `BRL` | BRL SELIC over | BCB SGS API (series `11`) | No auth required; daily percentage annualized over 252 business days before scoring |
 | `AUD` | AUD cash-rate target | Reserve Bank of Australia F1 money-market CSV | RBA cash-rate target used as the AUD local cash hurdle |
 | `CAD` | CAD overnight repo (CORRA proxy) | Bank of Canada Valet API (series `V122530`) | Overnight repo; CORRA-equivalent |
 | `RUB` | RUB CBR key rate | Central Bank of Russia DailyInfo `KeyRateXML` SOAP feed | Native benchmark for RUB pegs; validation accepts up to 100% so high key-rate regimes are not rejected by the standard 20% ceiling |
@@ -754,7 +754,7 @@ Fetches the benchmark registry used by Yield Intelligence:
 - GBP 3M compounded SONIA from the Bank of England IADB SONIA Compounded Index `IUDZOS2`, annualized from the trailing 90-day index change (v8.28)
 - JPY call-rate proxy from Bank of Japan Time-Series Data Search `STRDCLUCON` (v8.22)
 - MXN CETES 28-day from Banxico SIE (`SF43936`), falling back to Etherfuse CETES current issuance as a degraded proxy when Banxico is unavailable (v8.15)
-- BRL SELIC overnight from BCB SGS series 11 (no auth) (v8.13)
+- BRL SELIC overnight from BCB SGS series 11 (no auth), annualized from the daily percentage over 252 business days before scoring (v8.13)
 - AUD cash-rate target from the Reserve Bank of Australia F1 money-market CSV (v8.22)
 - CAD CORRA proxy from Bank of Canada Valet `V122530` (v8.13)
 - RUB CBR key rate from the Central Bank of Russia DailyInfo `KeyRateXML` SOAP feed (v8.291)

--- a/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
+++ b/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
@@ -866,9 +866,23 @@ describe("parseEtherfuseCetesStablebondPage", () => {
 });
 
 describe("parseBcbSelicSeries", () => {
-  it("extracts the most recent SELIC observation", () => {
-    const payload = JSON.stringify([{ data: "26/03/2026", valor: "12.75" }]);
-    expect(parseBcbSelicSeries(payload)).toEqual({ rate: 12.75, recordDate: "2026-03-26" });
+  it("annualizes the most recent daily SELIC observation", () => {
+    const payload = JSON.stringify([{ data: "18/06/2026", valor: "0.050747" }]);
+    expect(parseBcbSelicSeries(payload)).toEqual({
+      rate: 13.638253562615565,
+      recordDate: "2026-06-18",
+    });
+  });
+
+  it("skips implausible annualized SELIC observations", () => {
+    const payload = JSON.stringify([
+      { data: "17/06/2026", valor: "0.050747" },
+      { data: "18/06/2026", valor: "12.75" },
+    ]);
+    expect(parseBcbSelicSeries(payload)).toEqual({
+      rate: 13.638253562615565,
+      recordDate: "2026-06-17",
+    });
   });
 
   it("returns null when array is empty", () => {

--- a/worker/src/cron/fetch-tbill-rate.ts
+++ b/worker/src/cron/fetch-tbill-rate.ts
@@ -53,6 +53,7 @@ const LEGACY_USD_RISK_FREE_RATE_CACHE_KEY = "risk_free_rate";
 const BOE_SONIA_COMPOUNDED_INDEX_SERIES_CODE = "IUDZOS2";
 const BOE_COMPOUNDED_SONIA_WINDOW_DAYS = 90;
 const BOE_COMPOUNDED_SONIA_LOOKBACK_DAYS = 140;
+const BCB_SELIC_ANNUALIZATION_BUSINESS_DAYS = 252;
 
 function buildMetadata(fields: Record<string, unknown>): string {
   return JSON.stringify(fields);
@@ -108,6 +109,10 @@ function isValidBenchmarkRateForKey(key: YieldBenchmarkKey, rate: number): boole
 
 function isValidBenchmarkRate(rate: number): boolean {
   return isValidBenchmarkRateForKey("USD", rate);
+}
+
+function annualizeDailyPercentageRate(dailyRate: number, periodsPerYear: number): number {
+  return ((1 + dailyRate / 100) ** periodsPerYear - 1) * 100;
 }
 
 function parseFredLatest(csv: string): { recordDate: string; rate: number } | null {
@@ -749,8 +754,9 @@ export function parseBanxicoSeries(json: string): { recordDate: string; rate: nu
 
 /**
  * Parse a BCB SGS response. Shape:
- *   [{ data: "DD/MM/YYYY", valor: "12.75" }]
- * BCB returns SELIC over as a daily rate; we treat it directly as a daily APY proxy.
+ *   [{ data: "DD/MM/YYYY", valor: "0.050747" }]
+ * BCB SGS series 11 returns SELIC over as a daily percentage, so annualize it before
+ * storing the BRL benchmark alongside the other APY-compatible rates.
  */
 export function parseBcbSelicSeries(json: string): { recordDate: string; rate: number } | null {
   try {
@@ -760,10 +766,11 @@ export function parseBcbSelicSeries(json: string): { recordDate: string; rate: n
       const row = parsed[i];
       const rate = parseRate(typeof row?.valor === "string" ? row.valor : null);
       const dataRaw = typeof row?.data === "string" ? row.data : null;
-      if (!dataRaw || !isValidBenchmarkRate(rate)) continue;
+      const annualizedRate = annualizeDailyPercentageRate(rate, BCB_SELIC_ANNUALIZATION_BUSINESS_DAYS);
+      if (!dataRaw || !isValidBenchmarkRate(annualizedRate)) continue;
       const recordDate = parseSlashDmyToIso(dataRaw);
       if (!recordDate) continue;
-      return { rate, recordDate };
+      return { rate: annualizedRate, recordDate };
     }
     return null;
   } catch {

--- a/worker/src/cron/yield-sync/benchmarks.ts
+++ b/worker/src/cron/yield-sync/benchmarks.ts
@@ -70,7 +70,7 @@ const BENCHMARK_META_BY_KEY: Record<YieldBenchmarkKey, { label: string; currency
     isProxy: false,
   },
   BRL: {
-    // BCB SGS series 11 — SELIC over (daily).
+    // BCB SGS series 11 — SELIC over daily rate, annualized over 252 business days.
     label: "BRL SELIC over",
     currency: "BRL",
     isProxy: false,

--- a/worker/src/lib/constants.ts
+++ b/worker/src/lib/constants.ts
@@ -111,7 +111,7 @@ export const RBA_F1_MONEY_MARKET_CSV_URL = "https://www.rba.gov.au/statistics/ta
 export const BANXICO_CETES_28D_URL = "https://www.banxico.org.mx/SieAPIRest/service/v1/series/SF43936/datos/oportuno";
 /** Etherfuse app route whose Next data exposes the current CETES Stablebond issuance rate. */
 export const ETHERFUSE_CETES_BOND_PAGE_URL = "https://app.etherfuse.com/bonds/cetes";
-/** Banco Central do Brasil SGS — SELIC over (series 11), latest observation as JSON. */
+/** Banco Central do Brasil SGS — SELIC over (series 11), latest daily observation as JSON. */
 export const BCB_SELIC_URL = "https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados/ultimos/1?formato=json";
 /** Bank of Canada Valet — overnight repo rate (V122530), latest observation as JSON. */
 export const BOC_CORRA_URL = "https://www.bankofcanada.ca/valet/observations/V122530/json?recent=1";


### PR DESCRIPTION
### Motivation
- The BCB SGS series 11 feed reports SELIC-over as a daily percentage but the code stored the raw value as an annual benchmark, which understated the BRL hurdle and inflated yield scores for BRL-pegged assets.
- Existing tests used an annual-shaped fixture and therefore did not catch the unit mismatch, so the parser must annualize the daily observation to match other APY-compatible benchmarks.

### Description
- Annualize BCB SELIC daily percentages over 252 business days by adding `annualizeDailyPercentageRate()` and the constant `BCB_SELIC_ANNUALIZATION_BUSINESS_DAYS` and return the annualized rate from `parseBcbSelicSeries` instead of the raw `valor`.
- Update `worker/src/lib/constants.ts` and `worker/src/cron/yield-sync/benchmarks.ts` comments to document the daily-source/annualized-behavior for BRL.
- Replace the BRL test fixture with a daily-rate-shaped sample and add a test that ensures implausible (already-annualized) trailing values are skipped in favor of realistic daily observations in `worker/src/cron/__tests__/fetch-tbill-rate.test.ts`.
- Update `docs/yield-intelligence.md` to document that BRL SELIC series 11 values are daily percentages and are annualized before scoring.

### Testing
- Ran targeted unit tests with Vitest: `npx vitest run worker/src/cron/__tests__/fetch-tbill-rate.test.ts --testNamePattern 'parseBcbSelicSeries|fetchRiskFreeRateRegistry|benchmark key'`, and the test file passed (5 tests passed, 48 skipped).
- Type-check: `cd worker && npx tsc --noEmit` completed successfully without errors.
- Cron and docs checks: `npm run check:cron-sync`, `npm run check:cron-connections`, and `npm run check:doc-sync` all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fef30c8332a0587ac5aebc3d48)