### PR TITLE
fix(worker): preserve stale slot retry takeover

### DIFF
--- a/worker/src/lib/__tests__/cron-leases.test.ts
+++ b/worker/src/lib/__tests__/cron-leases.test.ts
@@ -363,10 +363,11 @@ function makeLeaseDb(seed?: {
         },
         all: async () => {
           if (sql.includes("FROM cron_slot_executions") && sql.includes("ORDER BY slot_started_at ASC")) {
-            const [slotKey, staleBefore] = args as [string, number];
+            const [slotKey, excludeSlotStartedAt, staleBefore] = args as [string, number, number];
             return {
               results: [...slots.values()].filter((slot) =>
                 slot.slot_key === slotKey &&
+                slot.slot_started_at !== excludeSlotStartedAt &&
                 slot.state === "running" &&
                 slot.updated_at < staleBefore,
               ),
@@ -900,6 +901,40 @@ describe("runScheduledSlotWithFence", () => {
     );
 
     expect(result.status).toBe("skipped_running");
+  });
+
+
+  it("takes over a stale running row for the requested slot", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const slotStartedAt = now - 3600;
+    const db = makeLeaseDb({
+      slots: [{
+        slot_key: "halfHourlyOffset",
+        slot_started_at: slotStartedAt,
+        state: "running",
+        result_status: null,
+        execution_owner: "owner-a",
+        started_at: slotStartedAt,
+        finished_at: null,
+        updated_at: now - 1800,
+        metadata: null,
+      }],
+    });
+    const fn = vi.fn(async () => ({ jobsErrored: 0, jobsDegraded: 0, jobsSkipped: 0 }));
+
+    const result = await runScheduledSlotWithFence(
+      db,
+      "halfHourlyOffset",
+      fn,
+      { slotStartedAt, owner: "owner-b", staleAfterSec: 1200 },
+    );
+
+    expect(result.status).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    const slot = db.getSlot("halfHourlyOffset", slotStartedAt);
+    expect(slot?.execution_owner).toBe("owner-b");
+    expect(slot?.result_status).toBe("ok");
+    expect(slot?.metadata).toBe(JSON.stringify({ jobsErrored: 0, jobsDegraded: 0, jobsSkipped: 0 }));
   });
 
   it("marks stale running slots for the same schedule as expired before claiming a new slot", async () => {

--- a/worker/src/lib/cron-lease.ts
+++ b/worker/src/lib/cron-lease.ts
@@ -277,6 +277,7 @@ async function listStaleScheduledSlotExecutions(
   db: D1Database,
   slotKey: string,
   staleBefore: number,
+  excludeSlotStartedAt: number,
 ): Promise<StaleSlotExecutionRow[]> {
   const rows = await runWithOverloadRetry(() =>
     db
@@ -284,11 +285,12 @@ async function listStaleScheduledSlotExecutions(
         `SELECT slot_key, slot_started_at, execution_owner, started_at, updated_at
            FROM cron_slot_executions
            WHERE slot_key = ?
+             AND slot_started_at != ?
              AND state = 'running'
              AND updated_at < ?
            ORDER BY slot_started_at ASC`,
       )
-      .bind(slotKey, staleBefore)
+      .bind(slotKey, excludeSlotStartedAt, staleBefore)
       .all<StaleSlotExecutionRow>(),
   );
   return rows.results ?? [];
@@ -505,7 +507,7 @@ async function claimScheduledSlotExecution(
 ): Promise<"claimed" | "duplicate" | "running"> {
   const nowSec = Math.floor(Date.now() / 1000);
   const staleBefore = nowSec - staleAfterSec;
-  const staleSlots = await listStaleScheduledSlotExecutions(db, slotKey, staleBefore);
+  const staleSlots = await listStaleScheduledSlotExecutions(db, slotKey, staleBefore, slotStartedAt);
   for (const staleSlot of staleSlots) {
     const reconciliation = await reconcileStaleSlotArtifacts(db, staleSlot, nowSec);
     await writeStaleSlotEventMarker(db, staleSlot, nowSec, reconciliation);


### PR DESCRIPTION
### Motivation
- A same-schedule stale-expiration step was marking every stale `running` row for a `slot_key` as `finished` without excluding the specific `slot_started_at` being claimed, causing retries of that same slot to be classified as `duplicate` instead of allowing the existing same-slot takeover logic to run.

### Description
- Exclude the requested `slot_started_at` from same-schedule stale cleanup by adding an `excludeSlotStartedAt` parameter to `listStaleScheduledSlotExecutions` and adding `AND slot_started_at != ?` to the query in `worker/src/lib/cron-lease.ts`.
- Pass the current `slotStartedAt` into the stale-listing call in `claimScheduledSlotExecution` so the slot being claimed is not pre-marked finished.
- Update the test D1 mock query signature to expect the new `excludeSlotStartedAt` bind parameter in `worker/src/lib/__tests__/cron-leases.test.ts`.
- Add a focused unit test that verifies a stale `running` row for the requested slot is taken over and executed (the retry path), ensuring the pre-existing takeover behavior is reachable.

### Testing
- Ran the focused Vitest cron-lease suite with `npx vitest run worker/src/lib/__tests__/cron-leases.test.ts` and observed all tests passed (`24 passed`).
- Verified TypeScript build for the worker with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0c3ad08332bb68a49bf3cfb0f5)