### PR TITLE
Derive blacklist summary active metrics from event history (fix preserved snapshot bug)

### DIFF
--- a/worker/src/api/__tests__/blacklist-summary.test.ts
+++ b/worker/src/api/__tests__/blacklist-summary.test.ts
@@ -298,35 +298,44 @@ describe("handleBlacklistSummary", () => {
         ],
       },
       {
-        match: "latest_event_type_by_balance",
+        match: "latest_event_type",
         rows: [
-          {
-            id: "USDC:base:0xgap",
-            stablecoin: "USDC",
-            chain_id: "base",
-            address: "0xgap",
-            timestamp: null,
-            config_key: null,
-            contract_address: null,
-          },
-          {
-            id: null,
+          makeBlacklistRow({
+            id: "USDC:ethereum:0xactive",
             stablecoin: "USDC",
             chain_id: "ethereum",
+            chain_name: "Ethereum",
+            event_type: "blacklist",
             address: "0xactive",
             timestamp: 1_777_000_000,
-            config_key: null,
-            contract_address: null,
-          },
-          {
-            id: "USDT:tron:TRdestroyed",
+          }),
+          makeBlacklistRow({
+            id: "USDT:tron:TRdestroyed-blacklist",
             stablecoin: "USDT",
             chain_id: "tron",
+            chain_name: "Tron",
+            event_type: "blacklist",
+            address: "TRdestroyed",
+            timestamp: 1_777_000_000,
+          }),
+          makeBlacklistRow({
+            id: "USDT:tron:TRdestroyed-destroy",
+            stablecoin: "USDT",
+            chain_id: "tron",
+            chain_name: "Tron",
+            event_type: "destroy",
             address: "TRdestroyed",
             timestamp: 1_777_000_100,
-            config_key: null,
-            contract_address: null,
-          },
+          }),
+          makeBlacklistRow({
+            id: "USDC:polygon:0xother",
+            stablecoin: "USDC",
+            chain_id: "polygon",
+            chain_name: "Polygon",
+            event_type: "blacklist",
+            address: "0xother",
+            timestamp: 1_777_000_050,
+          }),
         ],
       },
       {
@@ -413,11 +422,11 @@ describe("handleBlacklistSummary", () => {
       freezeLedgerMeta: { statusDistribution: Record<string, number>; sourceDistribution: Record<string, number> };
     };
 
-    expect(json.stats.activeAddressCount).toBe(4);
+    expect(json.stats.activeAddressCount).toBe(3);
     expect(json.stats.activeFrozenTotal).toBe(525);
-    expect(json.stats.activeAmountGapCount).toBe(1);
-    expect(json.stats.frozenAddresses).toBe(3);
-    expect(json.stats.perCoinFrozenAddressCount.USDC).toBe(3);
+    expect(json.stats.activeAmountGapCount).toBe(0);
+    expect(json.stats.frozenAddresses).toBe(2);
+    expect(json.stats.perCoinFrozenAddressCount.USDC).toBe(2);
     expect(json.stats.perCoinFrozenAddressCount.USDT).toBe(0);
     expect(json.stats.perCoinFrozenTotal.USDC).toBe(525);
     expect(json.stats.perCoinFrozenTotal.USDT).toBe(0);
@@ -425,6 +434,85 @@ describe("handleBlacklistSummary", () => {
     expect(json.freezeLedgerMeta.statusDistribution.recoverable_pending).toBe(1);
     expect(json.freezeLedgerMeta.sourceDistribution.destroy_event).toBe(1);
     expect(json.freezeLedgerMeta.sourceDistribution.reconciled_snapshot).toBe(1);
+  });
+
+  it("does not count preserved current-balance snapshots after unblacklist events as active freezes", async () => {
+    const observedAt = 1_777_000_300;
+    const db = mockD1([
+      {
+        match: "GROUP BY stablecoin, event_type",
+        rows: [{ stablecoin: "USDC", event_type: "blacklist", n: 1, usd_sum: 100 }],
+      },
+      {
+        match: "latest_event_type",
+        rows: [
+          makeBlacklistRow({
+            id: "released-blacklist",
+            stablecoin: "USDC",
+            chain_id: "ethereum",
+            chain_name: "Ethereum",
+            event_type: "blacklist",
+            address: "0xreleased",
+            amount_usd_at_event: 100,
+            timestamp: 1_777_000_000,
+          }),
+          makeBlacklistRow({
+            id: "released-unblacklist",
+            stablecoin: "USDC",
+            chain_id: "ethereum",
+            chain_name: "Ethereum",
+            event_type: "unblacklist",
+            address: "0xreleased",
+            timestamp: 1_777_000_100,
+          }),
+        ],
+      },
+      {
+        match: "COUNT(*) AS total",
+        rows: [],
+        first: { total: 2, max_ts: 1_777_000_100, recent_30d: 0, recent_24h: 0 },
+      },
+      {
+        match: "FROM blacklist_current_balances",
+        rows: [
+          {
+            id: "USDC:ethereum:0xreleased",
+            stablecoin: "USDC",
+            chain_id: "ethereum",
+            address: "0xreleased",
+            amount_native: 100,
+            amount_usd: 100,
+            source: "current_balance",
+            status: "resolved",
+            observed_at: observedAt,
+            attempt_count: 1,
+            last_attempted_at: observedAt,
+            last_error_class: null,
+          },
+        ],
+      },
+      { match: "quarter_sort_key", rows: [] },
+      { match: "cron_runs", rows: [], first: { started_at: observedAt } },
+    ]);
+
+    const res = await handleBlacklistSummary(db);
+    const json = await res.json() as {
+      stats: {
+        activeAddressCount: number;
+        activeFrozenTotal: number;
+        frozenAddresses: number;
+        trackedAddressCount: number;
+        trackedFrozenTotal: number;
+        perCoinFrozenAddressCount: Record<string, number>;
+      };
+    };
+
+    expect(json.stats.activeAddressCount).toBe(0);
+    expect(json.stats.activeFrozenTotal).toBe(0);
+    expect(json.stats.frozenAddresses).toBe(0);
+    expect(json.stats.perCoinFrozenAddressCount.USDC).toBe(0);
+    expect(json.stats.trackedAddressCount).toBe(1);
+    expect(json.stats.trackedFrozenTotal).toBe(100);
   });
 
   it("derives perCoinBlacklistCounts and preserves required stats", async () => {
@@ -902,11 +990,7 @@ describe("handleBlacklistSummary", () => {
     expect(json.stats.activeAddressCount).toBe(1);
     expect(json.stats.activeFrozenTotal).toBe(0);
     expect(json.chart[0]).toMatchObject({ quarter: "Q1 '24", total: 100 });
-    expect(
-      db.getHistory().some((entry) =>
-        entry.sql.includes("latest_event_type_by_balance")
-        && entry.sql.includes("e.config_key IS NULL AND e.contract_address IS NULL")),
-    ).toBe(true);
+    expect(db.getHistory().some((entry) => entry.sql.includes("latest_event_type_by_balance"))).toBe(false);
   });
 
   it("surfaces destroy-only coins without a freeze-ledger snapshot", async () => {

--- a/worker/src/api/blacklist-summary.ts
+++ b/worker/src/api/blacklist-summary.ts
@@ -156,113 +156,6 @@ function isDestroySnapshot(snapshot: BlacklistCurrentBalanceSnapshot): boolean {
   return sourceCategory(snapshot.source) === "destroy";
 }
 
-function computeActiveSummaryStatsFromCurrentBalances(
-  currentBalances: ReadonlyMap<string, BlacklistCurrentBalanceSnapshot>,
-): ReturnType<typeof computeBlacklistActiveSummaryStats> {
-  let activeAddressCount = 0;
-  let activeFrozenTotal = 0;
-  let activeAmountGapCount = 0;
-
-  for (const snapshot of currentBalances.values()) {
-    activeAddressCount++;
-    if (isDestroySnapshot(snapshot)) continue;
-    if (snapshot.amountUsd == null) {
-      activeAmountGapCount++;
-      continue;
-    }
-    activeFrozenTotal += snapshot.amountUsd;
-  }
-
-  return { activeAddressCount, activeFrozenTotal, activeAmountGapCount };
-}
-
-function buildSyntheticBlacklistEvent(row: {
-  id?: string | null;
-  stablecoin: string;
-  chain_id: string;
-  chain_name?: string | null;
-  address: string;
-  timestamp: number | null;
-  config_key?: string | null;
-  contract_address?: string | null;
-}): BlacklistEvent | null {
-  if (row.timestamp == null) return null;
-  return {
-    id: row.id ?? `${row.stablecoin}:${row.chain_id}:${row.address}:${row.timestamp}`,
-    stablecoin: row.stablecoin as BlacklistStablecoin,
-    chainId: row.chain_id,
-    chainName: row.chain_name ?? row.chain_id,
-    eventType: "blacklist",
-    address: row.address,
-    amountNative: null,
-    amountUsdAtEvent: null,
-    amountSource: "unavailable",
-    amountStatus: "recoverable_pending",
-    txHash: "",
-    blockNumber: 0,
-    timestamp: row.timestamp,
-    methodologyVersion: "",
-    contractAddress: row.contract_address ?? null,
-    configKey: row.config_key ?? null,
-    eventSignature: null,
-    eventTopic0: null,
-    suppressionReason: null,
-    explorerTxUrl: "",
-    explorerAddressUrl: "",
-  };
-}
-
-async function queryLatestBlacklistEventsForCurrentBalances(
-  db: D1Database,
-  currentBalances: ReadonlyMap<string, BlacklistCurrentBalanceSnapshot>,
-): Promise<BlacklistEvent[]> {
-  if (currentBalances.size === 0) return [];
-
-  const result = await db
-    .prepare(
-      `/* blacklist-summary-latest-event-type-by-balance latest_event_type_by_balance */
-       SELECT
-         b.id,
-         b.stablecoin,
-         b.chain_id,
-         b.address,
-         b.config_key,
-         b.contract_address,
-         MAX(e.timestamp) AS timestamp
-       FROM blacklist_current_balances b
-       LEFT JOIN blacklist_events e
-         ON e.stablecoin = b.stablecoin
-        AND e.chain_id = b.chain_id
-        AND LOWER(e.address) = LOWER(b.address)
-        AND e.event_type = 'blacklist'
-        AND e.suppression_reason IS NULL
-        AND (
-          (b.config_key IS NOT NULL AND e.config_key = b.config_key)
-          OR (b.config_key IS NULL AND b.contract_address IS NOT NULL AND LOWER(e.contract_address) = LOWER(b.contract_address))
-          OR (b.config_key IS NULL AND b.contract_address IS NULL)
-          OR (e.config_key IS NULL AND e.contract_address IS NULL)
-        )
-       GROUP BY b.id, b.stablecoin, b.chain_id, b.address, b.config_key, b.contract_address`,
-    )
-    .all<{
-      id: string | null;
-      stablecoin: string;
-      chain_id: string;
-      chain_name?: string | null;
-      event_type?: string | null;
-      address: string;
-      timestamp: number | null;
-      config_key: string | null;
-      contract_address: string | null;
-    }>();
-
-  return (result.results ?? []).flatMap((row) => {
-    if (row.event_type != null && row.event_type !== "blacklist") return [];
-    const event = buildSyntheticBlacklistEvent(row);
-    return event ? [event] : [];
-  });
-}
-
 async function queryLatestEventTypeHistory(db: D1Database): Promise<BlacklistEvent[]> {
   const activeHistoryResult = await db
     .prepare(
@@ -416,45 +309,31 @@ interface ActiveBlacklistRecords {
 }
 
 /**
- * Resolve the active freeze records from either the legacy event-derived path
- * (used when no current-balance snapshots exist) or the current-balance
- * snapshot path. The legacy-vs-snapshot decision is made once here so the four
- * derived outputs cannot drift between branches.
+ * Resolve active freeze records from event history for net blacklist state.
+ * Current-balance rows are retained freeze-ledger snapshots, including after
+ * releases, so they are only used to hydrate amounts for event-derived active
+ * records and must not define the active address set.
  */
 async function resolveActiveBlacklistRecords(
   db: D1Database,
   currentBalances: ReadonlyMap<string, BlacklistCurrentBalanceSnapshot>,
 ): Promise<ActiveBlacklistRecords> {
-  const useLegacyEventPath = currentBalances.size === 0;
+  const activeHistory = await queryLatestEventTypeHistory(db);
+  const latestByAddr = deriveLatestByIdentity(activeHistory);
+  const activeRecordEvents = activeHistory.length > 0 ? activeHistory : latestByAddr;
+  const activeRecords = buildBlacklistActiveRecords(activeRecordEvents, currentBalances);
+  const activeStats = computeBlacklistActiveSummaryStats(activeRecords);
+  const frozenAddresses = activeRecords.filter((record) => record.destroyedAt == null).length;
 
   const perCoinFrozenAddressCount = Object.fromEntries(
     BLACKLIST_STABLECOINS.map((s) => [s, 0]),
   ) as Record<BlacklistStablecoin, number>;
-
-  if (useLegacyEventPath) {
-    const activeHistory = await queryLatestEventTypeHistory(db);
-    const latestByAddr = deriveLatestByIdentity(activeHistory);
-    const activeRecordEvents = activeHistory.length > 0 ? activeHistory : latestByAddr;
-    const frozenAddresses = latestByAddr.filter((e) => e.eventType === "blacklist").length;
-    for (const row of latestByAddr) {
-      if (row.eventType !== "blacklist") continue;
-      if (!isBlacklistStablecoin(row.stablecoin)) continue;
-      perCoinFrozenAddressCount[row.stablecoin] += 1;
-    }
-    const activeStats = computeBlacklistActiveSummaryStats(
-      buildBlacklistActiveRecords(activeRecordEvents, currentBalances),
-    );
-    return { activeRecordEvents, frozenAddresses, perCoinFrozenAddressCount, activeStats };
+  for (const record of activeRecords) {
+    if (record.destroyedAt != null) continue;
+    if (!isBlacklistStablecoin(record.stablecoin)) continue;
+    perCoinFrozenAddressCount[record.stablecoin] += 1;
   }
 
-  const activeRecordEvents = await queryLatestBlacklistEventsForCurrentBalances(db, currentBalances);
-  const frozenAddresses = [...currentBalances.values()].filter((snapshot) => !isDestroySnapshot(snapshot)).length;
-  for (const snapshot of currentBalances.values()) {
-    if (isDestroySnapshot(snapshot)) continue;
-    if (!isBlacklistStablecoin(snapshot.stablecoin)) continue;
-    perCoinFrozenAddressCount[snapshot.stablecoin] += 1;
-  }
-  const activeStats = computeActiveSummaryStatsFromCurrentBalances(currentBalances);
   return { activeRecordEvents, frozenAddresses, perCoinFrozenAddressCount, activeStats };
 }
 


### PR DESCRIPTION
### Motivation
- Fix an incorrect optimization that treated `blacklist_current_balances` ledger rows as the authoritative active set and therefore continued to count preserved snapshots after `unblacklist` events as active frozen addresses. 
- Ensure net active/frozen metrics are derived from latest event history so `unblacklist` events remove identities from the active set as intended.

### Description
- Always derive the active set from latest event history by calling `queryLatestEventTypeHistory()` and building active records with `buildBlacklistActiveRecords(...)`, instead of switching to a snapshot-only shortcut when any `blacklist_current_balances` rows exist. 
- Compute active summary stats using `computeBlacklistActiveSummaryStats(...)` on event-derived active records and count per-coin frozen addresses from those active records, so retained ledger snapshots only hydrate amounts and do not define active identity membership. 
- Remove the legacy snapshot-based shortcut (including the helper that treated every current-balance row as active) and its synthetic-event path so the two branches cannot drift. 
- Add a regression test that proves a preserved current-balance snapshot for an address released by an `unblacklist` event is not counted in `activeAddressCount`, `activeFrozenTotal`, `frozenAddresses`, or per-coin frozen counts while still contributing to tracked ledger totals; update expectations in related tests accordingly.

### Testing
- Ran the focused Vitest suite `npx vitest run worker/src/api/__tests__/blacklist-summary.test.ts`, and all tests in that file passed. 
- Ran worker typecheck with `npm run typecheck:worker` (which executes `cd worker && npx tsc --noEmit`) and it succeeded. 
- Ran repository lint/checks (`git diff --check`) to ensure no leftover whitespace/check failures; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe0e048332a4fb34c2d9401cbd)