### PR TITLE
Restore Telegram global rate-limit backoff heuristics

### DIFF
--- a/worker/src/cron/__tests__/telegram-pending-queue.test.ts
+++ b/worker/src/cron/__tests__/telegram-pending-queue.test.ts
@@ -1250,7 +1250,7 @@ describe("drainPendingQueue", () => {
     expect(retryUpdates.every((entry) => entry.binds[0] === Math.floor(Date.now() / 1000) + 45)).toBe(true);
   });
 
-  it("keeps repeated pending 429s across distinct chats chat-scoped", async () => {
+  it("escalates repeated pending 429s across distinct chats to global backoff", async () => {
     const okResult = {
       ok: true, blocked: false, retryable: false, permanentFailure: false,
       statusCode: 200, errorClass: null, delivery: "sent", retryAfterSec: null,
@@ -1279,12 +1279,12 @@ describe("drainPendingQueue", () => {
 
     const result = await drainPendingQueue(db, "bot-token", 20);
 
-    expect(result.attempted).toBe(5);
-    expect(result.sent).toBe(2);
+    expect(result.attempted).toBe(4);
+    expect(result.sent).toBe(1);
     expect(result.retryQueued).toBe(3);
     expect(result.rateLimited).toBe(true);
-    expect(mockSendToChat).toHaveBeenCalledTimes(5);
-    expect(db.getHistory().some((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"))).toBe(false);
+    expect(mockSendToChat).toHaveBeenCalledTimes(4);
+    expect(db.getHistory().some((entry) => entry.sql.includes("INSERT OR REPLACE INTO cache"))).toBe(true);
   });
 
   it("stamps row-level backoff without setting global backoff on a chat-scoped 429", async () => {

--- a/worker/src/cron/telegram-pending/drain.ts
+++ b/worker/src/cron/telegram-pending/drain.ts
@@ -8,6 +8,7 @@ import {
   PENDING_BACKOFF_SCHEDULE_SEC,
   PENDING_TTL_SEC,
   SEND_BATCH_SIZE,
+  TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD,
   TELEGRAM_PENDING_PRIORITY,
 } from "../../lib/telegram-constants";
 import { recordTelegramDeliveryOutcomes } from "../../lib/telegram-usage-analytics";
@@ -523,6 +524,10 @@ export async function drainPendingQueue(
             } else {
               distinctRateLimitedChats.add(result.chatId);
               chatRateLimitedThisLoop.set(result.chatId, { notBeforeAt: classification.rateLimit.notBeforeAt });
+              if (distinctRateLimitedChats.size >= TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD) {
+                globalRateLimited = true;
+                await setTelegramGlobalBackoff(db, rateLimitNotBeforeAt);
+              }
             }
           }
           break;

--- a/worker/src/lib/__tests__/telegram.test.ts
+++ b/worker/src/lib/__tests__/telegram.test.ts
@@ -135,7 +135,7 @@ describe("sendToChat", () => {
     expect(fetchSpy.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("keeps ambiguous long retry-after 429s chat-scoped", async () => {
+  it("treats ambiguous long retry-after 429s as global", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response("Too Many Requests", {
         status: 429,
@@ -151,7 +151,7 @@ describe("sendToChat", () => {
       statusCode: 429,
       errorClass: "rate_limit",
       delivery: "retryable_failure",
-      rateLimitScope: "chat",
+      rateLimitScope: "global",
     });
     expect(result.retryAfterSec).toBe(30);
   });
@@ -371,7 +371,7 @@ describe("sendBatch", () => {
     expect(results.slice(3).every((result) => result.rateLimitScope === "global" && result.attempted === false)).toBe(true);
   });
 
-  it("keeps sending later batches after an ambiguous Telegram JSON retry_after", async () => {
+  it("stops later batches after an ambiguous long Telegram JSON retry_after", async () => {
     fetchSpy
       .mockResolvedValueOnce(
         new Response(
@@ -394,16 +394,17 @@ describe("sendBatch", () => {
 
     const results = await sendBatch(messages, "bot-token", 2);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(results).toHaveLength(5);
     expect(results[0]).toMatchObject({
       chatId: "chat-0",
       errorClass: "rate_limit",
       retryAfterSec: 38,
-      rateLimitScope: "chat",
+      rateLimitScope: "global",
       attempted: true,
     });
-    expect(results.slice(1).every((result) => result.ok && result.attempted === true)).toBe(true);
+    expect(results[1]).toMatchObject({ ok: true, attempted: true });
+    expect(results.slice(2).every((result) => result.rateLimitScope === "global" && result.attempted === false)).toBe(true);
   });
 
   it("marks the untouched tail as global retryable after a global rate limit stop", async () => {

--- a/worker/src/lib/telegram-constants.ts
+++ b/worker/src/lib/telegram-constants.ts
@@ -98,6 +98,12 @@ export const TELEGRAM_MAX_MESSAGES_PER_RUN = 3600;
 /** Pending drain share reserved from the per-run Telegram send budget. */
 export const TELEGRAM_PENDING_DRAIN_BUDGET = Math.floor(TELEGRAM_MAX_MESSAGES_PER_RUN / 4);
 
+/** Ambiguous retry_after values at or above this are treated as bot-wide flood limits. */
+export const TELEGRAM_GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC = 30;
+
+/** Distinct chat-scoped 429s in one send loop that imply a bot-wide flood limit. */
+export const TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD = 3;
+
 /**
  * Approximate alert lines that fit in one delivered message chunk. Used purely
  * as a cheap (no-format) chunk estimate when selecting which candidate chats to

--- a/worker/src/lib/telegram.ts
+++ b/worker/src/lib/telegram.ts
@@ -1,4 +1,8 @@
 import { drainResponseBody } from "./response-body";
+import {
+  TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD,
+  TELEGRAM_GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC,
+} from "./telegram-constants";
 
 export interface TelegramCreds {
   botToken: string;
@@ -150,15 +154,16 @@ export interface SendToChatResult {
   rateLimitScope?: "chat" | "global";
 }
 
-const GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD = 3;
-
-function inferRateLimitScope(responseBody: string): "chat" | "global" {
+function inferRateLimitScope(responseBody: string, retryAfterSec: number | null): "chat" | "global" {
   const lower = responseBody.toLowerCase();
   if (lower.includes("global") || lower.includes("bot-wide") || lower.includes("bot wide")) {
     return "global";
   }
   if (lower.includes("chat") || lower.includes("group") || lower.includes("user")) {
     return "chat";
+  }
+  if (retryAfterSec != null && retryAfterSec >= TELEGRAM_GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC) {
+    return "global";
   }
   return "chat";
 }
@@ -178,7 +183,7 @@ function parseTelegramRetryAfter(responseBody: string): number | null {
   }
 }
 
-function buildResponseFailure(statusCode: number, responseBody = ""): SendToChatResult {
+function buildResponseFailure(statusCode: number, responseBody = "", retryAfterSec: number | null = null): SendToChatResult {
   if (statusCode === 403) {
     return {
       ok: false,
@@ -201,7 +206,7 @@ function buildResponseFailure(statusCode: number, responseBody = ""): SendToChat
       errorClass: "rate_limit",
       delivery: "retryable_failure",
       retryAfterSec: null,
-      rateLimitScope: inferRateLimitScope(responseBody),
+      rateLimitScope: inferRateLimitScope(responseBody, retryAfterSec),
     };
   }
   if (statusCode >= 500) {
@@ -315,7 +320,7 @@ export async function sendToChat(
       const body = await res.text().catch(() => "");
       const telegramRetryAfterSec = parseTelegramRetryAfter(body);
       const resolvedRetryAfterSec = telegramRetryAfterSec ?? (Number.isFinite(retryAfterSec) ? retryAfterSec : null);
-      const failure = buildResponseFailure(res.status, body);
+      const failure = buildResponseFailure(res.status, body, resolvedRetryAfterSec);
       return {
         ...failure,
         retryAfterSec: resolvedRetryAfterSec,
@@ -461,7 +466,7 @@ export async function sendBatch(
           chatRateLimitedUntil.set(result.chatId, result.retryAfterSec);
         }
       }
-      if (distinctRateLimitedChats.size >= GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD) {
+      if (distinctRateLimitedChats.size >= TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD) {
         escalatedGlobalRateLimitedResult = batchResults.find(
           (r) => r.errorClass === "rate_limit" && r.rateLimitScope !== "global" && r.attempted !== false,
         );


### PR DESCRIPTION
### Motivation

- Prevent broad Telegram alert storms from being treated as per-chat-only when the Bot API returns ambiguous 429 responses, which can waste run budget and continue hammering Telegram instead of pausing globally.

### Description

- Add shared thresholds in `worker/src/lib/telegram-constants.ts`: `TELEGRAM_GLOBAL_RATE_LIMIT_RETRY_AFTER_THRESHOLD_SEC` and `TELEGRAM_GLOBAL_RATE_LIMIT_DISTINCT_CHAT_THRESHOLD` for consistent heuristics across send and pending-drain logic.
- Update rate-limit inference to accept the resolved `retryAfterSec` and treat ambiguous long `retry_after` values at-or-above the threshold as `global` scope in `worker/src/lib/telegram.ts`. 
- Restore escalation behavior in `sendBatch` so repeated distinct-chat 429s can be escalated to a global backoff and mark the remaining tail as unattempted global retries. 
- Escalate repeated distinct-chat 429s in the pending-queue drain to write the global backoff (`setTelegramGlobalBackoff`) so queued drains stop sending when bot-wide symptoms appear. 
- Update tests in `worker/src/lib/__tests__/telegram.test.ts` and `worker/src/cron/__tests__/telegram-pending-queue.test.ts` to reflect and validate the restored global-escalation behavior.

### Testing

- Ran the targeted unit suites with `npx vitest run worker/src/lib/__tests__/telegram.test.ts worker/src/cron/__tests__/telegram-pending-queue.test.ts --reporter=dot`, and all tests passed. 
- Type-checked the worker code with `npx tsc -p worker/tsconfig.json --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ba8e2ea0833291e05dde643d58d0)