### PR TITLE
fix(sync): count stale DL payloads against circuit

### DIFF
--- a/worker/src/cron/__tests__/sync-stablecoins.test.ts
+++ b/worker/src/cron/__tests__/sync-stablecoins.test.ts
@@ -1621,6 +1621,12 @@ describe("syncStablecoins", () => {
 
     expect(result.status).toBe("degraded");
     expect(cacheWrites.map((write) => write.key)).not.toContain("stablecoins");
+    expect(recordOutcome).toHaveBeenCalledWith(
+      expect.anything(),
+      CIRCUIT_SOURCE.DL_STABLECOINS,
+      false,
+      undefined,
+    );
   });
 
   it("degrades cleanly when the previous stablecoins cache is malformed", async () => {

--- a/worker/src/cron/sync-stablecoins.ts
+++ b/worker/src/cron/sync-stablecoins.ts
@@ -17,6 +17,8 @@ import {
   runStablecoinsPricingStage,
 } from "./sync-stablecoins/stages";
 import type { ChainRpcConfig } from "../lib/chain-registry";
+import { recordOutcome } from "../lib/circuit-breaker";
+import { CIRCUIT_SOURCE } from "../lib/constants";
 import type { CronProgressReporter } from "../lib/cron-logger";
 
 export interface SyncStablecoinsOptions {
@@ -131,6 +133,7 @@ export async function syncStablecoins(
     }),
   });
   if (stalenessCheck.blockedResult) {
+    await recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl);
     return stalenessCheck.blockedResult;
   }
   const { stalenessWarning, stalenessSummary } = stalenessCheck;


### PR DESCRIPTION
### Motivation
- A severe price-staleness path returned a degraded `stale-prices-blocked` result without recording a failed DefiLlama circuit outcome, preventing the circuit breaker from accumulating failures and opening to route runs to the CoinGecko fallback.
- This allowed a provider serving stale-but-structurally-valid data to repeatedly block publication without ever triggering the intended fallback, degrading public data freshness and alerting.

### Description
- Call `recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl)` in the staleness-blocked branch so the DefiLlama circuit receives a failure record before returning the blocked result. 
- Add the `recordOutcome` import and `CIRCUIT_SOURCE` import to `worker/src/cron/sync-stablecoins.ts` and invoke it immediately before returning the blocked result. 
- Add focused Vitest coverage asserting the stale-write-blocked path preserves the existing `stablecoins` cache and records a failed DefiLlama circuit outcome in `worker/src/cron/__tests__/sync-stablecoins.test.ts`.
- Preserve the existing no-write behavior and downstream-block behavior while enabling the circuit breaker to open on repeated stale responses.

### Testing
- Ran the focused test case with `npx vitest run worker/src/cron/__tests__/sync-stablecoins.test.ts -t "preserves the stablecoins cache when severe price staleness is detected" --reporter=verbose` and it passed. 
- Type-checked the worker with `cd worker && npx tsc --noEmit` and it succeeded. 
- Ran cron checks with `npm run check:cron-sync` and `npm run check:cron-connections` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bca3fe7083329f82abd39623b042)