### PR TITLE
Validate and skip malformed Fluid pool IDs

### DIFF
--- a/worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts
+++ b/worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts
@@ -158,7 +158,7 @@ describe("fetchFluidPools", () => {
     expect(mockFetch.mock.calls.some(([input]) => String(input) === "https://rpc.example")).toBe(true);
   });
 
-  it("isolates malformed Fluid pool IDs to a single pool enrichment failure", async () => {
+  it("skips malformed Fluid pool IDs while preserving valid pools", async () => {
     const malformedPoolAddress = "not-a-20-byte-hex-address";
     mockFetch.mockImplementation((input, init) => {
       const url = String(input);
@@ -216,12 +216,12 @@ describe("fetchFluidPools", () => {
 
     const pools = await fetchFluidPools(undefined, chainRpcs);
 
-    expect(pools.pools.map((pool) => pool.poolAddress)).toEqual([FLUID_POOL_ADDRESS, malformedPoolAddress]);
+    expect(pools.pools.map((pool) => pool.poolAddress)).toEqual([FLUID_POOL_ADDRESS]);
     expect(pools.pools[0].balances).toEqual([2000000, 3000000]);
-    expect(pools.pools[1].balances).toBeNull();
     expect(pools.ok).toBe(true);
     expect(pools.degraded).toBe(true);
     expect(pools.errors[0]).toContain(malformedPoolAddress);
+    expect(pools.errors[0]).toContain("invalid EVM address");
     expect(mockFetch.mock.calls.filter(([input]) => String(input) === "https://rpc.example")).toHaveLength(3);
   });
 
@@ -234,7 +234,7 @@ describe("fetchFluidPools", () => {
         last_price: "1.0",
         base_volume: "50000",
         target_volume: "50000",
-        pool_id: "0xpool",
+        pool_id: "0x2222222222222222222222222222222222222222",
         liquidity_in_usd: "200000",
       },
     ]);
@@ -255,7 +255,7 @@ describe("fetchFluidPools", () => {
         last_price: "1.0",
         base_volume: "75000",
         target_volume: "25000",
-        pool_id: "0xp",
+        pool_id: "0x3333333333333333333333333333333333333333",
         liquidity_in_usd: "100000",
       },
     ]);
@@ -298,7 +298,7 @@ describe("fetchFluidPools", () => {
         last_price: "1.0",
         base_volume: "100",
         target_volume: "100",
-        pool_id: "0xp",
+        pool_id: "0x3333333333333333333333333333333333333333",
         liquidity_in_usd: "0",
       },
       {
@@ -308,7 +308,7 @@ describe("fetchFluidPools", () => {
         last_price: "1.0",
         base_volume: "100",
         target_volume: "100",
-        pool_id: "0xp2",
+        pool_id: "0x4444444444444444444444444444444444444444",
         liquidity_in_usd: "NaN",
       },
     ]);
@@ -328,7 +328,7 @@ describe("fetchFluidPools", () => {
         last_price: "not-a-number",
         base_volume: "100",
         target_volume: "100",
-        pool_id: "0xp",
+        pool_id: "0x3333333333333333333333333333333333333333",
         liquidity_in_usd: "100000",
       },
     ]);
@@ -346,7 +346,7 @@ describe("fetchFluidPools", () => {
         last_price: "1.0",
         base_volume: "100",
         target_volume: "100",
-        pool_id: "0xp",
+        pool_id: "0x3333333333333333333333333333333333333333",
         liquidity_in_usd: "100000",
       },
     ]);

--- a/worker/src/cron/dex-liquidity/fetch-fluid.ts
+++ b/worker/src/cron/dex-liquidity/fetch-fluid.ts
@@ -47,6 +47,20 @@ interface FluidTicker {
   liquidity_in_usd: string;
 }
 
+const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const INVALID_FLUID_POOL_ID_LOG_LIMIT = 80;
+
+function isEvmAddress(value: unknown): value is string {
+  return typeof value === "string" && EVM_ADDRESS_RE.test(value);
+}
+
+function formatInvalidFluidPoolId(value: unknown): string {
+  if (typeof value !== "string") return String(value);
+  return value.length > INVALID_FLUID_POOL_ID_LOG_LIMIT
+    ? `${value.slice(0, INVALID_FLUID_POOL_ID_LOG_LIMIT)}…(${value.length} chars)`
+    : value;
+}
+
 function bigintToDecimalNumber(value: bigint, decimals: number): number {
   if (decimals <= 0) return Number(value);
   const negative = value < 0n;
@@ -180,6 +194,10 @@ export async function fetchFluidPools(
         const baseVol = parseFloat(t.base_volume);
         const targetVol = parseFloat(t.target_volume);
         if (!Number.isFinite(tvlUsd) || tvlUsd <= 0) return null;
+        if (!isEvmAddress(t.pool_id)) {
+          errors.push(`${chain} pool_id ${formatInvalidFluidPoolId(t.pool_id)} skipped: invalid EVM address`);
+          return null;
+        }
 
         return {
           source: "fluid",


### PR DESCRIPTION
### Motivation
- The Fluid direct-API fetcher copied external `pool_id` values into `DexApiPool.poolAddress` without validating them as EVM addresses, allowing malformed or oversized provider IDs to flow into normalization, scoring, and persistence.
- The change isolates provider-induced enrichment errors but did not prevent malformed rows from being returned, so the intent is to reject invalid pool IDs early to protect data integrity and downstream metrics.

### Description
- Add validation in `worker/src/cron/dex-liquidity/fetch-fluid.ts` to accept only 20-byte `0x`-prefixed EVM addresses via a new `isEvmAddress` helper and `EVM_ADDRESS_RE` constant, and skip invalid `pool_id` values before constructing `DexApiPool` rows.
- Record skipped/invalid Fluid IDs into the `errors` array with length-capped formatting via `formatInvalidFluidPoolId` to avoid oversized provider IDs in logs/metadata.
- Update `worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts` to assert that malformed Fluid `pool_id` values are dropped while valid pools continue to enrich and return.

### Testing
- Ran the focused test: `npx vitest run worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts -t "skips malformed Fluid pool IDs" --reporter=dot`, which passed; the whole direct-API test file was also run and passed (`50 passed`).
- Type-checking passed via `npx tsc -p worker/tsconfig.json --noEmit` and repository cleanliness checks passed via `git diff --check`.
- The change was committed and includes the updated tests that validate the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ba8e110c8332a6bfd1c329f0e58b)