### PR TITLE
Make script src detection quote-aware in phishing scanner

### DIFF
--- a/scripts/__tests__/check-phishing-signatures.test.ts
+++ b/scripts/__tests__/check-phishing-signatures.test.ts
@@ -31,6 +31,14 @@ describe("check-phishing-signatures", () => {
     ).toThrow(/Inline-script phishing-kit signatures detected/);
   });
 
+  it("scans inline scripts when src-like text appears inside another attribute value", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><script data-note=" src = not-an-attribute">try { const params = new URLSearchParams(window.location.hash.slice(1)); window.__PHAROS_TOKEN__ = params.get("token"); history.replaceState(null, "", location.pathname); } catch (error) {}</script></body></html>`,
+      ),
+    ).toThrow(/Inline-script phishing-kit signatures detected/);
+  });
+
   it("continues to skip external script tags that use a real src attribute", () => {
     expect(() =>
       runChecker(

--- a/scripts/ci/check-phishing-signatures.mjs
+++ b/scripts/ci/check-phishing-signatures.mjs
@@ -56,6 +56,40 @@ const SIGNATURES = [
   },
 ];
 
+/** Return true when raw script attributes include a real src attribute. */
+function hasScriptSrcAttribute(attributes) {
+  let index = 0;
+  while (index < attributes.length) {
+    while (index < attributes.length && /\s/.test(attributes[index])) index += 1;
+    if (index >= attributes.length) return false;
+
+    const nameStart = index;
+    while (index < attributes.length && !/[\s=/>]/.test(attributes[index])) index += 1;
+    if (nameStart === index) {
+      index += 1;
+      continue;
+    }
+    const name = attributes.slice(nameStart, index);
+
+    while (index < attributes.length && /\s/.test(attributes[index])) index += 1;
+    if (attributes[index] === "=") {
+      index += 1;
+      while (index < attributes.length && /\s/.test(attributes[index])) index += 1;
+      const quote = attributes[index];
+      if (quote === '"' || quote === "'") {
+        index += 1;
+        while (index < attributes.length && attributes[index] !== quote) index += 1;
+        if (attributes[index] === quote) index += 1;
+      } else {
+        while (index < attributes.length && !/\s/.test(attributes[index])) index += 1;
+      }
+    }
+
+    if (name.toLowerCase() === "src") return true;
+  }
+  return false;
+}
+
 /** Extract the textual content of every inline <script>...</script> block. */
 function extractInlineScripts(html) {
   const inline = [];
@@ -63,14 +97,13 @@ function extractInlineScripts(html) {
   let match;
   while ((match = pattern.exec(html)) !== null) {
     const attributes = match[1];
-    if (/(?:^|\s)src\s*=/i.test(attributes)) continue;
+    if (hasScriptSrcAttribute(attributes)) continue;
     const body = match[2];
     if (body.trim().length === 0) continue;
     inline.push(body);
   }
   return inline;
 }
-
 
 function relPath(file) {
   return path.relative(OUT_DIR, file).replace(/\\/g, "/");


### PR DESCRIPTION
### Motivation
- The phishing-signature scanner previously used a quote-insensitive regex to detect `src` which could be fooled by `src =` text inside a quoted attribute value, allowing executable inline scripts to be incorrectly skipped.
- The change aims to close this CI/deploy-gate bypass while preserving the intended behavior of skipping genuinely external `<script src=...>` tags.

### Description
- Add a small attribute parser `hasScriptSrcAttribute(attributes)` that walks attribute text, skips over quoted values, and returns true only when a real `src` attribute name is found (file: `scripts/ci/check-phishing-signatures.mjs`).
- Replace the previous regex test `/(?:^|\s)src\s*=/i.test(attributes)` with `hasScriptSrcAttribute(attributes)` in `extractInlineScripts()` so detection is quote-aware.
- Add a regression test covering the bypass vector (`<script data-note=" src = not-an-attribute">...`) so inline scripts with `src`-like text inside other attributes remain scanned (file: `scripts/__tests__/check-phishing-signatures.test.ts`).

### Testing
- Ran the targeted unit tests with `npx vitest run scripts/__tests__/check-phishing-signatures.test.ts` and the test file passed (`3 passed`).
- Formatted the changed files with `npx prettier --write` as part of the local verification step and re-ran the tests to confirm no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ba8d6da483329102bb20af01ec49)