### PR TITLE
fix(blacklist): chunk duplicate repair latest-state lookups

### DIFF
--- a/worker/src/cron/blacklist/__tests__/post-fetch.test.ts
+++ b/worker/src/cron/blacklist/__tests__/post-fetch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockD1 } from "../../../test-helpers/__shared/mock-d1";
 import { makeBlacklistRow } from "../../../test-helpers/__shared/fixtures";
 import type { ContractEventConfig } from "../../../lib/blacklist-contracts";
+import { D1_BATCH_SIZE } from "../../../lib/constants";
 import type { BlacklistRunBudget } from "../run-budget";
 import type { BlacklistRow } from "../shared";
 
@@ -114,6 +115,70 @@ describe("processFetchedBlacklistRows", () => {
       expect.objectContaining({
         assetPriceUsd: null,
         latestRows: [duplicateRow],
+      }),
+    );
+  });
+
+  it("chunks duplicate repair latest-state lookups at the D1 batch limit", async () => {
+    const duplicateRows = Array.from({ length: 101 }, (_, index) => makeBlacklistRow({
+      id: `ethereum-0xduplicate-chunk-${index}`,
+      stablecoin: "USDT",
+      chain_id: "ethereum",
+      chain_name: "Ethereum",
+      event_type: "blacklist",
+      address: `0x${(index + 1).toString(16).padStart(40, "0")}`,
+      amount_native: null,
+      amount_usd_at_event: null,
+      amount_source: "unavailable",
+      amount_status: "recoverable_pending",
+    }) as BlacklistRow);
+    const db = mockD1([
+      {
+        match: "SELECT id FROM blacklist_events WHERE id IN",
+        rows: duplicateRows.map((row) => ({ id: row.id })),
+      },
+      {
+        match: "SELECT * FROM blacklist_events",
+        rows: [],
+      },
+    ], { requireMatch: true });
+    const batchSizes: number[] = [];
+    const originalBatch = db.batch.bind(db);
+    db.batch = (async (statements: D1PreparedStatement[]) => {
+      batchSizes.push(statements.length);
+      if (statements.length > D1_BATCH_SIZE) {
+        throw new Error(`simulated D1 batch limit exceeded: ${statements.length} statements > ${D1_BATCH_SIZE}`);
+      }
+      return originalBatch(statements);
+    }) as D1Database["batch"];
+    vi.mocked(syncCurrentBalanceCacheForRows).mockResolvedValue({
+      updated: 0,
+      failed: 0,
+      skippedDueBudget: 0,
+      budgetExhausted: false,
+    });
+
+    const result = await processFetchedBlacklistRows({
+      db,
+      config,
+      rows: duplicateRows,
+      chainLabel: "evm",
+      etherscanApiKey: null,
+      drpcApiKey: null,
+      trongridApiKey: null,
+      etherscanLimiter: async <T>(fn: () => Promise<T>) => fn(),
+      tronLimiter: async <T>(fn: () => Promise<T>) => fn(),
+      runBudget: makeRunBudget(),
+    });
+
+    expect(result.insertedRows).toBe(0);
+    expect(batchSizes).toEqual([D1_BATCH_SIZE, 1]);
+    expect(syncCurrentBalanceCacheForRows).toHaveBeenCalledWith(
+      db,
+      config,
+      duplicateRows,
+      expect.objectContaining({
+        assetPriceUsd: null,
       }),
     );
   });

--- a/worker/src/cron/blacklist/post-fetch.ts
+++ b/worker/src/cron/blacklist/post-fetch.ts
@@ -1,5 +1,6 @@
 import { getBlacklistPriceAssetId } from "@shared/lib/blacklist";
 import { CONTRACT_CONFIGS } from "../../lib/blacklist-contracts";
+import { D1_BATCH_SIZE } from "../../lib/constants";
 import { buildInClause } from "../../lib/db";
 import { type RateLimitedFetch } from "../../lib/evm-logs";
 import { type ChainRpcConfig } from "../../lib/chain-registry";
@@ -107,7 +108,10 @@ async function fetchLatestKnownRepairRows(
     );
   }
 
-  const results = await db.batch(statements);
+  const results: D1Result[] = [];
+  for (let i = 0; i < statements.length; i += D1_BATCH_SIZE) {
+    results.push(...await db.batch(statements.slice(i, i + D1_BATCH_SIZE)));
+  }
   return results
     .map((result) => (result as { results?: BlacklistRow[] }).results?.[0])
     .filter((row): row is BlacklistRow => row != null && row.suppression_reason == null);


### PR DESCRIPTION
### Motivation

- Prevent oversized D1 batch submissions when repairing duplicate blacklist rows, which can exceed Cloudflare D1's per-call statement limit and cause the `sync-blacklist` cron to fail and stall cursor progression.

### Description

- Limit the number of prepared `SELECT` statements submitted per `db.batch()` by importing `D1_BATCH_SIZE` and slicing `statements` into chunks before calling `db.batch()` in `fetchLatestKnownRepairRows` in `worker/src/cron/blacklist/post-fetch.ts`.
- Add a regression test that simulates the D1 batch limit by feeding 101 duplicate repair rows and wrapping the mock `db.batch()` to assert the lookups are executed in chunks of `[D1_BATCH_SIZE, 1]` in `worker/src/cron/blacklist/__tests__/post-fetch.test.ts`.

### Testing

- Ran the focused Vitest suite: `npm exec -- vitest run worker/src/cron/blacklist/__tests__/post-fetch.test.ts`, and the tests passed.
- Verified type checks with `cd worker && npx tsc --noEmit` and ran the cron-connection budget check via `npm run check:cron-connections`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355f8f8e0c83329d8f4f0c5399e2be)