### PR TITLE
Preserve live-reserve breaker cleanup allowlist

### DIFF
--- a/worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts
+++ b/worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts
@@ -5,6 +5,7 @@ import { mockD1, type MockD1Database, type MockTableConfig } from "../../test-he
 import {
   CONFIGURED_COINS,
   SYNC_ORDERED_CONFIGURED_COINS,
+  breakerKeyForConfig,
   orderConfiguredCoinsForSync,
   type ConfiguredCoin,
 } from "../sync-live-reserves-shared";
@@ -53,6 +54,8 @@ interface RunMetadata {
   cursorRecordedAt?: number | null;
   cursorTailCompletedAt?: number | null;
   runBudgetTruncationCount?: number;
+  artifactCleanup?: { breakerCacheDeleted?: number };
+  breakerKeys?: string[];
 }
 
 function mockAdapterRegistry(
@@ -229,7 +232,15 @@ describe("syncLiveReserves orchestrator run-budget behavior", () => {
 
     activeRun = 2;
     nowMs = 1_700_100_000_000;
-    const resumedDb = mockD1([cursorTable(cursorValue)]);
+    const headBreakerCacheKey = `circuit:${breakerKeyForConfig(SYNC_ORDERED_CONFIGURED_COINS[0]!.liveReservesConfig!)}`;
+    const staleBreakerCacheKey = "circuit:live-reserves:removed-adapter";
+    const resumedDb = mockD1([
+      cursorTable(cursorValue),
+      {
+        match: "SELECT key FROM cache WHERE key LIKE 'circuit:live-reserves:%'",
+        rows: [{ key: headBreakerCacheKey }, { key: staleBreakerCacheKey }],
+      },
+    ]);
     const secondRun = await syncLiveReserves(resumedDb, new AbortController().signal, {}, undefined, TIGHT_BUDGET);
     const secondMetadata = parseMetadata(secondRun?.metadata);
 
@@ -242,6 +253,14 @@ describe("syncLiveReserves orchestrator run-budget behavior", () => {
     expect(secondMetadata.synced).toBe(CONFIGURED_COIN_COUNT - cursorIndex);
     expect(secondMetadata.total).toBe(CONFIGURED_COIN_COUNT - cursorIndex);
     expect(secondMetadata.deferredCoins).toBe(0);
+    expect(secondMetadata.breakerKeys).not.toContain(headBreakerCacheKey.slice("circuit:".length));
+    expect(secondMetadata.artifactCleanup?.breakerCacheDeleted).toBe(1);
+
+    const breakerDeletes = resumedDb.getHistory().filter((entry) => (
+      entry.sql.includes("DELETE FROM cache WHERE key")
+    ));
+    expect(breakerDeletes.some((entry) => entry.binds.includes(headBreakerCacheKey))).toBe(false);
+    expect(breakerDeletes.some((entry) => entry.binds.includes(staleBreakerCacheKey))).toBe(true);
 
     // The evidence-class ordering keeps independents at the queue head, so a
     // truncation this early defers an independent coin — and the cursored

--- a/worker/src/cron/sync-live-reserves-finalize.ts
+++ b/worker/src/cron/sync-live-reserves-finalize.ts
@@ -14,6 +14,7 @@ import {
 } from "../lib/live-reserves-store";
 import {
   CONFIGURED_COINS,
+  CONFIGURED_LIVE_RESERVE_BREAKER_KEYS,
   type ReserveAttemptFailureSummary,
 } from "./sync-live-reserves-shared";
 import {
@@ -199,7 +200,7 @@ export async function finalizeReserveSyncRun(args: FinalizeReserveSyncRunArgs): 
     artifactCleanup = await cleanupStaleLiveReserveArtifacts(
       args.db,
       CONFIGURED_COINS.map((coin) => coin.id),
-      args.breakerKeys,
+      CONFIGURED_LIVE_RESERVE_BREAKER_KEYS,
     );
   } catch (error) {
     artifactCleanupWarnings.push(

--- a/worker/src/cron/sync-live-reserves-shared.ts
+++ b/worker/src/cron/sync-live-reserves-shared.ts
@@ -59,6 +59,9 @@ export function orderConfiguredCoinsForSync(
 }
 
 export const SYNC_ORDERED_CONFIGURED_COINS = orderConfiguredCoinsForSync(CONFIGURED_COINS);
+export const CONFIGURED_LIVE_RESERVE_BREAKER_KEYS = new Set(
+  CONFIGURED_COINS.map((coin) => breakerKeyForConfig(coin.liveReservesConfig!)),
+);
 
 export interface ReserveAttemptFailureSummary {
   source: "primary" | "fallback";


### PR DESCRIPTION
### Motivation
- Fix a logic bug where cursor-resumed live-reserve runs supplied a suffix-only per-run `breakerKeys` to artifact cleanup, which could delete active circuit-breaker cache rows for configured coins before the cursor.
- Ensure artifact cleanup uses the full set of configured live-reserve breaker keys so active breakers are never removed by a resumed tail run.

### Description
- Add `CONFIGURED_LIVE_RESERVE_BREAKER_KEYS` (a Set of all configured live-reserve breaker keys) in `worker/src/cron/sync-live-reserves-shared.ts`.
- Use `CONFIGURED_LIVE_RESERVE_BREAKER_KEYS` as the allowlist passed to `cleanupStaleLiveReserveArtifacts` during finalization in `worker/src/cron/sync-live-reserves-finalize.ts` so cleanup is independent of the per-run visited/deferred breaker set.
- Keep per-run `breakerKeys` telemetry unchanged (run-scoped) so deferred-run telemetry still reflects only visited coins.
- Extend the orchestrator test `worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts` to assert that cursor-resume runs do not delete pre-cursor active breaker cache rows while still removing stale removed-breaker rows.

### Testing
- Ran targeted unit tests: `npx vitest run worker/src/cron/__tests__/sync-live-reserves-orchestrator.test.ts worker/src/lib/__tests__/live-reserves-store-write.test.ts`, and they passed.
- Type-checked worker code with `cd worker && npx tsc --noEmit`, which succeeded.
- Ran cron schedule and connection checks: `npm run check:cron-sync` and `npm run check:cron-connections`, both of which reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355f8fbb2483328a0bb9854ed7c533)