### PR TITLE
Fix peg chart guard for yield-bearing stablecoins

### DIFF
--- a/src/app/stablecoin/[id]/client.test.tsx
+++ b/src/app/stablecoin/[id]/client.test.tsx
@@ -297,6 +297,49 @@ describe("StablecoinDetailClient", () => {
     expect(screen.getAllByText("Sky Dollar").length).toBeGreaterThan(0);
   });
 
+  it("uses the market data section for non-yield-bearing USD assets with supply history", () => {
+    const coin = TRACKED_META_BY_ID.get("usds-sky")!;
+    useStablecoinDetailViewModelMock.mockReturnValue(makeReadyViewModel({
+      supplyHistory: [{ date: "2026-01-01", mcap: 100, price: 1, supply: 100 }],
+    }));
+
+    const { container } = render(
+      <StablecoinDetailClient id={coin.id} coin={coin} summary={null} staticCoin={buildStablecoinStaticMeta(coin)} />,
+    );
+
+    expect(container.querySelector("#chart")).toBeNull();
+    expect(screen.getAllByTestId("dynamic-detail-section").length).toBeGreaterThan(0);
+  });
+
+  it("keeps yield-bearing USD assets on the mcap chart instead of the peg chart", () => {
+    const coin = TRACKED_META_BY_ID.get("usds-sky")!;
+    const yieldBearingCoin = {
+      ...coin,
+      flags: {
+        ...coin.flags,
+        yieldBearing: true,
+        navToken: false,
+        pegCurrency: "USD" as const,
+      },
+    };
+    useStablecoinDetailViewModelMock.mockReturnValue(makeReadyViewModel({
+      coin: yieldBearingCoin,
+      isNavToken: false,
+      supplyHistory: [{ date: "2026-01-01", mcap: 100, price: 1.01, supply: 99 }],
+    }));
+
+    const { container } = render(
+      <StablecoinDetailClient
+        id={yieldBearingCoin.id}
+        coin={yieldBearingCoin}
+        summary={null}
+        staticCoin={buildStablecoinStaticMeta(yieldBearingCoin)}
+      />,
+    );
+
+    expect(container.querySelector("#chart")).toBeTruthy();
+  });
+
   it("mounts redemption backstop data in the liquidity zone", () => {
     const coin = TRACKED_META_BY_ID.get("usds-sky")!;
     useStablecoinDetailViewModelMock.mockReturnValue(makeReadyViewModel({

--- a/src/app/stablecoin/[id]/client.tsx
+++ b/src/app/stablecoin/[id]/client.tsx
@@ -341,7 +341,10 @@ export default function StablecoinDetailClient({
     />
   ) : null;
   const showPegChart =
-    viewModel.coin.flags.pegCurrency === "USD" && !viewModel.isNavToken && viewModel.supplyHistory.length > 0;
+    viewModel.coin.flags.pegCurrency === "USD" &&
+    !viewModel.isNavToken &&
+    viewModel.coin.flags.yieldBearing !== true &&
+    viewModel.supplyHistory.length > 0;
   const archetypeOverride = viewModel.coin.archetypeOverride === true;
   const isWrapperVariant = viewModel.isVariant && !archetypeOverride;
   const parentArchetype =


### PR DESCRIPTION
### Motivation
- The peg-deviation market chart should be hidden for NAV or yield-bearing products because their price can drift by design, but the previous render guard only excluded NAV tokens and allowed `yieldBearing: true` USD assets to show the peg chart.

### Description
- Require `viewModel.coin.flags.yieldBearing !== true` in the `showPegChart` guard in `src/app/stablecoin/[id]/client.tsx` so only non-yield-bearing USD assets with supply history render the peg-deviation/MarketDataSection, and add focused tests in `src/app/stablecoin/[id]/client.test.tsx` validating both the allowed peg-chart path and the yield-bearing fallback to the mcap chart.

### Testing
- Ran `npx vitest run src/app/stablecoin/'[id]'/client.test.tsx --reporter=verbose` and the file's tests passed (10/10).
- Ran `npm run typecheck` and TypeScript type checking succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35167334348332992ae6553bbfd2e5)