### PR TITLE
Reject future-dated supplemental price freshness

### DIFF
--- a/worker/src/cron/__tests__/supplemental-assets.test.ts
+++ b/worker/src/cron/__tests__/supplemental-assets.test.ts
@@ -131,6 +131,28 @@ describe("resolveSupplementalPrice", () => {
     )).toBeNull();
   });
 
+  it("rejects future-skewed supplemental upstream timestamps", () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    expect(resolveSupplementalPrice(
+      { coins: { "coingecko:vcred": { price: 1, timestamp: nowSec + 60 * 60 } } },
+      {},
+      "vcred",
+    )).toBeNull();
+
+    expect(resolveSupplementalPrice(
+      { coins: {} },
+      {
+        vcred: {
+          usd: 1,
+          usd_market_cap: 1_000_000,
+          last_updated_at: nowSec + 60 * 60,
+        },
+      },
+      "vcred",
+    )).toBeNull();
+  });
+
   it("preserves fresh supplemental CoinGecko upstream timestamps", () => {
     const nowSec = Math.floor(Date.now() / 1000);
 

--- a/worker/src/cron/sync-stablecoins/post-enrichment.ts
+++ b/worker/src/cron/sync-stablecoins/post-enrichment.ts
@@ -327,7 +327,7 @@ export async function runPostEnrichmentPricePipeline(
       const cached = priceCache.get(asset.id);
       if (!cached) continue;
       const maxAgeSec = getPriceCacheMaxAgeSec(cached.source, PRICE_CACHE_TTL);
-      if (now - cached.updatedAt >= maxAgeSec) continue;
+      if (cached.updatedAt > now || now - cached.updatedAt >= maxAgeSec) continue;
       const cachedAgreeSources =
         cached.agreeSources && cached.agreeSources.length > 0
           ? cached.agreeSources

--- a/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
@@ -1,5 +1,4 @@
 import { CHAIN_META } from "@shared/lib/chains";
-import { getPricingSourceRegistryEntry } from "@shared/lib/pricing-source-registry";
 import type { PriceObservedAtMode, StablecoinMeta } from "@shared/types/core";
 import { fetchWithRetry } from "../../../lib/fetch-retry";
 import { cancelResponseBodyQuietly } from "../../../lib/response-body";
@@ -32,11 +31,23 @@ export function toPositiveFiniteNumber(value: unknown): number | null {
   return null;
 }
 
-function isFreshSupplementalPrice(source: SupplementalPriceResolution["source"], observedAt: number | null): boolean {
-  if (observedAt == null) return true;
-  const maxTrustedAgeSec = getPricingSourceRegistryEntry(source)?.maxTrustedAgeSec ?? 15 * 60;
-  const nowSec = Math.floor(Date.now() / 1000);
-  return nowSec - observedAt <= maxTrustedAgeSec;
+function normalizeFreshSupplementalPriceResolution(
+  resolution: SupplementalPriceResolution,
+  options: { requireObservedAt?: boolean } = {},
+): SupplementalPriceResolution | null {
+  const freshness = validatePricingSourceFreshness({
+    source: resolution.source,
+    observedAt: resolution.observedAt,
+    observedAtMode: resolution.observedAtMode,
+    requireObservedAt: options.requireObservedAt,
+  });
+  if (!freshness.accepted) return null;
+
+  return {
+    ...resolution,
+    observedAt: freshness.observedAt,
+    observedAtMode: freshness.observedAtMode,
+  };
 }
 
 export function resolveLowVolumeCoinGeckoPrice(
@@ -83,7 +94,8 @@ export function resolveSupplementalPrice(
       observedAt,
       observedAtMode: observedAt != null ? "upstream" as const : null,
     };
-    if (isFreshSupplementalPrice(resolution.source, resolution.observedAt)) return resolution;
+    const freshResolution = normalizeFreshSupplementalPriceResolution(resolution);
+    if (freshResolution) return freshResolution;
   }
 
   const cgEntry = cgData[geckoId];
@@ -96,7 +108,7 @@ export function resolveSupplementalPrice(
       observedAt,
       observedAtMode: observedAt != null ? "upstream" as const : null,
     };
-    return isFreshSupplementalPrice(resolution.source, resolution.observedAt) ? resolution : null;
+    return normalizeFreshSupplementalPriceResolution(resolution);
   }
 
   return null;

--- a/worker/src/lib/__tests__/db-cache.test.ts
+++ b/worker/src/lib/__tests__/db-cache.test.ts
@@ -128,6 +128,32 @@ describe("getPriceCache", () => {
 });
 
 describe("savePriceCache", () => {
+  it("bounds cache freshness timestamps to the local sync time", async () => {
+    const statements: Array<{ sql: string; bindings: unknown[] }> = [];
+    const db = {
+      prepare: (sql: string) => ({
+        bind: (...bindings: unknown[]) => {
+          statements.push({ sql, bindings });
+          return { sql, bindings };
+        },
+      }),
+      batch: async () => [{ success: true, meta: { changes: 1 }, results: [] }],
+    } as unknown as D1Database;
+
+    await savePriceCache(db, [{
+      id: "future-priced-asset",
+      price: 1,
+      source: "coingecko",
+      confidence: "single-source",
+      observedAt: 1_800_003_700,
+      observedAtMode: "upstream",
+      syncedAt: 1_800_000_100,
+    }]);
+
+    expect(statements[0].bindings[2]).toBe(1_800_000_100);
+    expect(statements[0].bindings[5]).toBe(1_800_003_700);
+  });
+
   it("uses synced_at as the monotonic conflict guard while preserving observed_at as updated_at", async () => {
     const statements: Array<{ sql: string; bindings: unknown[] }> = [];
     const db = {

--- a/worker/src/lib/__tests__/depeg-trust-policy.test.ts
+++ b/worker/src/lib/__tests__/depeg-trust-policy.test.ts
@@ -34,6 +34,17 @@ describe("classifyPrimaryDepegTrust", () => {
     }, nowSec)).toBe("authoritative");
   });
 
+  it("requires confirmation for future-dated primary observations", () => {
+    expect(classifyPrimaryDepegTrust({
+      price: 0.998,
+      priceSource: "pyth",
+      priceConfidence: "single-source",
+      priceObservedAt: nowSec + 60,
+      priceObservedAtMode: "upstream",
+      agreeSources: ["pyth"],
+    }, nowSec)).toBe("confirm_required");
+  });
+
   it("uses source observation time rather than sync-write time for freshness", () => {
     expect(classifyPrimaryDepegTrust({
       price: 1,

--- a/worker/src/lib/db-cache.ts
+++ b/worker/src/lib/db-cache.ts
@@ -218,6 +218,12 @@ export interface PriceCacheWriteEntry {
   consensusSources?: string[];
 }
 
+function resolvePriceCacheUpdatedAt(e: PriceCacheWriteEntry, now: number): number {
+  const syncedAt = e.syncedAt ?? now;
+  if (e.observedAt == null) return syncedAt;
+  return e.observedAt <= syncedAt ? e.observedAt : syncedAt;
+}
+
 export async function savePriceCache(db: D1Database, entries: PriceCacheWriteEntry[]): Promise<void> {
   if (entries.length === 0) return;
   const now = Math.floor(Date.now() / 1000);
@@ -241,7 +247,7 @@ export async function savePriceCache(db: D1Database, entries: PriceCacheWriteEnt
       .bind(
         e.id,
         e.price,
-        e.observedAt ?? e.syncedAt ?? now,
+        resolvePriceCacheUpdatedAt(e, now),
         e.source ?? null,
         e.confidence ?? null,
         e.observedAt ?? null,

--- a/worker/src/lib/depeg-trust-policy.ts
+++ b/worker/src/lib/depeg-trust-policy.ts
@@ -43,11 +43,13 @@ function getPrimaryPriceAgeSec(
   input: Pick<PrimaryPriceTrustInput, "priceObservedAt" | "priceUpdatedAt">,
   nowSec: number,
 ): number {
-  return typeof input.priceObservedAt === "number" && Number.isFinite(input.priceObservedAt)
-    ? Math.max(0, nowSec - input.priceObservedAt)
+  const observedAt = typeof input.priceObservedAt === "number" && Number.isFinite(input.priceObservedAt)
+    ? input.priceObservedAt
     : typeof input.priceUpdatedAt === "number" && Number.isFinite(input.priceUpdatedAt)
-      ? Math.max(0, nowSec - input.priceUpdatedAt)
-      : Number.POSITIVE_INFINITY;
+      ? input.priceUpdatedAt
+      : null;
+  if (observedAt == null || observedAt > nowSec) return Number.POSITIVE_INFINITY;
+  return nowSec - observedAt;
 }
 
 function getPrimaryTrustSources(input: Pick<PrimaryPriceTrustInput, "agreeSources" | "priceSource">): string[] {


### PR DESCRIPTION
### Motivation
- Upstream-supplied future `timestamp` / `last_updated_at` values could be accepted as fresh and persisted, allowing poisoned supplemental prices to remain replayable until the forged future time plus the trust window. 
- The change restores a strict freshness gate and bounds cache timestamps so future-skewed upstream observations cannot extend publication or depeg-trust windows.

### Description
- Route DefiLlama/CoinGecko supplemental observations through the shared validator by using `validatePricingSourceFreshness()` in `worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts` so stale and future-skewed upstream timestamps fail closed and `observedAt`/`observedAtMode` are normalized. 
- Clamp `price_cache.updated_at` on write by adding `resolvePriceCacheUpdatedAt()` and using it in `savePriceCache()` in `worker/src/lib/db-cache.ts` so future upstream timestamps are written no later than the local sync time while preserving raw `observed_at` for diagnostics. 
- Prevent replay of future-dated cache rows by skipping cached fallback entries whose `updatedAt` is greater than local now in `worker/src/cron/sync-stablecoins/post-enrichment.ts`. 
- Treat future primary observations as untrusted in depeg decisions by changing `getPrimaryPriceAgeSec()` in `worker/src/lib/depeg-trust-policy.ts` to consider future `observedAt`/`updatedAt` values as invalid (infinite age). 
- Add focused unit tests covering supplemental future-skew rejection, cache-timestamp bounding, and future-primary depeg behavior in `worker/src/cron/__tests__/supplemental-assets.test.ts`, `worker/src/lib/__tests__/db-cache.test.ts`, and `worker/src/lib/__tests__/depeg-trust-policy.test.ts`.

### Testing
- Ran the targeted Vitest suites with `npx vitest run worker/src/cron/__tests__/supplemental-assets.test.ts worker/src/lib/__tests__/db-cache.test.ts worker/src/lib/__tests__/depeg-trust-policy.test.ts` and all tests passed. 
- Ran TypeScript checks with `cd worker && npx tsc --noEmit` and the compile check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bca35358833294a5c4c7eddf56d1)