### PR TITLE
fix(telegram): scope mini app shared mutation metrics

### DIFF
--- a/worker/src/lib/__tests__/telegram-bot-stats.test.ts
+++ b/worker/src/lib/__tests__/telegram-bot-stats.test.ts
@@ -476,6 +476,8 @@ describe("loadTelegramMiniAppDailyAggregate", () => {
           "mini_app_forget",
           "timezone_change",
           "unsubscribe",
+          "startapp",
+          "menu_or_main_app",
           day,
         ],
         first: {
@@ -493,7 +495,7 @@ describe("loadTelegramMiniAppDailyAggregate", () => {
     const history = db.getHistory();
     const aggregateSql = history.find((entry) => entry.sql.includes("FROM telegram_usage_daily"));
     expect(aggregateSql?.sql).toContain(
-      "event_type IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      "event_type IN (?, ?, ?, ?, ?, ?, ?, ?)",
     );
     expect(aggregateSql?.binds).toEqual([
       "mini_app_mutation",
@@ -506,11 +508,50 @@ describe("loadTelegramMiniAppDailyAggregate", () => {
       "mini_app_forget",
       "timezone_change",
       "unsubscribe",
+      "startapp",
+      "menu_or_main_app",
       day,
     ]);
     expect(aggregate.mutations).toBe(9);
     expect(aggregate.denied).toBe(0);
     expect(aggregate.sessions).toBe(4);
     expect(aggregate.replayClaimed).toBe(0);
+  });
+
+  it("filters shared success event types to Mini App source categories", async () => {
+    const day = "2026-05-14";
+    const db = mockD1([
+      {
+        match: "FROM telegram_usage_daily",
+        matchBinds: [
+          "mini_app_mutation",
+          "mini_app_recommended_setup",
+          "mini_app_coin_add",
+          "mini_app_coin_remove",
+          "mini_app_quiet_hours",
+          "mini_app_snooze",
+          "mini_app_coin_snooze",
+          "mini_app_forget",
+          "timezone_change",
+          "unsubscribe",
+          "startapp",
+          "menu_or_main_app",
+          day,
+        ],
+        first: {
+          mini_app_sessions: 0,
+          mini_app_mutations: 1,
+          mini_app_denied: 0,
+          mini_app_replay_claimed: 0,
+        },
+        rows: [],
+      },
+    ]);
+
+    const aggregate = await loadTelegramMiniAppDailyAggregate(db, day);
+
+    const aggregateSql = db.getHistory().find((entry) => entry.sql.includes("FROM telegram_usage_daily"));
+    expect(aggregateSql?.sql).toContain("source_category IN (?, ?)");
+    expect(aggregate.mutations).toBe(1);
   });
 });

--- a/worker/src/lib/status/telegram-bot-stats.ts
+++ b/worker/src/lib/status/telegram-bot-stats.ts
@@ -272,15 +272,40 @@ const TELEGRAM_MINI_APP_SUCCESS_EVENT_TYPES = [
   "mini_app_snooze",
   "mini_app_coin_snooze",
   "mini_app_forget",
+] as const;
+// These generic event types are also emitted by non-Mini-App bot flows, so
+// only count rows whose Mini App recorder populated a Mini App source category.
+const TELEGRAM_MINI_APP_SHARED_SUCCESS_EVENT_TYPES = [
   "timezone_change",
   "unsubscribe",
+] as const;
+const TELEGRAM_MINI_APP_SOURCE_CATEGORIES = [
+  "startapp",
+  "menu_or_main_app",
 ] as const;
 const TELEGRAM_MINI_APP_SUCCESS_EVENT_PLACEHOLDERS = TELEGRAM_MINI_APP_SUCCESS_EVENT_TYPES
   .map(() => "?")
   .join(", ");
+const TELEGRAM_MINI_APP_SHARED_SUCCESS_EVENT_PLACEHOLDERS = TELEGRAM_MINI_APP_SHARED_SUCCESS_EVENT_TYPES
+  .map(() => "?")
+  .join(", ");
+const TELEGRAM_MINI_APP_SOURCE_CATEGORY_PLACEHOLDERS = TELEGRAM_MINI_APP_SOURCE_CATEGORIES
+  .map(() => "?")
+  .join(", ");
 const TELEGRAM_MINI_APP_DAILY_AGGREGATE_SQL = `SELECT
   SUM(CASE WHEN event_type = 'mini_app_session_valid' AND outcome = 'success' THEN count ELSE 0 END) AS mini_app_sessions,
-  SUM(CASE WHEN event_type IN (${TELEGRAM_MINI_APP_SUCCESS_EVENT_PLACEHOLDERS}) AND outcome = 'success' THEN count ELSE 0 END) AS mini_app_mutations,
+  SUM(
+    CASE
+      WHEN (
+        event_type IN (${TELEGRAM_MINI_APP_SUCCESS_EVENT_PLACEHOLDERS})
+        OR (
+          event_type IN (${TELEGRAM_MINI_APP_SHARED_SUCCESS_EVENT_PLACEHOLDERS})
+          AND source_category IN (${TELEGRAM_MINI_APP_SOURCE_CATEGORY_PLACEHOLDERS})
+        )
+      )
+      AND outcome = 'success' THEN count ELSE 0
+    END
+  ) AS mini_app_mutations,
   SUM(CASE WHEN event_type = 'mini_app_mutation_denied' THEN count ELSE 0 END) AS mini_app_denied,
   SUM(CASE WHEN event_type = 'mini_app_mutation_denied' AND failure_class = 'replayed-auth' THEN count ELSE 0 END) AS mini_app_replay_claimed
 FROM telegram_usage_daily
@@ -368,7 +393,12 @@ export async function loadTelegramMiniAppDailyAggregate(
 ): Promise<TelegramMiniAppDailyAggregate> {
   const row = await db
     .prepare(TELEGRAM_MINI_APP_DAILY_AGGREGATE_SQL)
-    .bind(...TELEGRAM_MINI_APP_SUCCESS_EVENT_TYPES, day)
+    .bind(
+      ...TELEGRAM_MINI_APP_SUCCESS_EVENT_TYPES,
+      ...TELEGRAM_MINI_APP_SHARED_SUCCESS_EVENT_TYPES,
+      ...TELEGRAM_MINI_APP_SOURCE_CATEGORIES,
+      day,
+    )
     .first<TelegramMiniAppDailyAggregateRow>();
   return {
     sessions: coerceCount(row?.mini_app_sessions),


### PR DESCRIPTION
### Motivation
- Prevent normal bot unsubscribe and timezone-change telemetry from inflating Mini App mutation metrics by ensuring generic shared events are only counted when recorded with a Mini App source category.
- Preserve existing Mini App-specific mutation coverage while avoiding cross-seam metric contamination that affected operator/public `/api/telegram-pulse` values.

### Description
- Split the Mini App success-event tuple into Mini App-specific events and shared success events, and introduce `TELEGRAM_MINI_APP_SOURCE_CATEGORIES` to identify Mini App-recorded rows.
- Update the daily aggregate SQL to count Mini App-specific events unconditionally but require `source_category IN (...)` for shared events (`timezone_change`, `unsubscribe`).
- Adjust the `.bind()` order to pass Mini App event types, shared event types, source categories, then the day placeholder to match the SQL placeholders.
- Add a regression test asserting the aggregate bind order and the `source_category` predicate so normal bot unsubscribes do not count as Mini App mutations (`worker/src/lib/__tests__/telegram-bot-stats.test.ts`).

### Testing
- Ran the focused unit tests with `npx vitest run worker/src/lib/__tests__/telegram-bot-stats.test.ts` and all tests passed.
- Performed a TypeScript check with `cd worker && npx tsc --noEmit` which succeeded.
- Verified no whitespace or lint diffs with `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fed7c88332aea6003c6ce2fb8a)