### PR TITLE
Fix variant blacklist inheritance live-reserve lookup

### DIFF
--- a/shared/lib/__tests__/report-card-blacklist-matchers.test.ts
+++ b/shared/lib/__tests__/report-card-blacklist-matchers.test.ts
@@ -256,6 +256,37 @@ describe("resolveBlacklistStatuses variant inheritance", () => {
     expect(resolved.get("child")).toBe("possible");
   });
 
+  it("uses the parent's live reserves when resolving variant inheritance", () => {
+    const metas = [
+      {
+        id: "parent",
+        name: "Parent",
+        symbol: "PAR",
+        flags: { governance: "centralized-dependent" as const },
+        reserves: [{ name: "ETH", pct: 100, risk: "very-low" as const }],
+      },
+      {
+        id: "child",
+        name: "Child",
+        symbol: "CHD",
+        flags: { governance: "centralized-dependent" as const, navToken: true },
+        variantOf: "parent",
+        variantKind: "savings-passthrough" as const,
+        pegReferenceId: "parent",
+        reserves: [{ name: "ETH", pct: 100, risk: "very-low" as const }],
+      },
+    ];
+    const reserveSlicesById = new Map([
+      ["parent", [{ name: "DAI reserves", pct: 100, risk: "low" as const }]],
+      ["child", [{ name: "ETH", pct: 100, risk: "very-low" as const }]],
+    ]);
+
+    const resolved = resolveBlacklistStatuses(metas as never, { reserveSlicesById });
+
+    expect(resolved.get("parent")).toBe("inherited");
+    expect(resolved.get("child")).toBe("inherited");
+  });
+
   it("does not coerce a variant to inherited when the parent is not blacklistable", () => {
     const metas = [
       {

--- a/shared/lib/report-card-blacklist-matchers.ts
+++ b/shared/lib/report-card-blacklist-matchers.ts
@@ -24,6 +24,7 @@ export interface BlacklistResolutionContext {
 export interface ResolveBlacklistStatusOptions {
   context?: BlacklistResolutionContext;
   reserveSlices?: readonly ReserveSlice[];
+  reserveSlicesById?: ReadonlyMap<string, readonly ReserveSlice[]>;
 }
 
 export interface ResolveBlacklistStatusesOptions {
@@ -249,7 +250,10 @@ function resolveBlacklistStatusWithoutExplicitOverride(
     }
     const parentMeta = options.context.trackedMetaById?.get(meta.variantOf);
     if (parentMeta) {
-      const parentStatus = resolveBlacklistStatus(parentMeta, options);
+      const parentStatus = resolveBlacklistStatus(parentMeta, {
+        ...options,
+        reserveSlices: options.reserveSlicesById?.get(parentMeta.id),
+      });
       if (parentStatus === true || parentStatus === "inherited") return "inherited";
       if (parentStatus === "possible") return "possible";
     }
@@ -324,6 +328,7 @@ export function resolveBlacklistStatuses(
       const status = resolveBlacklistStatus(meta, {
         context,
         reserveSlices: reserveSlicesById?.get(meta.id),
+        reserveSlicesById,
       });
       if ((status === true || status === "inherited") && !blacklistableIds.has(meta.id)) {
         blacklistableIds.add(meta.id);
@@ -337,6 +342,7 @@ export function resolveBlacklistStatuses(
         metas.map((meta) => [meta.id, resolveBlacklistStatus(meta, {
           context: finalContext,
           reserveSlices: reserveSlicesById?.get(meta.id),
+          reserveSlicesById,
         })] as const),
       );
     }


### PR DESCRIPTION
### Motivation
- Variant parent-status resolution could be evaluated using the child variant's live reserve slices, causing incorrect "inherited"/"possible" blacklist analytics when a parent's status depended on its own live reserves.
- The public snapshot path supplies a per-id live reserve map, which made this mismatch reachable in runtime report-card generation.

### Description
- Add `reserveSlicesById` to `ResolveBlacklistStatusOptions` and thread it through `resolveBlacklistStatuses` so the per-id live reserve map is available during recursive resolution.
- When resolving a tracked variant's parent, call `resolveBlacklistStatus(parentMeta, { ..., reserveSlices: options.reserveSlicesById?.get(parentMeta.id) })` so the parent is evaluated with its own live reserves instead of the child's slices.
- Pass `reserveSlicesById` into both the iterative resolution passes and the final status materialization to ensure consistent per-id reserve lookups.
- Add a regression test `uses the parent's live reserves when resolving variant inheritance` in `shared/lib/__tests__/report-card-blacklist-matchers.test.ts` that exercises a parent becoming blacklistable only from live reserve data.

### Testing
- Ran `npx vitest run shared/lib/__tests__/report-card-blacklist-matchers.test.ts` and the suite passed (28 tests, all passed).
- Ran worker boundary and dependency cycle checks with `npm run check:worker-boundary` and `npm run check:shared-cycles` and both completed without blocking errors.
- Ran type checks with `npm run typecheck` and `npm run typecheck:worker` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356ef20b0c833280b8823d5a9ab3e1)