### PR TITLE
Protect global Telegram alerts from inactive cleanup

### DIFF
--- a/worker/src/cron/__tests__/telegram-inactive-cleanup.test.ts
+++ b/worker/src/cron/__tests__/telegram-inactive-cleanup.test.ts
@@ -39,6 +39,11 @@ beforeEach(() => {
 interface SubscriberRow {
   chat_id: string;
   last_active_at: number;
+  global_alert_dews?: number;
+  global_alert_depeg?: number;
+  global_alert_safety?: number;
+  global_alert_launch?: number;
+  global_alert_reserve?: number;
 }
 
 interface ChildRow {
@@ -214,8 +219,14 @@ function createStubDb(state: StubState): D1Database {
             || state.presets.some((r) => r.chat_id === chatId)
             || state.pendingAlerts.some((r) => r.chat_id === chatId)
             || state.pendingDisambig.some((r) => r.chat_id === chatId);
+          const hasGlobalAlert = (sub: SubscriberRow) =>
+            sub.global_alert_dews === 1
+            || sub.global_alert_depeg === 1
+            || sub.global_alert_safety === 1
+            || sub.global_alert_launch === 1
+            || sub.global_alert_reserve === 1;
           const eligible = state.subscribers
-            .filter((sub) => sub.last_active_at < cutoffSec && !hasChild(sub.chat_id))
+            .filter((sub) => sub.last_active_at < cutoffSec && !hasChild(sub.chat_id) && !hasGlobalAlert(sub))
             .sort((a, b) => a.last_active_at - b.last_active_at)
             .slice(0, limit)
             .map((row) => ({ chat_id: row.chat_id }));
@@ -315,6 +326,51 @@ describe("runTelegramInactiveCleanup", () => {
       "has-pending-disambig",
       "has-preset",
       "has-sub",
+    ]);
+  });
+
+  it("preserves inactive subscribers that only have global alert flags", async () => {
+    const state = makeState();
+    const now = Math.floor(Date.now() / 1000);
+    state.subscribers.push(
+      {
+        chat_id: "global-dews",
+        last_active_at: now - INACTIVE_RETENTION_SEC - 1,
+        global_alert_dews: 1,
+      },
+      {
+        chat_id: "global-depeg",
+        last_active_at: now - INACTIVE_RETENTION_SEC - 1,
+        global_alert_depeg: 1,
+      },
+      {
+        chat_id: "global-safety",
+        last_active_at: now - INACTIVE_RETENTION_SEC - 1,
+        global_alert_safety: 1,
+      },
+      {
+        chat_id: "global-launch",
+        last_active_at: now - INACTIVE_RETENTION_SEC - 1,
+        global_alert_launch: 1,
+      },
+      {
+        chat_id: "global-reserve",
+        last_active_at: now - INACTIVE_RETENTION_SEC - 1,
+        global_alert_reserve: 1,
+      },
+      { chat_id: "eligible", last_active_at: now - INACTIVE_RETENTION_SEC - 1 },
+    );
+    const db = createStubDb(state);
+
+    const result = await runTelegramInactiveCleanup(db);
+
+    expect(result.itemCount).toBe(1);
+    expect(state.subscribers.map((row) => row.chat_id).sort()).toEqual([
+      "global-depeg",
+      "global-dews",
+      "global-launch",
+      "global-reserve",
+      "global-safety",
     ]);
   });
 

--- a/worker/src/cron/telegram-inactive-cleanup.ts
+++ b/worker/src/cron/telegram-inactive-cleanup.ts
@@ -17,6 +17,7 @@ import { runBoundedQueue } from "./shared/bounded-queue";
  *       `telegram_preset_subscriptions`
  *       `telegram_pending_alerts`
  *       `telegram_pending_disambiguation`
+ *   - no `global_alert_*` flags are enabled on `telegram_subscribers`
  *
  * Cap at `MAX_DELETIONS_PER_RUN` per invocation so a large backlog cannot
  * push the daily-0300 slot past D1's per-statement budget. The cleanup is
@@ -68,6 +69,11 @@ async function loadCandidateChats(db: D1Database, cutoffSec: number, limit: numb
           AND ps.chat_id IS NULL
           AND pa.chat_id IS NULL
           AND pd.chat_id IS NULL
+          AND s.global_alert_dews = 0
+          AND s.global_alert_depeg = 0
+          AND s.global_alert_safety = 0
+          AND s.global_alert_launch = 0
+          AND s.global_alert_reserve = 0
         ORDER BY s.last_active_at ASC
         LIMIT ?`,
     )


### PR DESCRIPTION
### Motivation
- The weekly `telegram-inactive-cleanup` cron was selecting stale subscribers only by age and absence of child rows and thus could delete chats that still had active `global_alert_*` flags stored on `telegram_subscribers`, silently unsubscribing them.
- The fix prevents data-loss of users who enabled global alerts (which are treated elsewhere as deliverable subscriptions) while remaining inactive.

### Description
- Updated the candidate selection SQL in `worker/src/cron/telegram-inactive-cleanup.ts` to exclude rows where any `s.global_alert_dews`, `s.global_alert_depeg`, `s.global_alert_safety`, `s.global_alert_launch`, or `s.global_alert_reserve` is set (require all to be `0`).
- Clarified the function comment to document that global flags are considered when deciding deletions.
- Extended the focused cron test stub in `worker/src/cron/__tests__/telegram-inactive-cleanup.test.ts` to model `global_alert_*` columns and added a regression test that proves stale global-only subscribers are preserved while an otherwise-empty stale subscriber is deleted.
- Kept existing behavior: warn-pass, per-run caps (`MAX_DELETIONS_PER_RUN`), cache guard, and the deletion cascade via `forgetSubscriber` remain unchanged.

### Testing
- Ran the focused unit suite with `npx vitest run worker/src/cron/__tests__/telegram-inactive-cleanup.test.ts --reporter=dot` and all tests passed.
- Verified cron trigger budgets with `npm run check:cron-connections` and the job stayed within budget.
- Type-checked the worker code with `cd worker && npx tsc --noEmit` with no errors.
- Ran `git diff --check` to ensure no whitespace or diff issues; no problems found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3516fef6088332bf8ba8710d3d7050)