### PR TITLE
fix(worker): validate raw BCB SELIC daily rates

### DIFF
--- a/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
+++ b/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
@@ -885,6 +885,22 @@ describe("parseBcbSelicSeries", () => {
     });
   });
 
+  it("skips impossible negative daily SELIC observations before annualization", () => {
+    const payload = JSON.stringify([
+      { data: "17/06/2026", valor: "0.050747" },
+      { data: "18/06/2026", valor: "-200.05" },
+    ]);
+    expect(parseBcbSelicSeries(payload)).toEqual({
+      rate: 13.638253562615565,
+      recordDate: "2026-06-17",
+    });
+  });
+
+  it("returns null when every SELIC observation has an impossible negative daily rate", () => {
+    const payload = JSON.stringify([{ data: "18/06/2026", valor: "-200.05" }]);
+    expect(parseBcbSelicSeries(payload)).toBeNull();
+  });
+
   it("returns null when array is empty", () => {
     expect(parseBcbSelicSeries("[]")).toBeNull();
   });

--- a/worker/src/cron/tbill-sources/bcb.ts
+++ b/worker/src/cron/tbill-sources/bcb.ts
@@ -7,6 +7,11 @@ import {
 } from "./shared";
 
 const BCB_SELIC_ANNUALIZATION_BUSINESS_DAYS = 252;
+const BCB_SELIC_MIN_DAILY_PERCENTAGE_RATE = -100;
+
+function isValidBcbSelicDailyRate(rate: number): boolean {
+  return Number.isFinite(rate) && rate > BCB_SELIC_MIN_DAILY_PERCENTAGE_RATE;
+}
 
 function annualizeDailyPercentageRate(rate: number, businessDays: number): number {
   return ((1 + rate / 100) ** businessDays - 1) * 100;
@@ -26,6 +31,7 @@ export function parseBcbSelicSeries(json: string): { recordDate: string; rate: n
       const row = parsed[i];
       const rate = parseRate(typeof row?.valor === "string" ? row.valor : null);
       const dataRaw = typeof row?.data === "string" ? row.data : null;
+      if (!isValidBcbSelicDailyRate(rate)) continue;
       const annualizedRate = annualizeDailyPercentageRate(rate, BCB_SELIC_ANNUALIZATION_BUSINESS_DAYS);
       if (!dataRaw || !isValidBenchmarkRate(annualizedRate)) continue;
       const recordDate = parseSlashDmyToIso(dataRaw);


### PR DESCRIPTION
### Motivation
- Prevent malicious or impossible BCB SELIC daily percentage inputs (e.g. `-200.05`) from being annualized into plausible BRL benchmark rates by validating the raw daily value before compounding.

### Description
- Add `BCB_SELIC_MIN_DAILY_PERCENTAGE_RATE = -100` and `isValidBcbSelicDailyRate()` to `worker/src/cron/tbill-sources/bcb.ts` and skip rows with non-finite or <= -100% daily rates before annualizing. 
- Keep the existing annualized benchmark validation (`isValidBenchmarkRate`) unchanged so APY-compatible BRL rates are still enforced after annualization. 
- Add regression tests in `worker/src/cron/__tests__/fetch-tbill-rate.test.ts` that assert a malicious `valor: "-200.05"` row is ignored and that a payload composed entirely of impossible negative daily rates returns `null`.

### Testing
- Ran the focused Vitest suite for tbill parsers with `npx vitest run worker/src/cron/__tests__/fetch-tbill-rate.test.ts`, and the test file passed (all tests succeeded). 
- Type-checking with `cd worker && npx tsc --noEmit` succeeded. 
- Cron checks `npm run check:cron-sync` and `npm run check:cron-connections` both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ba8d95908332950951860a387cb4)