### PR TITLE
fix(api): derive frozen status from registry only

### DIFF
--- a/shared/types/__tests__/market-frozen.test.ts
+++ b/shared/types/__tests__/market-frozen.test.ts
@@ -36,6 +36,12 @@ describe("/api/stablecoins payload shape — frozen fields", () => {
     expect(entry.frozenAt).toBe("2026-04-27");
   });
 
+  it("rejects malformed frozenAt values", () => {
+    expect(() => StablecoinListResponseSchema.parse({
+      peggedAssets: [makeRawAsset({ id: "frozen-coin", frozen: true, frozenAt: "not-a-registry-date" })],
+    })).toThrow();
+  });
+
   it("omits frozen and frozenAt when not present on the raw asset", () => {
     const parsed = StablecoinListResponseSchema.parse({
       peggedAssets: [makeRawAsset()],

--- a/shared/types/market.ts
+++ b/shared/types/market.ts
@@ -18,6 +18,7 @@ export {
 } from "./bluechip";
 
 const PegBucketsSchema = z.record(z.string(), z.number());
+const IsoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 const PriceSourceConfidenceProfileSchema = z.object({
   activeDexLanes: z.number().int().min(0),
   freshestDexLaneAgeSec: z.number().int().min(0).nullable(),
@@ -62,7 +63,7 @@ const StablecoinDataRawSchema = z.object({
   chains: z.array(z.string()),
   contracts: z.array(ContractDeploymentSchema).optional(),
   frozen: z.boolean().optional(),
-  frozenAt: z.string().optional(),
+  frozenAt: IsoDateSchema.optional(),
 });
 
 export const StablecoinDataSchema = StablecoinDataRawSchema.transform((asset) => ({

--- a/worker/src/cron/sync-stablecoins/__tests__/cache-publication.test.ts
+++ b/worker/src/cron/sync-stablecoins/__tests__/cache-publication.test.ts
@@ -48,4 +48,61 @@ describe("validateAndWriteStablecoinsCache", () => {
       responseReadyCacheError: "Error",
     });
   });
+  it("strips upstream frozen fields from non-registry assets before publishing", async () => {
+    const syncStartSec = 1_777_000_000;
+    const db = mockD1([
+      {
+        match: "INSERT INTO cache",
+        rows: [],
+        runMeta: { changes: 1 },
+      },
+    ], { requireMatch: true });
+
+    const result = await validateAndWriteStablecoinsCache({
+      assets: [{
+        id: "upstream-controlled-active-coin",
+        name: "Active Coin",
+        symbol: "ACTIVE",
+        pegType: "peggedUSD",
+        pegMechanism: "fiat-backed",
+        price: 1,
+        priceSource: "defillama",
+        circulating: { peggedUSD: 1000 },
+        chainCirculating: {
+          Ethereum: {
+            current: 1000,
+            circulatingPrevDay: 1000,
+            circulatingPrevWeek: 1000,
+            circulatingPrevMonth: 1000,
+          },
+        },
+        chains: ["Ethereum"],
+        frozen: true,
+        frozenAt: "2026-04-27",
+      }],
+      db,
+      syncStartSec,
+      validationContext: "main",
+      returnIfAborted: () => null,
+      abortResult: () => ({
+        status: "degraded",
+        itemCount: 0,
+        metadata: "aborted",
+      }),
+    }, () => ({
+      status: "degraded",
+      itemCount: 0,
+      metadata: "blocked",
+    }));
+
+    expect(result).toMatchObject({ written: true, skippedBecauseNewer: false });
+    const stablecoinsWrite = db.getHistory().find((entry) => entry.binds[0] === "stablecoins");
+    expect(stablecoinsWrite).toBeDefined();
+    const published = JSON.parse(stablecoinsWrite?.binds[1] as string) as {
+      peggedAssets: Array<{ frozen?: boolean; frozenAt?: string }>;
+    };
+    expect(published.peggedAssets[0].frozen).toBeUndefined();
+    expect(published.peggedAssets[0].frozenAt).toBeUndefined();
+  });
+
 });

--- a/worker/src/cron/sync-stablecoins/cache-publication.ts
+++ b/worker/src/cron/sync-stablecoins/cache-publication.ts
@@ -68,13 +68,18 @@ export async function validateAndWriteStablecoinsCache(
   // Tag frozen coins so /api/stablecoins exposes `frozen` and `frozenAt` per-coin.
   // Runs after intake's mergeFrozenSnapshots so injected rows also get tagged here.
   for (const asset of assets) {
+    const frozenMeta = FROZEN_META_BY_ID.get(asset.id);
     if (FROZEN_IDS.has(asset.id)) {
       asset.frozen = true;
-      const frozenAt = FROZEN_META_BY_ID.get(asset.id)?.frozenAt;
-      if (frozenAt != null) {
-        asset.frozenAt = frozenAt;
+      if (frozenMeta?.frozenAt != null) {
+        asset.frozenAt = frozenMeta.frozenAt;
+      } else {
+        delete asset.frozenAt;
       }
+      continue;
     }
+    delete asset.frozen;
+    delete asset.frozenAt;
   }
 
   const llamaData: StablecoinsPayload = { peggedAssets: assets, fxFallbackRates };


### PR DESCRIPTION
### Motivation
- Upstream provider payloads could include `frozen` and `frozenAt` properties that survived normalization and were persisted to the public stablecoins cache, allowing an untrusted provider to spoof lifecycle metadata. 
- `frozen`/`frozenAt` are authoritative registry metadata and must only be set from the local frozen registry, not from DefiLlama or other upstream rows. 
- `frozenAt` should be constrained to the expected date shape to avoid publishing malformed values.

### Description
- Clear upstream-provided `frozen` and `frozenAt` from every asset that is not in the local frozen registry and set these fields only from `FROZEN_META_BY_ID` for registry entries in `worker/src/cron/sync-stablecoins/cache-publication.ts`.
- Constrain the published `frozenAt` shape by adding an `IsoDateSchema` (`YYYY-MM-DD`) and using it for `frozenAt` in `shared/types/market.ts`.
- Add a regression test that ensures upstream-supplied `frozen`/`frozenAt` are stripped before publishing in `worker/src/cron/sync-stablecoins/__tests__/cache-publication.test.ts`.
- Add a schema test to reject malformed `frozenAt` values in `shared/types/__tests__/market-frozen.test.ts`.

### Testing
- Ran the focused Vitest suites: `npx vitest run shared/types/__tests__/market-frozen.test.ts worker/src/cron/sync-stablecoins/__tests__/cache-publication.test.ts`, and all tests passed.
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, which completed without errors.
- Ran the worker import-boundary check `npm run check:worker-boundary`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0c60d88332bf1be6fa3c0b14a5)