### PR TITLE
fix(tape): preserve distinct collapsed event transitions

### DIFF
--- a/src/app/timeline/client.test.tsx
+++ b/src/app/timeline/client.test.tsx
@@ -154,7 +154,7 @@ describe("TimelineClient", () => {
     expect(hrefs.some((h) => h.startsWith("/freezewatch"))).toBe(true);
   });
 
-  it("collapses repeated same-coin same-class events within a day", () => {
+  it("collapses repeated same-coin same-type events within a day", () => {
     const now = Date.UTC(2026, 0, 15, 12, 0, 0);
     // Use peak_worsened only so the open-incidents banner stays out of the
     // way and the assertion isolates the collapse behavior.

--- a/src/components/__tests__/homepage-tape.test.tsx
+++ b/src/components/__tests__/homepage-tape.test.tsx
@@ -203,7 +203,7 @@ describe("HomepageTape", () => {
     expect(root?.className).not.toContain("-mx-3");
   });
 
-  it("collapses repeated same-coin same-class events into one cell with a count badge", () => {
+  it("collapses repeated same-coin same-type events into one cell with a count badge", () => {
     mockLatestEvents({
       data: {
         events: [
@@ -217,15 +217,15 @@ describe("HomepageTape", () => {
           makeTapeEvent({
             id: "evt-2",
             ts: Date.now() - 600_000,
-            type: "depeg.opened",
-            title: "USDXL depeg opened (−109 bps)",
+            type: "depeg.peak_worsened",
+            title: "USDXL depeg peak worsened (−109 bps)",
             coinId: "usdxl-last",
           }),
           makeTapeEvent({
             id: "evt-1",
             ts: Date.now() - 1_200_000,
-            type: "depeg.resolved",
-            title: "USDXL depeg resolved",
+            type: "depeg.peak_worsened",
+            title: "USDXL depeg peak worsened (−104 bps)",
             coinId: "usdxl-last",
           }),
         ],
@@ -237,11 +237,11 @@ describe("HomepageTape", () => {
 
     render(<HomepageTape />);
 
-    // The most recent event's title is kept; the two older same-(coin,class)
+    // The most recent event's title is kept; the two older same-(coin,type)
     // events are collapsed into the single cell.
     expect(screen.getAllByText("USDXL depeg peak worsened (−112 bps)")).toHaveLength(2);
-    expect(screen.queryByText("USDXL depeg opened (−109 bps)")).toBeNull();
-    expect(screen.queryByText("USDXL depeg resolved")).toBeNull();
+    expect(screen.queryByText("USDXL depeg peak worsened (−109 bps)")).toBeNull();
+    expect(screen.queryByText("USDXL depeg peak worsened (−104 bps)")).toBeNull();
     // ×N badge reflects the total event count in the collapsed group, doubled
     // by the marquee loop.
     expect(screen.getAllByText("×3")).toHaveLength(2);

--- a/src/lib/__tests__/tape-collapse.test.ts
+++ b/src/lib/__tests__/tape-collapse.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { collapseByCoinClass } from "@/lib/tape-collapse";
+import type { TapeEvent } from "@shared/types/tape-event";
+
+function makeEvent(overrides: Partial<TapeEvent> = {}): TapeEvent {
+  return {
+    id: "evt-1",
+    type: "depeg.peak_worsened",
+    severity: "warning",
+    ts: Date.UTC(2026, 0, 15, 12, 0, 0),
+    endsAt: null,
+    coinId: "usdxl-last",
+    issuerId: null,
+    pegCurrency: "USD",
+    chain: null,
+    title: "USDXL depeg peak worsened",
+    summary: "USDXL drift worsened.",
+    payload: {},
+    sourceTable: "depeg_events",
+    sourceRowId: "1",
+    transition: "updated",
+    sourceUrl: "/stablecoin/usdxl-last/#peg-history",
+    methodologyVersion: null,
+    ...overrides,
+  };
+}
+
+describe("collapseByCoinClass", () => {
+  it("collapses repeated same-coin same-type events", () => {
+    const collapsed = collapseByCoinClass([
+      makeEvent({ id: "evt-3", sourceRowId: "3" }),
+      makeEvent({ id: "evt-2", sourceRowId: "2" }),
+      makeEvent({ id: "evt-1", sourceRowId: "1" }),
+    ]);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]).toMatchObject({ event: expect.objectContaining({ id: "evt-3" }), count: 3 });
+  });
+
+  it("keeps distinct same-coin class transitions visible", () => {
+    const collapsed = collapseByCoinClass([
+      makeEvent({ id: "evt-resolved", type: "depeg.resolved", severity: "info", transition: "resolved" }),
+      makeEvent({ id: "evt-opened", type: "depeg.opened", severity: "critical", transition: "opened" }),
+      makeEvent({ id: "evt-peak", type: "depeg.peak_worsened", severity: "warning", transition: "updated" }),
+    ]);
+
+    expect(collapsed.map((entry) => entry.event.id)).toEqual(["evt-resolved", "evt-opened", "evt-peak"]);
+    expect(collapsed.every((entry) => entry.count === 1)).toBe(true);
+  });
+
+  it("keeps same-type severity changes visible", () => {
+    const collapsed = collapseByCoinClass([
+      makeEvent({ id: "evt-warning", severity: "warning" }),
+      makeEvent({ id: "evt-critical", severity: "critical" }),
+    ]);
+
+    expect(collapsed.map((entry) => entry.event.id)).toEqual(["evt-warning", "evt-critical"]);
+  });
+});

--- a/src/lib/tape-collapse.ts
+++ b/src/lib/tape-collapse.ts
@@ -15,23 +15,38 @@ export interface CollapsedTapeEntry {
   coinIds?: string[];
 }
 
-// Collapse non-consecutive runs of the same (coinId, eventClass) into one
+function collapseAttributionKey(event: TapeEvent, cls: string): string {
+  // Events with no coin attribution (e.g., USDT freeze.blocked rows from the
+  // blacklist projector) still share a chain — group those so a single busy
+  // chain doesn't flood the strip with one row per blacklist tx.
+  if (event.coinId) return `coin:${event.coinId}:${cls}`;
+  if (event.chain) return `chain:${event.chain}:${cls}`;
+  return `event:${event.id}`;
+}
+
+function collapseTransitionKey(event: TapeEvent): string {
+  return typeof event.transition === "string" && event.transition.length > 0
+    ? event.transition
+    : "none";
+}
+
+// Collapse non-consecutive runs of the same attribution, full event type,
+// severity, and lifecycle transition into one
 // entry positioned at the most recent occurrence. Used by the homepage strip
 // and by /tape's day groups to keep flapping coins (e.g. USDXL with repeated
-// peg cycles) from dominating the visible list.
+// peak updates) from dominating the visible list while keeping opposite
+// lifecycle transitions and severity changes visible.
 export function collapseByCoinClass(events: ReadonlyArray<TapeEvent>): CollapsedTapeEntry[] {
   const result: CollapsedTapeEntry[] = [];
   const indexByKey = new Map<string, number>();
   for (const event of events) {
     const cls = eventClassSlug(event.type);
-    // Events with no coin attribution (e.g., USDT freeze.blocked rows from the
-    // blacklist projector) still share a chain — group those so a single busy
-    // chain doesn't flood the strip with one row per blacklist tx.
-    const key = event.coinId
-      ? `${event.coinId}:${cls}`
-      : event.chain
-        ? `chain:${event.chain}:${cls}`
-        : `event:${event.id}`;
+    const key = [
+      collapseAttributionKey(event, cls),
+      `type:${event.type}`,
+      `severity:${event.severity}`,
+      `transition:${collapseTransitionKey(event)}`,
+    ].join("|");
     const existingIdx = indexByKey.get(key);
     if (existingIdx != null) {
       result[existingIdx]!.count += 1;


### PR DESCRIPTION
### Motivation
- The existing collapse logic grouped events by only `coinId` + event class, which caused distinct lifecycle transitions and severities (e.g. `depeg.opened`, `depeg.resolved`, `depeg.peak_worsened`) for the same coin/day to be hidden behind a single representative row. 
- The goal is to retain noise-reduction for repeated identical updates while preserving opposite transitions and higher-severity events in the public timeline and homepage tape.

### Description
- Narrowed the collapse key in `collapseByCoinClass` to include full `type`, `severity`, and `transition` in addition to attribution, and preserved the chain fallback for unattributed events by adding `collapseAttributionKey` and `collapseTransitionKey` helpers in `src/lib/tape-collapse.ts`.
- Kept `collapseForHomepageStrip` behaviour (DEWS consolidation) working on top of the tightened base collapse while preserving `coinIds` aggregation when appropriate in `src/lib/tape-collapse.ts`.
- Added focused unit tests `src/lib/__tests__/tape-collapse.test.ts` that assert same-type grouping and that distinct transitions and severity changes remain visible, and updated timeline/homepage expectations in `src/app/timeline/client.test.tsx` and `src/components/__tests__/homepage-tape.test.tsx` to reflect same-type (not broad class) grouping.

### Testing
- Ran the focused Vitest suites with `npx vitest run src/lib/__tests__/tape-collapse.test.ts src/app/timeline/client.test.tsx src/components/__tests__/homepage-tape.test.tsx --reporter=verbose`, and all tests passed (tests: 32 passed).
- Ran the typecheck with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff84b4833290b146b78460d7c1)