### PR TITLE
fix(yield): suppress legacy avUSD handoff history

### DIFF
--- a/worker/src/api/__tests__/yield-history.test.ts
+++ b/worker/src/api/__tests__/yield-history.test.ts
@@ -350,6 +350,12 @@ describe("handleYieldHistory", () => {
   });
 
   it("suppresses all tracked parent handoff source keys in source mode", async () => {
+    expect(YIELD_HISTORY_OWNERSHIP_HANDOFFS["avusd-avant"]).toEqual(expect.arrayContaining([
+      "onchain:avusd-avant",
+      "2fe112ff-95a5-4ba0-8ee3-a741e6a8f7c9",
+      "c74227a1-e738-4021-bbe1-13363815aecb",
+    ]));
+
     for (const [stablecoinId, sourceKeys] of Object.entries(YIELD_HISTORY_OWNERSHIP_HANDOFFS)) {
       for (const sourceKey of sourceKeys) {
         const suppressedRow = makeYieldHistoryRow({

--- a/worker/src/lib/yield-history-ownership-handoffs.ts
+++ b/worker/src/lib/yield-history-ownership-handoffs.ts
@@ -39,6 +39,11 @@ export const YIELD_HISTORY_OWNERSHIP_HANDOFFS: Record<string, string[]> = {
     "5fd328af-4203-471b-bd16-1705c726d926",
     "onchain:crvusd-curve:scrvusd-current-rate",
   ],
+  "avusd-avant": [
+    buildOnChainSourceKey("avusd-avant"),
+    "2fe112ff-95a5-4ba0-8ee3-a741e6a8f7c9",
+    "c74227a1-e738-4021-bbe1-13363815aecb",
+  ],
   "dusd-dtrinity": [
     "defillama-weighted:dtrinity-sdusd",
     "78049985-79a8-4343-8618-3c27d41d5054",


### PR DESCRIPTION
### Motivation
- A recent change moved Avant yield publishing from `avusd-avant` to `savusd-avant`, but the yield-history ownership handoff registry was not updated, allowing legacy parent-owned `avUSD` rows to remain queryable and not be purged.

### Description
- Add `avusd-avant` to `YIELD_HISTORY_OWNERSHIP_HANDOFFS` in `worker/src/lib/yield-history-ownership-handoffs.ts` with the on-chain source key and legacy pool/source keys so the existing `isSuppressedYieldHistoryRow` read-time filter and the hourly purge path cover Avant parent rows.
- Extend the yield-history API test in `worker/src/api/__tests__/yield-history.test.ts` to assert the Avant handoff keys remain registered before exercising the source-mode suppression checks.

### Testing
- Ran `npx vitest run worker/src/api/__tests__/yield-history.test.ts` and all tests in that suite passed.
- Ran `cd worker && npx tsc --noEmit` to validate TypeScript and the build check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff3c248332882b770fb89e75d2)