### PR TITLE
fix(worker): age DEWS aggregate headers by oldest row

### DIFF
--- a/worker/src/api/__tests__/stress-signals.test.ts
+++ b/worker/src/api/__tests__/stress-signals.test.ts
@@ -634,7 +634,7 @@ describe("handleStressSignals contract tests", () => {
     expect(body.history[1].amplifiers).toEqual({ psi: 1.05, contagion: 1.2 });
   });
 
-  it("uses the newest aggregate row for freshness headers while exposing oldest body timestamp", async () => {
+  it("uses the oldest aggregate row for freshness headers while exposing newest body timestamp", async () => {
     const requestNowSec = Math.floor(Date.now() / 1000);
     const freshComputedAt = requestNowSec - 60;
     const staleComputedAt = requestNowSec - 15_000;
@@ -665,9 +665,9 @@ describe("handleStressSignals contract tests", () => {
     };
     expect(body.updatedAt).toBe(freshComputedAt);
     expect(body.oldestComputedAt).toBe(staleComputedAt);
-    expect(Number(res.headers.get("X-Data-Age"))).toBeLessThan(120);
-    expect(res.headers.get("Warning")).toBeNull();
-    expect(res.headers.get("Cache-Control")).toContain("s-maxage");
+    expect(Number(res.headers.get("X-Data-Age"))).toBeGreaterThanOrEqual(15_000);
+    expect(res.headers.get("Warning")).toContain("Response is stale");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(body.signals["usdt-tether"].ageClassification).toBe("fresh");
     expect(body.signals["usdc-circle"].ageClassification).toBe("retainedLastValid");
   });

--- a/worker/src/api/stress-signals.ts
+++ b/worker/src/api/stress-signals.ts
@@ -465,7 +465,7 @@ export const handleStressSignals = withErrorHandler(
     const responseHeaders = updatedAt > 0
       ? addFreshnessHeaders({
           "Cache-Control": CACHE_PROFILES.standard,
-        }, updatedAt, STRESS_SIGNALS_MAX_AGE_SEC)
+        }, oldestComputedAt ?? updatedAt, STRESS_SIGNALS_MAX_AGE_SEC)
       : buildUnavailableHeaders("DEWS current rows unavailable");
 
     return jsonResponse({ signals, updatedAt, oldestComputedAt: oldestComputedAt ?? undefined, eligibleCount, computedCount, missingCount, malformedRows, coverageRatio, coverageStatus: coverage.status, coverageReasons: coverage.reasons, methodology: buildMethodologyEnvelope({


### PR DESCRIPTION
### Motivation
- The DEWS aggregate response could include mixed fresh rows and retained last-valid (stale) rows, but headers were being derived from the newest returned row so a single fresh row could suppress stale `Warning`/`no-store` behavior for the whole response.
- This made mixed fresh/stale aggregates cacheable and appear fresh to clients even when some returned per-coin scores were older than the DEWS freshness budget.

### Description
- Change freshness header input so the aggregate handler calls `addFreshnessHeaders(..., oldestComputedAt ?? updatedAt, STRESS_SIGNALS_MAX_AGE_SEC)` instead of using only `updatedAt`, so headers reflect the oldest returned computed timestamp while `updatedAt` in the body remains the newest row timestamp (`worker/src/api/stress-signals.ts`).
- Update the stress-signals regression test to assert that a mixed fresh/stale aggregate exposes `oldestComputedAt` in the body while the emitted `X-Data-Age`, `Warning`, and `Cache-Control` reflect the stale oldest row (`worker/src/api/__tests__/stress-signals.test.ts`).

### Testing
- Ran `npx vitest run worker/src/api/__tests__/stress-signals.test.ts --reporter=verbose` and the suite passed (all tests in that file passed).
- Ran `npm run typecheck:worker` (`cd worker && npx tsc --noEmit`) and the worker typecheck completed successfully.
- Ran `git diff --check` to validate no whitespace/errors and committed the change as `fix(worker): age DEWS aggregate headers by oldest row`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ba8db97c833296a329b5157a3516)