### PR TITLE
fix(dex-liquidity): preserve orderbook dedup identities

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts
@@ -19,6 +19,18 @@ describe("pool identity dedup", () => {
     expect(identity.exactPoolKey).toBe("ethereum:0xabc0000000000000000000000000000000000000");
   });
 
+  it("preserves synthetic orderbook prefixes for exact dedup identity", () => {
+    const identity = buildPoolIdentity({
+      chain: "orderbook",
+      protocol: "binance",
+      poolAddressOrId: "orderbook:binance",
+      tokenAddresses: [],
+    });
+
+    expect(identity.exactPoolKey).toBe("orderbook:orderbook:binance");
+    expect(identity.identitySource).toBe("native-id");
+  });
+
   it("can dedupe an identity-poor Uniswap v4 DL row against one staged exact-pool-id row", () => {
     const known = createKnownPoolIdentityIndex();
     registerKnownPoolIdentity(

--- a/worker/src/cron/dex-liquidity/pool-identity.ts
+++ b/worker/src/cron/dex-liquidity/pool-identity.ts
@@ -42,6 +42,7 @@ function isUniswapV4PoolId(poolId: string, protocol?: string | null): boolean {
 
 function canonicalizeExactPoolId(poolId: string, chain: string): string {
   const trimmed = poolId.trim();
+  if (chain.toLowerCase() === "orderbook") return trimmed;
   const chainPrefix = `${chain.toLowerCase()}:`;
   return trimmed.toLowerCase().startsWith(chainPrefix)
     ? trimmed.slice(chainPrefix.length)


### PR DESCRIPTION
### Motivation
- Fix a regression where canonicalizing exact pool IDs stripped the `orderbook:` prefix for rows with `chain: "orderbook"`, which prevented `isTrustworthyExactPoolId` from recognizing synthetic orderbook IDs and disabled exact deduplication for staged orderbook pools.

### Description
- Preserve synthetic orderbook pool IDs by skipping chain-prefix stripping when `chain === "orderbook"` in `canonicalizeExactPoolId` so the `orderbook:` marker remains available for trust checks.
- Add a regression unit test that verifies `orderbook:<exchange>` rows with no token addresses produce an `exactPoolKey` and `native-id` identity source.

### Testing
- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts` and the suite passed.
- Ran `cd worker && npx tsc --noEmit` and TypeScript typecheck completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bca348088332a8af7c61cd43c53a)