### PR TITLE
Harden live-reserve scoring freshness

### DIFF
--- a/worker/src/cron/__tests__/sync-live-reserves.test.ts
+++ b/worker/src/cron/__tests__/sync-live-reserves.test.ts
@@ -1217,6 +1217,85 @@ describe("syncLiveReserves", () => {
     expect(scoringMap.has(coin.id)).toBe(false);
   });
 
+  it("does not let scoring source-age overrides weaken adapter freshness policy", async () => {
+    const coin = ACTIVE_STABLECOINS.find((candidate) =>
+      candidate.liveReservesConfig?.adapter === "mento"
+      && candidate.liveReservesConfig.scoring?.maxSourceAgeSec === 4_000_000
+    ) as ConfiguredCoin | undefined;
+    expect(coin).toBeDefined();
+    const { syncReserveCoin } = await import("../sync-live-reserves-core");
+    const db = mockD1();
+    const result = await syncReserveCoin({
+      db,
+      coin: coin!,
+      signal: new AbortController().signal,
+      adapter: adapterForCoin(coin!),
+      runAdapter: async () => ({
+        slices: [{ name: "Mento reserve", pct: 100, risk: "low" as const }],
+        metadata: {
+          freshnessMode: "verified" as const,
+          sourceTimestamp: Math.floor(Date.now() / 1000) - 35 * 24 * 60 * 60,
+        },
+      }),
+      breakerCanFetch: new Map([[`live-reserves:${coin!.liveReservesConfig.breakerScope ?? coin!.liveReservesConfig.adapter}`, true]]),
+      d1FinalizeTimeoutMs: 30_000,
+      previousState: null,
+    });
+
+    expect(result.status).toBe("synced");
+    const finalizeSuccess = db.getHistory().find((entry) => (
+      entry.sql.includes("UPDATE reserve_sync_state")
+      && entry.sql.includes("last_success_at = ?")
+    ));
+    expect(finalizeSuccess?.binds).toContain("degraded");
+    expect(finalizeSuccess?.binds.some((bind) =>
+      typeof bind === "string" && bind.includes("stale-source-data")
+    )).toBe(true);
+  });
+
+  it("keeps unverified reserve freshness unscoreable and degraded warnings degrading", async () => {
+    const coin = ACTIVE_STABLECOINS.find((candidate) =>
+      candidate.liveReservesConfig?.adapter === "reservoir"
+      && candidate.liveReservesConfig.scoring?.allowedDegradedWarningCodes?.includes("unknown-position")
+    ) as ConfiguredCoin | undefined;
+    expect(coin).toBeDefined();
+    const { syncReserveCoin } = await import("../sync-live-reserves-core");
+    const db = mockD1();
+    const result = await syncReserveCoin({
+      db,
+      coin: coin!,
+      signal: new AbortController().signal,
+      adapter: adapterForCoin(coin!),
+      runAdapter: async () => ({
+        slices: [{ name: "Reservoir reserve", pct: 100, risk: "low" as const }],
+        metadata: { freshnessMode: "unverified" as const },
+        warnings: [{
+          code: "unknown-position",
+          message: "Unmapped reserve position: new-farm",
+          severity: "warning" as const,
+          effect: "degraded" as const,
+        }],
+      }),
+      breakerCanFetch: new Map([[`live-reserves:${coin!.liveReservesConfig.breakerScope ?? coin!.liveReservesConfig.adapter}`, true]]),
+      d1FinalizeTimeoutMs: 30_000,
+      previousState: null,
+    });
+
+    expect(result.status).toBe("synced");
+    const composition = db.getHistory().find((entry) => entry.sql.includes("INSERT INTO reserve_composition"));
+    expect(composition?.binds.some((bind) =>
+      typeof bind === "string" && bind.includes("scoringAllowsUnverifiedFreshness")
+    )).toBe(false);
+    const finalizeSuccess = db.getHistory().find((entry) => (
+      entry.sql.includes("UPDATE reserve_sync_state")
+      && entry.sql.includes("last_success_at = ?")
+    ));
+    expect(finalizeSuccess?.binds).toContain("degraded");
+    expect(finalizeSuccess?.binds.some((bind) =>
+      typeof bind === "string" && bind.includes("unknown-position")
+    )).toBe(true);
+  });
+
   it("keeps expired prior reserve detail stale and unscoreable after a transient failure", async () => {
     const now = 1_900_000_000;
     const coin = getIndependentConfiguredCoin();

--- a/worker/src/cron/sync-live-reserves-core.ts
+++ b/worker/src/cron/sync-live-reserves-core.ts
@@ -1,5 +1,4 @@
 import { raceWithTimeout } from "@shared/lib/timeout-signal";
-import type { LiveReserveWarning } from "@shared/types/live-reserves";
 import type { AdapterResult, ReserveAdapterDefinition } from "./reserve-adapters/index";
 import { shouldAttemptFetch } from "../lib/circuit-breaker";
 import { hasDegradingWarnings, hasFatalWarnings, validateAdapterOutput } from "./reserve-adapters/validate";
@@ -40,14 +39,16 @@ export type ReserveAdapterRunner = (
   adapter: ReserveAdapterDefinition,
 ) => Promise<AdapterResult>;
 
-function getScoringRelevantWarnings(
-  warnings: readonly LiveReserveWarning[],
-  config: LiveReserveConfig,
-): LiveReserveWarning[] {
-  const allowedCodes = new Set(config.scoring?.allowedDegradedWarningCodes ?? []);
-  return warnings.filter((warning) =>
-    warning.effect !== "degraded" || !allowedCodes.has(warning.code),
-  );
+function getEffectiveScoringMaxSourceAgeSec(config: LiveReserveConfig, adapter: ReserveAdapterDefinition): number | undefined {
+  const adapterMaxSourceAgeSec = adapter.validation?.maxSourceAgeSec;
+  const scoringMaxSourceAgeSec = config.scoring?.maxSourceAgeSec;
+  if (adapterMaxSourceAgeSec == null) {
+    return scoringMaxSourceAgeSec;
+  }
+  if (scoringMaxSourceAgeSec == null) {
+    return undefined;
+  }
+  return Math.min(scoringMaxSourceAgeSec, adapterMaxSourceAgeSec);
 }
 
 export async function syncReserveCoin(args: {
@@ -133,7 +134,7 @@ export async function syncReserveCoin(args: {
     const validation = validateAdapterOutput(result, {
       adapter,
       now: attemptStartedAt,
-      maxSourceAgeSec: config.scoring?.maxSourceAgeSec ?? undefined,
+      maxSourceAgeSec: getEffectiveScoringMaxSourceAgeSec(config, adapter),
     });
     if (!validation.valid) {
       const message = validation.warnings.map((warning) => warning.message).join("; ");
@@ -158,8 +159,7 @@ export async function syncReserveCoin(args: {
       return { breakerKey, status: "failed", breakerOutcome: false, warningMessages: [], hasWarnings: false };
     }
 
-    const scoringAllowsUnverifiedFreshness = config.scoring?.maxSourceAgeSec != null
-      && result.metadata?.freshnessMode === "unverified";
+    const scoringAllowsUnverifiedFreshness = false;
     const snapshotMetadata = {
       ...(result.metadata ?? {}),
       ...(scoringAllowsUnverifiedFreshness ? { scoringAllowsUnverifiedFreshness: true } : {}),
@@ -179,7 +179,6 @@ export async function syncReserveCoin(args: {
       adapterEvidenceClass: adapter.evidenceClass,
     };
 
-    const scoringRelevantWarnings = getScoringRelevantWarnings(warnings, config);
     const successState = buildReserveSyncStateRecord({
       stablecoinId: coin.id,
       config,
@@ -188,7 +187,7 @@ export async function syncReserveCoin(args: {
       previousLastSuccessAttemptId: prevSuccessAttemptId,
       attemptId,
       now: attemptStartedAt,
-      status: hasDegradingWarnings(scoringRelevantWarnings) ? "degraded" : "ok",
+      status: hasDegradingWarnings(warnings) ? "degraded" : "ok",
       warnings,
       metadata: {
         warningEffects: {


### PR DESCRIPTION
### Motivation

- Prevent per-coin scoring overrides from weakening adapter-enforced freshness policies so that upstream providers cannot make stale or timestampless reserve feeds scoreable as fresh.
- Stop promoting `freshnessMode: "unverified"` snapshots into scoring eligibility solely because a per-coin `scoring.maxSourceAgeSec` exists.
- Ensure degraded validation/adapter warnings continue to mark the sync status as `degraded` so incomplete or questionable reserve data cannot be treated as `ok` for scoring.

### Description

- Replace the previous scoring-age passthrough with `getEffectiveScoringMaxSourceAgeSec()` which returns `Math.min(adapter.validation?.maxSourceAgeSec, config.scoring?.maxSourceAgeSec)` when both exist, uses adapter policy when present, and only applies a scoring override if the adapter has no policy; this prevents scoring configs from widening adapter windows (`worker/src/cron/sync-live-reserves-core.ts`).
- Stop setting `scoringAllowsUnverifiedFreshness` from the presence of a scoring-age override so `freshnessMode: "unverified"` is not implicitly made scoring-eligible (`worker/src/cron/sync-live-reserves-core.ts`).
- Use the full set of produced warnings when deciding `lastStatus` so degraded warnings cannot be filtered away by per-coin allowlists before deciding `ok` vs `degraded` (`worker/src/cron/sync-live-reserves-core.ts`).
- Add regression tests covering a stale Mento timestamp and a Reservoir unverified/degraded-warning path to assert adapter freshness limits and degraded-status behaviour remain enforced (`worker/src/cron/__tests__/sync-live-reserves.test.ts`).

### Testing

- Ran the relevant unit suites with `npx vitest run worker/src/cron/__tests__/sync-live-reserves.test.ts worker/src/cron/__tests__/reserve-adapter-validate.test.ts` and all tests passed (Test Files 2 passed, Tests 60 passed).
- Verified TypeScript compilation for worker code with `cd worker && npx tsc --noEmit` which completed successfully.
- Ran cron sanity checks `npm run check:cron-sync` and `npm run check:cron-connections`, both of which passed.
- Existing reserve validation tests and the new regressions executed as part of the above suites and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3509b1657c833284257d9f8ffb0801)