### PR TITLE
fix(freezewatch): clear chainId alias on filter updates

### DIFF
--- a/src/app/freezewatch/view-model.test.tsx
+++ b/src/app/freezewatch/view-model.test.tsx
@@ -243,6 +243,32 @@ describe("useFreezeWatchPageController", () => {
     expect(result.current.rangeEnd).toBe(0);
   });
 
+  it("removes stale chainId alias when updating the chain filter", () => {
+    currentSearch = "?chainId=ethereum&page=2";
+    const { result, rerender } = renderHook(() => useFreezeWatchPageController());
+
+    expect(result.current.chainFilter).toBe("ethereum");
+
+    act(() => {
+      result.current.handleChainChange("all");
+    });
+
+    let nextParams = new URLSearchParams(currentSearch);
+    expect(nextParams.get("chain")).toBeNull();
+    expect(nextParams.get("chainId")).toBeNull();
+    expect(nextParams.get("page")).toBeNull();
+
+    currentSearch = "?chainId=ethereum";
+    rerender();
+    act(() => {
+      result.current.handleChainChange("tron");
+    });
+
+    nextParams = new URLSearchParams(currentSearch);
+    expect(nextParams.get("chain")).toBe("tron");
+    expect(nextParams.get("chainId")).toBeNull();
+  });
+
   it("resets page to 1 when applying a new filter", () => {
     currentSearch = "?page=3";
     const { result } = renderHook(() => useFreezeWatchPageController());

--- a/src/app/freezewatch/view-model.ts
+++ b/src/app/freezewatch/view-model.ts
@@ -157,6 +157,7 @@ export function useFreezeWatchPageController() {
         if (next.stablecoinFilter !== "all") params.set("stablecoin", next.stablecoinFilter);
         else params.delete("stablecoin");
 
+        params.delete("chainId");
         if (next.chainFilter !== "all") params.set("chain", next.chainFilter);
         else params.delete("chain");
 


### PR DESCRIPTION
### Motivation
- The FreezeWatch page accepted `?chainId=...` as an alias for the canonical `chain` query parameter but filter serialization only wrote/deleted `chain`, leaving stale `chainId` values in the URL and making the chain filter sticky.
- This caused shared URLs like `/freezewatch/?chainId=ethereum` to resurrect the chain filter after users cleared it via the UI.

### Description
- Delete the legacy alias before serializing the canonical chain parameter by calling `params.delete("chainId")` in `useFreezeWatchPageController`'s `updateFilters` implementation in `src/app/freezewatch/view-model.ts`.
- Add a focused regression test in `src/app/freezewatch/view-model.test.tsx` that starts from `?chainId=ethereum`, verifies clearing the chain removes both `chain` and `chainId`, and verifies changing the chain writes only `chain`.
- No other filter serialization behavior was changed; other query keys are still set/deleted as before.

### Testing
- Ran `npx vitest run src/app/freezewatch/view-model.test.tsx --reporter verbose` and all tests in that file passed (10 tests, 10 passed).
- Ran `git diff --check` to ensure no whitespace/patch issues and it reported clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516ffaab083328d82a16b8163ce48)