### PR TITLE
Prioritize critical digest risk signals

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1587,7 +1587,7 @@ If no digest exists yet, the endpoint returns only `{ "digest": null }`.
 | `digestExtended`      | `string \| null`                     | Extended commentary for the website view                                                  |
 | `generatedAt`         | `number`                             | Unix seconds when this digest was generated (present only when `digest` is non-null)      |
 | `editionNumber`       | `number \| null`                     | Sequential daily digest number (present only when `digest` is non-null)                   |
-| `riskSignal`          | `DigestRiskSignal \| null`           | Compact active-depeg risk summary parsed from stored digest input data                    |
+| `riskSignal`          | `DigestRiskSignal \| null`           | Compact active-depeg risk summary parsed from stored digest input data; critical depegs are prioritized before market impact and deviation size |
 | `changeSummary`       | `DigestChangeSummary \| null`        | Deterministic "what changed since yesterday" summary parsed from stored digest input data |
 | `nextTriggers`        | `DigestNextTrigger[] \| null`        | Structured forward-looking threshold checks for tomorrow's digest                         |
 | `forwardLookOutcomes` | `DigestForwardLookOutcome[] \| null` | Evaluation of the previous digest's next triggers against the latest input                |
@@ -1655,7 +1655,7 @@ Each element uses `digestText` (note: differs from the singular `/api/daily-dige
 | `psiScore`            | `number \| null`                     | PSI score parsed from archived digest input data                                         |
 | `psiBand`             | `string \| null`                     | PSI condition band parsed from archived digest input data                                |
 | `totalMcapUsd`        | `number \| null`                     | Ecosystem market cap parsed from archived digest input data                              |
-| `riskSignal`          | `DigestRiskSignal \| null`           | Compact active-depeg risk summary parsed from archived digest input data                 |
+| `riskSignal`          | `DigestRiskSignal \| null`           | Compact active-depeg risk summary parsed from archived digest input data; critical depegs are prioritized before market impact and deviation size |
 | `nextTriggers`        | `DigestNextTrigger[] \| null`        | Structured forward-looking threshold checks parsed from archived digest input data       |
 | `forwardLookOutcomes` | `DigestForwardLookOutcome[] \| null` | Evaluation of the previous digest's next triggers parsed from archived digest input data |
 | `riskTape`            | `DigestRiskTapeItem[] \| null`       | Compact risk-state chips parsed from archived digest input data                          |

--- a/docs/digest-pipeline.md
+++ b/docs/digest-pipeline.md
@@ -310,7 +310,7 @@ Posted to Telegram only (no Twitter for weekly recaps). Title is prefixed with "
 The latest digest is presented in a broadsheet newspaper style:
 - **Masthead:** compact uppercase lockup with the full date; the homepage preview uses a slightly sharper mono masthead treatment than the archive broadsheet
 - **Headline:** the homepage preview uses `Newsreader` at a larger newspaper-style display scale, while the full `/digest/` broadsheet keeps the original serif headline treatment
-- **Risk badge + tape:** when `/api/daily-digest` exposes an active depeg `riskSignal`, the broadsheet renders a compact depeg badge near the headline so a truncated first paragraph cannot hide the risk state. New rows also render the `riskTape` chips and a compact next-trigger line in preview mode.
+- **Risk badge + tape:** when `/api/daily-digest` exposes an active depeg `riskSignal`, the API prioritizes critical depegs before market impact and deviation size, and the broadsheet renders the resulting compact depeg badge near the headline so a truncated first paragraph cannot hide the risk state. New rows also render the `riskTape` chips and a compact next-trigger line in preview mode.
 - **Body:** Extended text paragraphs in italic Courier-style monospace (`EDITORIAL_BODY_STYLE`). On the homepage and `/digest/` archive preview, only the first editorial paragraph is shown as a teaser; the paragraph is preserved whole and never character-clamped mid-sentence. Digest detail pages show the full editorial body.
 - **Homepage preview split:** desktop uses an asymmetric two-column layout with a hairline `Executive Summary` label and headline block on the left, then the lead paragraph plus CTA rail on the right
 

--- a/worker/src/api/__tests__/digest-risk-summary.test.ts
+++ b/worker/src/api/__tests__/digest-risk-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { selectDigestRiskSignal } from "../digest-risk-summary";
+
+describe("selectDigestRiskSignal", () => {
+  it("prioritizes critical depegs over larger-bps small-cap watch noise", () => {
+    const signal = selectDigestRiskSignal({
+      activeDepegCount: 2,
+      topDepegs: [
+        { symbol: "SMALL", bps: -9000, mcapUsd: 100_000 },
+        { symbol: "PMUSD", bps: -3000, mcapUsd: 60_000_000, impactScore: 1_800_000_000 },
+      ],
+    });
+
+    expect(signal).toMatchObject({
+      symbol: "PMUSD",
+      bps: -3000,
+      mcapUsd: 60_000_000,
+      severity: "critical",
+      activeCount: 2,
+      date: null,
+    });
+  });
+
+  it("prioritizes critical daily entries in weekly digest archives", () => {
+    const signal = selectDigestRiskSignal({
+      dailyDigests: [
+        {
+          date: "2026-06-18",
+          inputData: {
+            activeDepegCount: 1,
+            topDepegs: [{ symbol: "SMALL", bps: -9000, mcapUsd: 100_000 }],
+          },
+        },
+        {
+          date: "2026-06-19",
+          inputData: {
+            activeDepegCount: 1,
+            topDepegs: [{ symbol: "PMUSD", bps: -3000, mcapUsd: 60_000_000 }],
+          },
+        },
+      ],
+    });
+
+    expect(signal).toMatchObject({
+      symbol: "PMUSD",
+      bps: -3000,
+      mcapUsd: 60_000_000,
+      severity: "critical",
+      date: "2026-06-19",
+    });
+  });
+});

--- a/worker/src/api/digest-risk-summary.ts
+++ b/worker/src/api/digest-risk-summary.ts
@@ -8,10 +8,29 @@ function isDailyDigestLike(value: unknown): value is DailyDigestLike {
   return isRecord(value) && Array.isArray(value.topDepegs);
 }
 
+function depegImpactScore(depeg: { bps: number; mcapUsd: number; impactScore?: number | null }): number {
+  return depeg.impactScore ?? Math.abs(depeg.bps) * depeg.mcapUsd;
+}
+
+function compareDepegRisk(
+  a: { bps: number; mcapUsd: number; impactScore?: number | null },
+  b: { bps: number; mcapUsd: number; impactScore?: number | null },
+): number {
+  const criticalDelta = Number(isCriticalDepegRisk(b)) - Number(isCriticalDepegRisk(a));
+  return criticalDelta || depegImpactScore(b) - depegImpactScore(a) || Math.abs(b.bps) - Math.abs(a.bps);
+}
+
+function compareDigestRiskSignal(a: DigestRiskSignal, b: DigestRiskSignal): number {
+  return compareDepegRisk(
+    { bps: a.bps, mcapUsd: a.mcapUsd ?? 0 },
+    { bps: b.bps, mcapUsd: b.mcapUsd ?? 0 },
+  );
+}
+
 function selectTopDepeg(input: DailyDigestLike, date?: string | null): DigestRiskSignal | null {
   const top = input.topDepegs
     .filter((depeg) => Number.isFinite(depeg.bps))
-    .sort((a, b) => Math.abs(b.bps) - Math.abs(a.bps) || (b.impactScore ?? 0) - (a.impactScore ?? 0))[0];
+    .sort(compareDepegRisk)[0];
   if (!top) return null;
   return {
     kind: "depeg",
@@ -41,7 +60,7 @@ export function selectDigestRiskSignal(input: unknown): DigestRiskSignal | null 
         return selectTopDepeg(dailyInput, date);
       })
       .filter((entry): entry is DigestRiskSignal => entry !== null)
-      .sort((a, b) => Math.abs(b.bps) - Math.abs(a.bps) || (b.mcapUsd ?? 0) - (a.mcapUsd ?? 0));
+      .sort(compareDigestRiskSignal);
     return candidates[0] ?? null;
   }
 


### PR DESCRIPTION
### Motivation
- The public digest `riskSignal` helper selected the top depeg by absolute basis points (bps) first, which could let a high-bps, low‑mcap event mask a lower‑bps but critical high‑mcap depeg contrary to the `isCriticalDepegRisk()` definition.  
- The weekly archive aggregation repeated the same absolute‑bps-first ordering, so archived badge data could also omit material critical depegs.

### Description
- Change the digest selector to rank critical depegs first, then by market impact (falling back to per-event `impactScore` or `|bps| * mcap`), and finally by absolute deviation; implemented via `depegImpactScore`, `compareDepegRisk`, and `compareDigestRiskSignal` in `worker/src/api/digest-risk-summary.ts`.  
- Apply the safer comparator to both daily `topDepegs` selection and weekly `dailyDigests` candidate aggregation so latest and archived `riskSignal` responses preserve critical ordering.  
- Add focused regression tests in `worker/src/api/__tests__/digest-risk-summary.test.ts` that prove a small-cap high-bps watch event no longer masks a lower-bps critical depeg in both daily and weekly inputs.  
- Update docs to reflect the public API ordering semantics in `docs/api-reference.md` and `docs/digest-pipeline.md`.

### Testing
- Ran the new unit suite with `npx vitest run worker/src/api/__tests__/digest-risk-summary.test.ts` and the file-level digest suites with `npx vitest run worker/src/api/__tests__/daily-digest.test.ts worker/src/api/__tests__/digest-archive.test.ts worker/src/api/__tests__/digest-risk-summary.test.ts`, and all tests passed.  
- Ran worker TypeScript checks with `npm run typecheck:worker`, and the worker typecheck completed successfully.  
- The changes are limited to the digest risk selector, tests, and documentation and preserve existing API shapes and behavior except for the intended ordering fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bca3f97883328306606f4e6bc4f7)