### PR TITLE
Fix worker promotion for ambiguous package-lock metadata changes

### DIFF
--- a/scripts/__tests__/classify-deploy-changes.test.ts
+++ b/scripts/__tests__/classify-deploy-changes.test.ts
@@ -146,6 +146,23 @@ diff --git a/package-lock.json b/package-lock.json
 `),
     ).toBe(true);
   });
+
+  it("falls back to Worker promotion for package-lock metadata hunks without enclosing package context", () => {
+    expect(
+      hasWorkerPackagePromotionImpact(`
+diff --git a/package-lock.json b/package-lock.json
+@@ -1123 +1123 @@
+-      "version": "4.3.6",
++      "version": "4.3.7",
+@@ -1124 +1124 @@
+-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
++      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.7.tgz",
+@@ -1125 +1125 @@
+-      "integrity": "sha512-old",
++      "integrity": "sha512-new",
+`),
+    ).toBe(true);
+  });
 });
 
 describe("hasDeployImpact", () => {

--- a/scripts/lib/deploy-impact.mjs
+++ b/scripts/lib/deploy-impact.mjs
@@ -14,6 +14,20 @@ const WORKER_PROMOTION_EXACT_PATHS = new Set(DEPLOY_IMPACT_REGISTRY.workerPromot
 const WORKER_SHARED_EXCLUDED_PATHS = new Set(DEPLOY_IMPACT_REGISTRY.worker.sharedExcludedPaths ?? []);
 const WORKER_PROMOTION_SHARED_EXCLUDED_PATHS = new Set(DEPLOY_IMPACT_REGISTRY.workerPromotion.sharedExcludedPaths);
 const WORKER_ROOT_RUNTIME_PACKAGES = new Set(DEPLOY_IMPACT_REGISTRY.workerRootRuntimePackages);
+const LOCKFILE_PACKAGE_METADATA_KEYS = new Set([
+  "bin",
+  "cpu",
+  "dependencies",
+  "engines",
+  "integrity",
+  "license",
+  "optionalDependencies",
+  "os",
+  "peerDependencies",
+  "resolved",
+  "version",
+]);
+const UNKNOWN_LOCKFILE_PACKAGE_CHANGE = "*lockfile-package-change*";
 const PAGES_UI_EXACT_PATHS = new Set([
   "next.config.ts",
   "package.json",
@@ -78,32 +92,88 @@ function normalizeLockPackageName(packagePath) {
 
 export function extractPackageNamesFromDiff(diffText) {
   const names = new Set();
+  let currentFile = null;
+  let currentLockPackageName = null;
+  let hunkLockPackageName = null;
+  let hunkHasUnknownLockPackageMetadataChange = false;
+
+  function flushHunk() {
+    if (hunkLockPackageName) {
+      names.add(hunkLockPackageName);
+    } else if (hunkHasUnknownLockPackageMetadataChange) {
+      names.add(UNKNOWN_LOCKFILE_PACKAGE_CHANGE);
+    }
+    hunkLockPackageName = null;
+    hunkHasUnknownLockPackageMetadataChange = false;
+  }
+
   for (const rawLine of diffText.split(/\r?\n/g)) {
-    if (
-      (!rawLine.startsWith("+") && !rawLine.startsWith("-"))
-      || rawLine.startsWith("+++")
-      || rawLine.startsWith("---")
-    ) {
+    if (rawLine.startsWith("diff --git ")) {
+      flushHunk();
+      const match = rawLine.match(/ b\/(.+)$/);
+      currentFile = match ? match[1].trim() : null;
+      currentLockPackageName = null;
       continue;
     }
+    if (rawLine.startsWith("+++ b/")) {
+      currentFile = rawLine.slice("+++ b/".length).trim();
+      currentLockPackageName = null;
+      continue;
+    }
+    if (rawLine.startsWith("@@")) {
+      flushHunk();
+      currentLockPackageName = null;
+      continue;
+    }
+    if (rawLine.startsWith("---")) {
+      continue;
+    }
+
+    if (!rawLine.startsWith("+") && !rawLine.startsWith("-") && !rawLine.startsWith(" ")) {
+      continue;
+    }
+
     const line = rawLine.slice(1).trim();
     const parsed = parseQuotedJsonKey(line);
     if (!parsed) {
       continue;
     }
+
     if (parsed.key.startsWith("node_modules/")) {
-      names.add(normalizeLockPackageName(parsed.key.slice("node_modules/".length)));
+      const packageName = normalizeLockPackageName(parsed.key.slice("node_modules/".length));
+      currentLockPackageName = packageName;
+      hunkLockPackageName = packageName;
+      if (rawLine.startsWith("+") || rawLine.startsWith("-")) {
+        names.add(packageName);
+      }
       continue;
     }
-    if (parsed.rest.startsWith(":")) {
+
+    if (!parsed.rest.startsWith(":")) {
+      continue;
+    }
+
+    if (currentFile === "package-lock.json" && LOCKFILE_PACKAGE_METADATA_KEYS.has(parsed.key)) {
+      if (currentLockPackageName) {
+        hunkLockPackageName = currentLockPackageName;
+      } else if (rawLine.startsWith("+") || rawLine.startsWith("-")) {
+        hunkHasUnknownLockPackageMetadataChange = true;
+      }
+      continue;
+    }
+
+    if (rawLine.startsWith("+") || rawLine.startsWith("-")) {
       names.add(parsed.key);
     }
   }
+  flushHunk();
   return [...names];
 }
 
 export function hasWorkerPackagePromotionImpact(diffText) {
-  return extractPackageNamesFromDiff(diffText).some((name) => WORKER_ROOT_RUNTIME_PACKAGES.has(name));
+  return extractPackageNamesFromDiff(diffText).some((name) =>
+    name === UNKNOWN_LOCKFILE_PACKAGE_CHANGE || WORKER_ROOT_RUNTIME_PACKAGES.has(name),
+  );
 }
 
 export function hasWorkerDeployImpact(files) {


### PR DESCRIPTION
### Motivation
- Zero-context `package-lock.json` diffs (with `--unified=0`) can omit the enclosing `node_modules/<pkg>` key and expose only metadata keys like `version`, `resolved`, or `integrity`, which caused the classifier to miss Worker runtime dependency updates and skip Worker promotion.
- The deploy workflow gates Worker upload/promotion on the classifier output, so a conservative fix is required to preserve deployment integrity when lockfile metadata changes are observed.

### Description
- Update `scripts/lib/deploy-impact.mjs` to conservatively treat ambiguous lockfile metadata hunks as Worker-impacting by default, without losing precise package-name extraction when `node_modules/<pkg>` context is present.
- Add `LOCKFILE_PACKAGE_METADATA_KEYS` and an `UNKNOWN_LOCKFILE_PACKAGE_CHANGE` marker to recognize metadata-only edits such as `version`, `resolved`, and `integrity`.
- Rewrite `extractPackageNamesFromDiff()` to track diff hunks and file context, flush hunk state, and record either the concrete package name or the unknown-change marker when package context is absent.
- Change `hasWorkerPackagePromotionImpact()` to return true when the unknown-lockfile marker is present or when a known Worker runtime package is identified.
- Add a regression test in `scripts/__tests__/classify-deploy-changes.test.ts` that asserts the classifier treats package-lock-only `version`/`resolved`/`integrity` hunks without enclosing `node_modules/<pkg>` lines as Worker-promotion impacting.

### Testing
- Ran the focused unit suite: `npx vitest run scripts/__tests__/classify-deploy-changes.test.ts`, and all tests passed (28 passed, 0 failed).
- Attempted the local merge gate with `npm run test:merge-gate`, but it could not complete because the local checkout lacks an `origin/main` ref to diff against; the command failed to run to completion in this environment and is therefore blocked here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0cbb3c8332b802a51f1c56145a)