### PR TITLE
Fix live reserve decimal-scale DoS guard

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/collateral-positions-api.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/collateral-positions-api.test.ts
@@ -290,4 +290,38 @@ describe("adaptCollateralPositions", () => {
       { name: "DAI (Dai Stablecoin)", pct: 50, risk: "low", coinId: "dai-makerdao" },
     ]);
   });
+
+  it("ignores provider positions with unsafe decimal scales", () => {
+    const result = adaptCollateralPositions(
+      {
+        "0xusdc": {
+          address: "0xUSDC",
+          name: "USD Coin",
+          symbol: "USDC",
+          decimals: 6,
+          positions: [{ collateralBalance: "1000000" }],
+        },
+        "0xunsafe": {
+          address: "0xUNSAFE",
+          name: "Unsafe Scale",
+          symbol: "DAI",
+          decimals: 1_000_000_000,
+          positions: [{ collateralBalance: "1" }],
+        },
+      },
+      {
+        "0xusdc": { price: { usd: 1 } },
+        "0xunsafe": { price: { usd: 1 } },
+      },
+      0,
+    );
+
+    expect(result.metadata).toMatchObject({
+      assetCount: 1,
+      activePositionCount: 1,
+    });
+    expect(result.slices).toEqual([
+      { name: "USDC (USD Coin)", pct: 100, risk: "low", coinId: "usdc-circle" },
+    ]);
+  });
 });

--- a/worker/src/cron/reserve-adapters/__tests__/jupusd.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/jupusd.test.ts
@@ -114,6 +114,20 @@ describe("adaptJupUsdData", () => {
     ]);
   });
 
+  it("ignores provider amounts with unsafe decimal scales", () => {
+    const result = adaptJupUsdData({
+      holdings: [
+        { name: "USDC", amount: "1000000", decimals: 6 },
+        { name: "USDtb", amount: "1", decimals: 1_000_000_000 },
+      ],
+    });
+
+    expect(result.metadata?.totalReserveUsd).toBe(1);
+    expect(result.slices).toEqual([
+      { name: "USDC", pct: 100, risk: "low", coinId: "usdc-circle", depType: "collateral" },
+    ]);
+  });
+
   it("passes through extra warnings from the fetch layer", () => {
     const result = adaptJupUsdData(
       {

--- a/worker/src/cron/reserve-adapters/collateral-positions-api.ts
+++ b/worker/src/cron/reserve-adapters/collateral-positions-api.ts
@@ -8,6 +8,7 @@ import {
   fetchJsonWithRetry,
   notApplicableFreshnessMetadata,
   normalizeSlices,
+  parseBoundedDecimals,
   requireJsonInput,
   reserveDegradedWarning,
   valueUsdFromBigIntPrice,
@@ -126,7 +127,7 @@ function inferDepType(symbol: string): ReserveSlice["depType"] | undefined {
 
 function parseCollateralBalance(raw: string | undefined, decimals: number): bigint {
   if (typeof raw !== "string" || !/^\d+$/.test(raw)) return 0n;
-  if (!Number.isInteger(decimals) || decimals < 0) return 0n;
+  if (parseBoundedDecimals(decimals) == null) return 0n;
   return BigInt(raw);
 }
 

--- a/worker/src/cron/reserve-adapters/helpers.ts
+++ b/worker/src/cron/reserve-adapters/helpers.ts
@@ -16,6 +16,7 @@ export {
   decimalStringFromBigInt,
   isReserveRisk,
   normalizeSlices,
+  parseBoundedDecimals,
   parsePositiveNumericLike,
   slicesFromPercentages,
   slicesFromValues,

--- a/worker/src/cron/reserve-adapters/jupusd.ts
+++ b/worker/src/cron/reserve-adapters/jupusd.ts
@@ -11,6 +11,7 @@ import {
   fetchJsonWithRetry,
   freshnessMetadataFromTimestamp,
   normalizeSlices,
+  parseBoundedDecimals,
   parseTimestampLikeToUnixSeconds,
   requireJsonInput,
 } from "./helpers";
@@ -100,7 +101,8 @@ async function fetchJupUsdJson<T>(
 
 function parseAmount(amount: string | undefined, decimals: number | undefined): number {
   if (typeof amount !== "string" || !/^\d+$/.test(amount)) return 0;
-  const precision = Number.isInteger(decimals) && decimals != null && decimals >= 0 ? decimals : 0;
+  const precision = decimals == null ? 0 : parseBoundedDecimals(decimals);
+  if (precision == null) return 0;
   const parsed = decimalNumberFromBigInt(BigInt(amount), precision);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }


### PR DESCRIPTION
### Motivation
- Provider-supplied `decimals` fields were used unchecked when converting BigInt holdings via `decimalNumberFromBigInt`, which can lead to huge `padStart` allocations and RangeError/OOM for attacker-controlled large scales. 
- The change bounds untrusted decimal scales before any BigInt-to-decimal string conversion so malicious upstream payloads cannot force excessive allocations while preserving normal parsing for legitimate scales.

### Description
- Validate and bound provider `decimals` using the existing `parseBoundedDecimals` check before calling `decimalNumberFromBigInt` in `jupusd` by updating `parseAmount` to reject unsafe scales. 
- Apply the same bounded-decimals guard in `collateral-positions-api` by validating `decimals` in `parseCollateralBalance` before constructing a `BigInt`. 
- Re-export `parseBoundedDecimals` from the reserve-adapters `helpers` barrel so adapters share a single validator. 
- Add regression tests to `worker/src/cron/reserve-adapters/__tests__/jupusd.test.ts` and `__tests__/collateral-positions-api.test.ts` asserting unsafe large decimal scales are ignored rather than parsed.

### Testing
- Ran targeted unit tests with `npx vitest run worker/src/cron/reserve-adapters/__tests__/jupusd.test.ts worker/src/cron/reserve-adapters/__tests__/collateral-positions-api.test.ts worker/src/cron/reserve-adapters/__tests__/slice-math.test.ts` and all tests passed. 
- Ran TypeScript typecheck with `cd worker && npx tsc --noEmit` and the build typecheck succeeded. 
- Added regression tests that cover maliciously large `decimals` values and verified they are ignored by the adapters (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bca381248332843064e7683827e8)