### PR TITLE
Fix Centrifuge vault NAV drift detection

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts
@@ -55,8 +55,11 @@ describe("fetchCentrifugeVaultReserves", () => {
       if (body.params[0].data === "0x18160ddd") {
         return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000064" });
       }
+      if (body.params[0].data === "0x313ce567") {
+        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000006" });
+      }
       if (body.params[0].data.startsWith("0x07a2d13a")) {
-        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000064" });
+        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000001" });
       }
       return null;
     });
@@ -80,7 +83,9 @@ describe("fetchCentrifugeVaultReserves", () => {
       assetAddress: USDC_ASSET,
       totalAssetsRaw: "100",
       totalSupplyRaw: "100",
-      convertToAssetsRaw: "100",
+      convertToAssetsRaw: "1",
+      shareDecimals: 6,
+      assetDecimals: 6,
       collateralizationRatio: 1,
       details: {
         proofKind: "centrifuge-vault-total-assets",
@@ -115,7 +120,7 @@ describe("fetchCentrifugeVaultReserves", () => {
     ).rejects.toThrow(/asset\(\) returned/);
   });
 
-  it("emits degraded warning when convertToAssets diverges from totalAssets by >1%", async () => {
+  it("emits degraded warning when normalized share price diverges from 1:1 by >1%", async () => {
     fetchWithRetryMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as { params: [{ data: string }] };
       if (body.params[0].data === "0x38d52e0f") {
@@ -124,13 +129,16 @@ describe("fetchCentrifugeVaultReserves", () => {
         });
       }
       if (body.params[0].data === "0x01e1d114") {
-        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000064" });
+        return jsonResponse({ result: "0x000000000000000000000000000000000000000000000000000000000000006e" });
       }
       if (body.params[0].data === "0x18160ddd") {
         return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000064" });
       }
+      if (body.params[0].data === "0x313ce567") {
+        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000006" });
+      }
       if (body.params[0].data.startsWith("0x07a2d13a")) {
-        return jsonResponse({ result: "0x000000000000000000000000000000000000000000000000000000000000006e" });
+        return jsonResponse({ result: "0x0000000000000000000000000000000000000000000000000000000000000001" });
       }
       return null;
     });

--- a/worker/src/cron/reserve-adapters/centrifuge-vault.ts
+++ b/worker/src/cron/reserve-adapters/centrifuge-vault.ts
@@ -1,20 +1,23 @@
 import type { StablecoinMeta } from "@shared/types/core";
 import type { LiveReserveWarning, LiveReservesConfig } from "@shared/types/live-reserves";
 import { parseLiveReserveAdapterParams } from "@shared/lib/live-reserve-adapters";
-import { TOTAL_SUPPLY_SELECTOR } from "../../lib/evm-selectors";
+import { DECIMALS_SELECTOR, TOTAL_SUPPLY_SELECTOR, encodeUint256 } from "../../lib/evm-selectors";
 import type { AdapterContext, AdapterResult } from "./types";
 import { parseEvmAddressResult, resolveCoinContractAddress } from "./evm";
 import {
+  fetchOnchainUint256,
   notApplicableFreshnessMetadata,
   requireOnchainInput,
+  reserveDegradedWarning,
   reserveInfoWarning,
 } from "./helpers";
 import {
   ERC4626_ASSET_SELECTOR,
+  ERC4626_CONVERT_TO_ASSETS_SELECTOR,
   ERC4626_TOTAL_ASSETS_SELECTOR,
-  computeErc4626CollateralizationRatio,
   makeContractRawCaller,
 } from "./erc4626";
+import { decimalNumberFromBigInt, parseBoundedDecimals } from "./slice-math";
 
 /**
  * Centrifuge V3 / ERC-7540 vault adapter.
@@ -156,27 +159,53 @@ export async function fetchCentrifugeVaultReserves(
 
   const assetAddress = assetResult ? parseEvmAddressResult(assetResult as `0x${string}`) : null;
   if (!assetAddress) {
-    throw new Error(
-      `ERC-7540 asset() could not be read for ${coin.id}; expected ${expectedAssetAddress}`,
-    );
+    throw new Error(`ERC-7540 asset() could not be read for ${coin.id}; expected ${expectedAssetAddress}`);
   }
   if (assetAddress !== expectedAssetAddress) {
-    throw new Error(
-      `ERC-7540 asset() returned ${assetAddress}, expected ${expectedAssetAddress} for ${coin.id}`,
-    );
+    throw new Error(`ERC-7540 asset() returned ${assetAddress}, expected ${expectedAssetAddress} for ${coin.id}`);
   }
 
   const warnings: LiveReserveWarning[] = [];
 
-  // NAV cross-check: convertToAssets(totalSupply) vs totalAssets().
-  const navCheck = await computeErc4626CollateralizationRatio({
-    call,
-    totalAssetsRaw,
-    totalSupplyRaw,
-    warningCode: "centrifuge-vault-nav-divergence",
+  // NAV cross-check: compare the asset/share price against 1:1 after decimal normalization.
+  let collateralizationRatio: number | undefined;
+  let convertToAssetsRaw: bigint | undefined;
+  const shareDecimalsRaw = await call(DECIMALS_SELECTOR);
+  const assetDecimalsRaw = await fetchOnchainUint256({
+    contract: assetAddress,
+    data: DECIMALS_SELECTOR,
+    signal,
+    ctx: _ctx,
+    rpcMode: primaryInput.rpcMode,
+    chain: primaryInput.chain,
+    rpcUrl: params.rpcUrl,
+    fallbackRpcUrl: params.fallbackRpcUrl,
+    timeoutMs: timeout,
   });
-  const { collateralizationRatio, convertToAssetsRaw } = navCheck;
-  warnings.push(...navCheck.warnings);
+  const shareDecimals = shareDecimalsRaw == null ? null : parseBoundedDecimals(BigInt(shareDecimalsRaw));
+  const assetDecimals = parseBoundedDecimals(assetDecimalsRaw);
+
+  if (totalSupplyRaw != null && totalSupplyRaw > 0n && shareDecimals != null && assetDecimals != null) {
+    const shareUnit = 10n ** BigInt(shareDecimals);
+    const convertResult = await call(`${ERC4626_CONVERT_TO_ASSETS_SELECTOR}${encodeUint256(shareUnit)}`);
+    if (convertResult) {
+      convertToAssetsRaw = BigInt(convertResult);
+    }
+
+    const assets = decimalNumberFromBigInt(totalAssetsRaw, assetDecimals);
+    const shares = decimalNumberFromBigInt(totalSupplyRaw, shareDecimals);
+    if (shares > 0) {
+      collateralizationRatio = assets / shares;
+      if (Number.isFinite(collateralizationRatio) && Math.abs(collateralizationRatio - 1) > 0.01) {
+        warnings.push(
+          reserveDegradedWarning(
+            "centrifuge-vault-nav-divergence",
+            `Centrifuge vault share price diverges from 1:1 by ${((collateralizationRatio - 1) * 100).toFixed(2)}%`,
+          ),
+        );
+      }
+    }
+  }
 
   return {
     slices: [
@@ -198,13 +227,13 @@ export async function fetchCentrifugeVaultReserves(
       assetAddress,
       ...(totalSupplyRaw != null ? { totalSupplyRaw: totalSupplyRaw.toString() } : {}),
       ...(convertToAssetsRaw != null ? { convertToAssetsRaw: convertToAssetsRaw.toString() } : {}),
-      ...(collateralizationRatio != null && Number.isFinite(collateralizationRatio)
-        ? { collateralizationRatio }
-        : {}),
+      ...(shareDecimals != null ? { shareDecimals } : {}),
+      ...(assetDecimals != null ? { assetDecimals } : {}),
+      ...(collateralizationRatio != null && Number.isFinite(collateralizationRatio) ? { collateralizationRatio } : {}),
       redemption: {
         capacityKind: "documented-eventual" as const,
         freshnessKind: "same-run-onchain" as const,
-        routeStatus: warnings.length > 0 ? "degraded" as const : "unknown" as const,
+        routeStatus: warnings.length > 0 ? ("degraded" as const) : ("unknown" as const),
         ...(warnings.length > 0 ? { routeStatusSource: "onchain" as const } : {}),
       },
     },

--- a/worker/src/cron/reserve-adapters/erc4626.ts
+++ b/worker/src/cron/reserve-adapters/erc4626.ts
@@ -10,7 +10,7 @@ type EvmInput = Extract<LiveReserveInput, { kind: "onchain-evm" }>;
 
 export const ERC4626_TOTAL_ASSETS_SELECTOR = "0x01e1d114";
 export const ERC4626_ASSET_SELECTOR = "0x38d52e0f";
-const ERC4626_CONVERT_TO_ASSETS_SELECTOR = "0x07a2d13a";
+export const ERC4626_CONVERT_TO_ASSETS_SELECTOR = "0x07a2d13a";
 
 export type ContractRawCaller = (data: string) => Promise<string | null>;
 


### PR DESCRIPTION
### Motivation
- The Centrifuge vault adapter computed a tautological NAV ratio by dividing `convertToAssets(totalSupply)` by `totalAssets`, which for ERC-4626-compliant contracts will usually be ~1 and therefore fails to detect share-price drift from 1:1.
- JTRSY was promoted to use this adapter, so the incorrect check could silently omit the intended `centrifuge-vault-nav-divergence` warning and leave redemption `routeStatus` as `unknown` instead of `degraded` when share-price drift exists.

### Description
- Replace the NAV cross-check with a decimal-normalized assets-per-share comparison that computes `totalAssets / totalSupply` using on-chain decimals and flags a >1% divergence from 1:1 as a `centrifuge-vault-nav-divergence` degraded warning.
- Preserve the existing `convertToAssets` probe by exporting the convert selector and calling `convertToAssets(shareUnit)` (one whole share unit) to retain `convertToAssetsRaw` metadata without using `convertToAssets(totalSupply)` for the drift check.
- Add `shareDecimals` and `assetDecimals` to the metadata and retain `convertToAssetsRaw` and `collateralizationRatio` when available, and keep redemption `routeStatus` degraded when warnings are emitted.
- Changes made in `worker/src/cron/reserve-adapters/centrifuge-vault.ts`, a small export added in `worker/src/cron/reserve-adapters/erc4626.ts`, and the focused unit test `worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts` was updated to assert the intended behavior.

### Testing
- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/centrifuge-vault.test.ts`, and the focused test file passed (6 tests passed).
- Ran `cd worker && npx tsc --noEmit` and the TypeScript build check succeeded with no errors.
- Ran `git diff --check` to validate whitespace/format issues and there were no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a351afd06548332bd8ff350a26920f4)