### PR TITLE
fix: preserve non-EVM DefiLlama coin casing

### DIFF
--- a/worker/src/cron/__tests__/enrich-prices.test.ts
+++ b/worker/src/cron/__tests__/enrich-prices.test.ts
@@ -470,6 +470,61 @@ describe("enrichMissingPrices", () => {
     expect(stats.finalMissing).toBe(0);
   });
 
+  it("preserves case-sensitive Sui Move identifiers from tracked metadata", async () => {
+    const suiAusdCoinId = "sui:0x2053d08c1e2bd02791056171aab0fd12bd7cd7efad2ab8f6b9c8902f14df2ff2::ausd::AUSD";
+    const assets: PeggedAsset[] = [
+      {
+        id: "ausd-agora", name: "Agora Dollar", symbol: "AUSD", price: 0,
+        pegType: "peggedUSD", circulating: {},
+      },
+    ];
+
+    mockFetch([
+      {
+        match: suiAusdCoinId,
+        body: {
+          coins: {
+            [suiAusdCoinId]: dlQuote(1.0002, "AUSD", { confidence: 0.95 }),
+          },
+        },
+      },
+    ]);
+
+    const result = await runDlContractPasses(assets, undefined);
+
+    expect(result.pass1).toBe(1);
+    expect(assets[0].price).toBe(1.0002);
+    expect(assets[0].priceSource).toBe("defillama-contract");
+  });
+
+  it("preserves colon-rich Move identifiers in explicit chain-qualified addresses", async () => {
+    const suiUsdtCoinId = "sui:0x375f70cf2ae4c00bf37117d0c85a2c71545e6ee05c4a5c7d282cd66a4504b068::usdt::USDT";
+    const assets: PeggedAsset[] = [
+      {
+        id: "sui-usdt-test", name: "Sui USDT", symbol: "USDT", price: 0,
+        address: suiUsdtCoinId,
+        pegType: "peggedUSD", circulating: {},
+      },
+    ];
+
+    mockFetch([
+      {
+        match: suiUsdtCoinId,
+        body: {
+          coins: {
+            [suiUsdtCoinId]: dlQuote(0.9998, "USDT", { confidence: 0.95 }),
+          },
+        },
+      },
+    ]);
+
+    const result = await runDlContractPasses(assets, undefined);
+
+    expect(result.pass1).toBe(1);
+    expect(assets[0].price).toBe(0.9998);
+    expect(assets[0].priceSource).toBe("defillama-contract");
+  });
+
   it("rejects unreasonable DefiLlama contract prices and allows later fallback passes to resolve", async () => {
     const assets: PeggedAsset[] = [
       {

--- a/worker/src/cron/sync-stablecoins/enrich-prices-defillama-pass.ts
+++ b/worker/src/cron/sync-stablecoins/enrich-prices-defillama-pass.ts
@@ -1,5 +1,5 @@
 import { ACTIVE_META_BY_ID } from "@shared/lib/stablecoins/registry";
-import { resolveChainId } from "@shared/lib/chains";
+import { CHAIN_META, resolveChainId } from "@shared/lib/chains";
 import { CIRCUIT_SOURCE, DEFILLAMA_COINS } from "../../lib/constants";
 import { fetchWithRetry } from "../../lib/fetch-retry";
 import { throwIfAborted } from "../../lib/abort";
@@ -30,10 +30,21 @@ const ADDRESS_OVERRIDES: Record<string, string> = {
   "bean-beanstalk": "arbitrum:0xBEA0005B8599265D41256905A9B3073D397812E4",
 };
 
+function isEvmChain(chain: string): boolean {
+  const canonicalChain = resolveChainId(chain);
+  return canonicalChain != null && CHAIN_META[canonicalChain]?.type === "evm";
+}
+
+function normalizeAddressForDefiLlamaChain(chain: string, address: string): string {
+  return isEvmChain(chain) && address.startsWith("0x") ? address.toLowerCase() : address;
+}
+
 function addressToCoinId(address: string): string {
-  if (address.includes(":")) {
-    const [chain, rawAddress] = address.split(":", 2);
-    return rawAddress?.startsWith("0x") ? `${chain}:${rawAddress.toLowerCase()}` : address;
+  const separatorIndex = address.indexOf(":");
+  if (separatorIndex >= 0) {
+    const chain = address.slice(0, separatorIndex);
+    const rawAddress = address.slice(separatorIndex + 1);
+    return `${chain}:${normalizeAddressForDefiLlamaChain(chain, rawAddress)}`;
   }
   if (address.startsWith("0x")) {
     return `ethereum:${address.toLowerCase()}`;
@@ -136,7 +147,7 @@ function isDefiLlamaContractQuoteUsable(
 
 function buildDefiLlamaCoinIdForChainAddress(chain: string, address: string): string {
   const prefix = DL_COINS_CHAIN_PREFIX_BY_CHAIN[chain] ?? chain;
-  const normalizedAddress = address.startsWith("0x") ? address.toLowerCase() : address;
+  const normalizedAddress = normalizeAddressForDefiLlamaChain(chain, address);
   return `${prefix}:${normalizedAddress}`;
 }
 


### PR DESCRIPTION
### Motivation
- A previous normalization change lowercased any `0x`-prefixed value and split colon-qualified identifiers in a way that truncated Move coin types, causing Sui (non-EVM) coin IDs to be lowercased or truncated and breaking DefiLlama fallback lookups. 
- The intent is to keep EVM address normalization while preserving case-sensitive and colon-rich identifiers for non-EVM chains like Sui.

### Description
- Limit EVM-only lowercasing by adding `isEvmChain()` and `normalizeAddressForDefiLlamaChain()` and importing `CHAIN_META` from `@shared/lib/chains`. 
- Change `addressToCoinId()` to split on the first `:` via `indexOf`/`slice` so the full remainder (e.g., Move `::module::TYPE`) is preserved rather than truncated. 
- Apply the same EVM-only normalization in `buildDefiLlamaCoinIdForChainAddress()` so metadata-derived coin IDs for non-EVM chains keep their original casing. 
- Add focused regression tests to `worker/src/cron/__tests__/enrich-prices.test.ts` that assert tracked Sui metadata and explicit chain-qualified Move identifiers resolve via the DefiLlama contract fallback.

### Testing
- Ran the targeted Vitest suite with `npx vitest run worker/src/cron/__tests__/enrich-prices.test.ts --testNamePattern "DefiLlama contract|Sui|Move identifiers|EVM contract casing"` and the added tests passed. 
- Verified TypeScript build with `cd worker && npx tsc --noEmit` which completed successfully. 
- Ran `git diff --check` to ensure no whitespace/errors; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ff4ac88332b8d55cc84d21cf70)