### PR TITLE
fix(ci): catch shorthand SQLite required columns

### DIFF
--- a/scripts/__tests__/check-worker-migrations.test.ts
+++ b/scripts/__tests__/check-worker-migrations.test.ts
@@ -248,15 +248,18 @@ describe("validateRolloutSafetyAnnotation", () => {
   });
 
   it("rejects new NOT NULL columns that would break still-live writes without a default", () => {
-    expect(() =>
-      validateRolloutSafetyAnnotation(
-        "0071_add_required_column.sql",
-        [
-          `-- rollout-safety: ${REQUIRED_ROLLOUT_SAFETY_MODE}`,
-          "ALTER TABLE api_keys ADD COLUMN owner_team TEXT NOT NULL;",
-        ].join("\n"),
-      ),
-    ).toThrow(UNSAFE_ROLLOUT_ADD_COLUMN_LABEL);
+    for (const addColumnStatement of [
+      "ALTER TABLE api_keys ADD COLUMN owner_team TEXT NOT NULL;",
+      "ALTER TABLE api_keys ADD owner_team TEXT NOT NULL;",
+      ["ALTER TABLE api_keys", "  ADD owner_team TEXT NOT NULL", "  CHECK (length(owner_team) > 0);"].join("\n"),
+    ]) {
+      expect(() =>
+        validateRolloutSafetyAnnotation(
+          "0071_add_required_column.sql",
+          [`-- rollout-safety: ${REQUIRED_ROLLOUT_SAFETY_MODE}`, addColumnStatement].join("\n"),
+        ),
+      ).toThrow(UNSAFE_ROLLOUT_ADD_COLUMN_LABEL);
+    }
   });
 
   it("accepts additive migrations with the required rollout-safety header", () => {

--- a/scripts/ci/check-worker-migrations.mjs
+++ b/scripts/ci/check-worker-migrations.mjs
@@ -216,7 +216,8 @@ export function findUnsafeRolloutStatements(sql) {
   const unsafeStatements = UNSAFE_ROLLOUT_SAFETY_PATTERNS.filter(({ pattern }) => pattern.test(normalizedSql)).map(
     ({ label }) => label,
   );
-  const addColumnStatements = normalizedSql.match(/\bALTER\s+TABLE\b[\s\S]*?\bADD\s+COLUMN\b[\s\S]*?(?:;|$)/gi) ?? [];
+  const addColumnStatements =
+    normalizedSql.match(/\bALTER\s+TABLE\b[\s\S]*?\bADD\b(?:\s+COLUMN\b)?[\s\S]*?(?:;|$)/gi) ?? [];
   const hasUnsafeAddColumn = addColumnStatements.some(
     (statement) => /\bNOT\s+NULL\b/i.test(statement) && !/\bDEFAULT\b/i.test(statement),
   );


### PR DESCRIPTION
### Motivation
- The rollout-safety checker could be bypassed by SQLite's optional `COLUMN` syntax in `ALTER TABLE ... ADD ...`, letting `NOT NULL` columns without a `DEFAULT` pass CI and potentially break still-live workers.

### Description
- Update the migration checker in `scripts/ci/check-worker-migrations.mjs` so `findUnsafeRolloutStatements()` treats `ALTER TABLE ... ADD` the same as `ALTER TABLE ... ADD COLUMN` by matching an optional `COLUMN` token.
- Keep the existing `NOT NULL`-without-`DEFAULT` detection logic and surface the same `UNSAFE_ROLLOUT_ADD_COLUMN_LABEL` when found.
- Expand the focused unit test in `scripts/__tests__/check-worker-migrations.test.ts` to assert detection for `ADD COLUMN`, shorthand `ADD`, and a multiline shorthand `ADD` variant.

### Testing
- Ran `npx vitest run scripts/__tests__/check-worker-migrations.test.ts` and the test suite passed.
- Ran `npm run check:migrations` (the migration validation script) and it validated migrations while rejecting the unsafe shorthand `ADD` case as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0be2708332bd3ad19a8f18fb76)