### PR TITLE
Fix Telegram /list per-coin snooze visibility

### DIFF
--- a/worker/src/api/telegram-store/subscriptions.ts
+++ b/worker/src/api/telegram-store/subscriptions.ts
@@ -144,7 +144,7 @@ export async function loadSubscriptionRowsByChat(
 ): Promise<SubscriptionRow[]> {
   const result = await db
     .prepare(
-      `SELECT stablecoin_id, alert_dews, alert_depeg, alert_safety, alert_launch, alert_reserve, dews_min_band, safety_mode, depeg_worsening_bps_step
+      `SELECT stablecoin_id, alert_dews, alert_depeg, alert_safety, alert_launch, alert_reserve, dews_min_band, safety_mode, depeg_worsening_bps_step, alert_snooze_until_ts
          FROM telegram_subscriptions
         WHERE chat_id = ?
         ORDER BY stablecoin_id`,

--- a/worker/src/api/webhook-commands/__tests__/command-handlers.test.ts
+++ b/worker/src/api/webhook-commands/__tests__/command-handlers.test.ts
@@ -407,6 +407,29 @@ describe("webhook command handlers", () => {
     expectMiniAppButton(buttons, "Browse presets", "presets");
   });
 
+  it("/list loads per-coin snooze state for subscription summaries", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const db = mockD1([
+      { match: "FROM telegram_subscribers", rows: [], first: subscriberRow() },
+      {
+        match: "FROM telegram_subscriptions",
+        rows: [subscriptionRow({ alert_snooze_until_ts: nowSec + 2 * 3600 })],
+      },
+      { match: "FROM telegram_preset_subscriptions", rows: [] },
+    ]);
+    const replyToChatWithMarkup = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeContext({ db, replyToChatWithMarkup });
+
+    await handleList(ctx, "");
+
+    const subscriptionSelect = db.getHistory().find((entry) =>
+      entry.sql.includes("FROM telegram_subscriptions"),
+    );
+    expect(subscriptionSelect?.sql).toContain("alert_snooze_until_ts");
+    const [message] = replyToChatWithMarkup.mock.calls[0]!;
+    expect(message).toContain("USDC (usdc-circle): DEWS · per-coin — snoozed for 2 h");
+  });
+
   it("/cancel without pending state gives recovery commands", async () => {
     const replyToChat = vi.fn().mockResolvedValue(undefined);
     const ctx = makeContext({ replyToChat });


### PR DESCRIPTION
### Motivation
- A refactor of the Telegram command handlers removed `alert_snooze_until_ts` from the subscription `SELECT`, so `/list` could not detect or render active per-coin snooze countdowns and thus hid snooze state from users.

### Description
- Restored `alert_snooze_until_ts` in the subscription query returned by `loadSubscriptionRowsByChat` in `worker/src/api/telegram-store/subscriptions.ts` so row objects include per-coin snooze state.
- Added a focused test in `worker/src/api/webhook-commands/__tests__/command-handlers.test.ts` that verifies the `/list` handler issues a `SELECT` including `alert_snooze_until_ts` and that the rendered message shows the per-coin snooze countdown.

### Testing
- Ran the focused Vitest suites with `npx --no-install vitest run worker/src/api/webhook-commands/__tests__/command-handlers.test.ts worker/src/api/__tests__/telegram-webhook-messages.test.ts` and all tests passed (54 passed, 0 failed).
- Ran the TypeScript check `cd worker && npx tsc --noEmit` and the build type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fe61908332a7dca23c69ff8643)