### PR TITLE
Harden ZSD supplemental market cap pricing

### DIFF
--- a/worker/src/cron/__tests__/zephyr-zsd.test.ts
+++ b/worker/src/cron/__tests__/zephyr-zsd.test.ts
@@ -172,6 +172,26 @@ describe("buildZephyrZsdPeggedAsset", () => {
     });
   });
 
+  it("falls back to peg price for ZSD market cap when supplemental price is unreasonable", () => {
+    const asset = buildZephyrZsdPeggedAsset(
+      makeZsdMeta(),
+      { supply: 1_000, mcapPrice: 1, mcap: 1_000 },
+      {
+        price: 50_000,
+        source: "coingecko",
+        observedAt: 1_700_000_000,
+        observedAtMode: "upstream",
+      },
+      1_700_000_060,
+    );
+
+    expect(asset).toMatchObject({
+      price: 50_000,
+      priceSource: "coingecko",
+      circulating: { peggedUSD: 1_000 },
+    });
+  });
+
   it("uses Zephyr Scanner price as a fallback when the official ZSD price is reported", () => {
     const asset = buildZephyrZsdPeggedAsset(
       makeZsdMeta(),

--- a/worker/src/cron/sync-stablecoins/zephyr-zsd.ts
+++ b/worker/src/cron/sync-stablecoins/zephyr-zsd.ts
@@ -138,12 +138,17 @@ function buildZephyrPeggedAsset(
   nowSec = Math.floor(Date.now() / 1000),
 ): PeggedAsset | null {
   if (!isZephyrScannerAssetId(meta.id)) return null;
+
+  const pKey = pegTypeKey(meta);
+  const priceForCirculatingMcap = priceResolution?.price != null
+    && isReasonablePrice(priceResolution.price, pKey, undefined, { navToken: meta.flags.navToken })
+    ? priceResolution.price
+    : 1.0;
   const circulatingMcap = meta.id === ZEPHYR_ZSD_ASSET_ID
-    ? stats.supply * (priceResolution?.price ?? 1.0)
+    ? stats.supply * priceForCirculatingMcap
     : stats.mcap;
   if (!Number.isFinite(circulatingMcap) || circulatingMcap <= 0) return null;
 
-  const pKey = pegTypeKey(meta);
   const resolvedPrice = resolveZephyrPrice(stats, priceResolution, nowSec);
   return {
     id: meta.id,


### PR DESCRIPTION
### Motivation
- Prevent a data-integrity poisoning path where ZSD's circulating market cap could be inflated by an unbounded supplemental `priceResolution.price` from CoinGecko/DefiLlama before `clearPriceMetadata` ran. 
- Ensure supplemental prices used to compute `circulating` are subject to the same peg reasonableness checks as direct scanner prices so post-enrichment price rejection cannot leave a poisoned `circulating` value.

### Description
- Apply `isReasonablePrice` to supplemental `priceResolution.price` when computing the ZSD circulating market cap and fall back to the USD peg `1.0` for unreasonable or missing supplemental quotes in `buildZephyrPeggedAsset` in `worker/src/cron/sync-stablecoins/zephyr-zsd.ts`.
- Replace the previous unconditional `stats.supply * (priceResolution?.price ?? 1.0)` with a vetted `priceForCirculatingMcap` that uses peg-aware bounds.
- Add a focused Vitest case to `worker/src/cron/__tests__/zephyr-zsd.test.ts` that asserts an unreasonable supplemental price does not inflate `circulating.peggedUSD`.

### Testing
- Ran the Zephyr unit tests with `npx vitest run worker/src/cron/__tests__/zephyr-zsd.test.ts --reporter=dot` and all tests passed (13 passed).
- Type-checked the Worker code with `cd worker && npx tsc --noEmit` and the build check passed.
- Verified cron schedule consistency with `npm run check:cron-sync` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355f8fc3488332b4fdbf22fbdf5abd)