### PR TITLE
fix(telegram): avoid missing preset columns in overflow validation

### DIFF
--- a/worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts
+++ b/worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts
@@ -506,7 +506,14 @@ describe("dispatchTelegramAlerts", () => {
     expect(metadata.cappedAtLimit).toBe(true);
     expect(formatConsolidatedMessageSpy).toHaveBeenCalledTimes(1);
     expect(mockSendToChat).not.toHaveBeenCalled();
-    expect(db.getHistory().some((entry) => entry.sql.includes("INSERT INTO telegram_pending_alerts"))).toBe(true);
+    const history = db.getHistory();
+    expect(history.some((entry) => entry.sql.includes("INSERT INTO telegram_pending_alerts"))).toBe(true);
+    const activeOverflowQuery = history.find((entry) => entry.sql.includes("SELECT s.chat_id"));
+    expect(activeOverflowQuery?.sql).toContain("preset.alert_dews = 1");
+    expect(activeOverflowQuery?.sql).toContain("preset.alert_depeg = 1");
+    expect(activeOverflowQuery?.sql).toContain("preset.alert_safety = 1");
+    expect(activeOverflowQuery?.sql).not.toContain("preset.alert_launch");
+    expect(activeOverflowQuery?.sql).not.toContain("preset.alert_reserve");
 
     const overflowBacklogWrite = mockSetCache.mock.calls.find((call) =>
       call[1] === "telegram:dispatch-overflow-plan"

--- a/worker/src/cron/dispatch-telegram-delivery.ts
+++ b/worker/src/cron/dispatch-telegram-delivery.ts
@@ -137,16 +137,10 @@ async function loadActiveOverflowSubscriberPlanKeys(
                 CASE WHEN s.global_alert_launch = 1 OR EXISTS (
                   SELECT 1 FROM telegram_subscriptions sub
                    WHERE sub.chat_id = s.chat_id AND sub.alert_launch = 1
-                ) OR EXISTS (
-                  SELECT 1 FROM telegram_preset_subscriptions preset
-                   WHERE preset.chat_id = s.chat_id AND preset.alert_launch = 1
                 ) THEN 1 ELSE 0 END AS launch_active,
                 CASE WHEN s.global_alert_reserve = 1 OR EXISTS (
                   SELECT 1 FROM telegram_subscriptions sub
                    WHERE sub.chat_id = s.chat_id AND sub.alert_reserve = 1
-                ) OR EXISTS (
-                  SELECT 1 FROM telegram_preset_subscriptions preset
-                   WHERE preset.chat_id = s.chat_id AND preset.alert_reserve = 1
                 ) THEN 1 ELSE 0 END AS reserve_active
            FROM telegram_subscribers s
           WHERE s.chat_id IN (${inClause.sql})`,


### PR DESCRIPTION
### Motivation
- Prevent scheduled Telegram dispatch runs from failing with D1/SQLite "no such column" errors when overflow revalidation queries reference nonexistent preset columns for `launch` and `reserve`.
- Keep overflow-tail enqueue behavior unchanged while ensuring preset-backed checks only reference columns that actually exist on `telegram_preset_subscriptions`.

### Description
- Remove `telegram_preset_subscriptions` EXISTS predicates for `alert_launch` and `alert_reserve` from the active-overflow validation SQL in `worker/src/cron/dispatch-telegram-delivery.ts`, leaving direct subscription and global-flag checks intact for those alert types.
- Preserve preset-backed predicates for the alert types that exist on `telegram_preset_subscriptions` (`alert_dews`, `alert_depeg`, `alert_safety`).
- Add a regression assertion to `worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts` that inspects the prepared overflow revalidation SQL and asserts it contains `preset.alert_dews|alert_depeg|alert_safety` and does not contain `preset.alert_launch|preset.alert_reserve`.

### Testing
- Ran the focused Vitest file with a pattern: `npx vitest run worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts --testNamePattern "drains stored overflow plans during an eventless run|does not enqueue cached overflow plans"` and the tests passed.
- Ran the full test file: `npx vitest run worker/src/cron/__tests__/dispatch-telegram-alerts.test.ts` and all tests passed.
- Performed TypeScript check: `cd worker && npx tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355f903e608332acae47c44923b305)