### PR TITLE
fix: make env contract imports Node-resolvable

### DIFF
--- a/shared/lib/env-contract.ts
+++ b/shared/lib/env-contract.ts
@@ -3,17 +3,17 @@ export {
   getAllEnvBindingKeys,
   getRuntimeActiveEnvKeys,
   getRuntimeEnvKeys,
-} from "./env-contract/registry";
-export type { EnvBindingKey } from "./env-contract/registry";
-export { renderEnvExample } from "./env-contract/render-env-example";
+} from "./env-contract/registry.ts";
+export type { EnvBindingKey } from "./env-contract/registry.ts";
+export { renderEnvExample } from "./env-contract/render-env-example.ts";
 export {
   renderOperatorOriginAccessEnvBlock,
   renderWorkerInfrastructureEnvBlock,
-} from "./env-contract/render-markdown";
+} from "./env-contract/render-markdown.ts";
 export type {
   EnvBindingDefinition,
   EnvBindingValueType,
   EnvExampleSection,
   EnvRuntimeName,
   EnvRuntimeStatus,
-} from "./env-contract/types";
+} from "./env-contract/types.ts";

--- a/shared/lib/env-contract/registry.ts
+++ b/shared/lib/env-contract/registry.ts
@@ -2,7 +2,7 @@ import type {
   EnvBindingDefinition,
   EnvRuntimeName,
   EnvRuntimeStatus,
-} from "./types";
+} from "./types.ts";
 
 export const ENV_BINDINGS = [
   {

--- a/shared/lib/env-contract/render-env-example.ts
+++ b/shared/lib/env-contract/render-env-example.ts
@@ -1,8 +1,8 @@
-import type { EnvExampleSection } from "./types";
+import type { EnvExampleSection } from "./types.ts";
 import {
   ENV_BINDINGS,
   compareRuntimeOrder,
-} from "./registry";
+} from "./registry.ts";
 
 const ENV_EXAMPLE_SECTION_ORDER: readonly {
   comments: readonly string[];

--- a/shared/lib/env-contract/render-markdown.ts
+++ b/shared/lib/env-contract/render-markdown.ts
@@ -1,8 +1,8 @@
 import type {
   EnvBindingDefinition,
   EnvRuntimeName,
-} from "./types";
-import { ENV_BINDINGS } from "./registry";
+} from "./types.ts";
+import { ENV_BINDINGS } from "./registry.ts";
 
 function escapeMarkdownCell(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "allowImportingTsExtensions": true,
     "paths": {
       "@/*": ["./src/*"],
       "@data/*": ["./data/*"],

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "types": ["@cloudflare/workers-types", "node"],
+    "allowImportingTsExtensions": true,
     "paths": {
       "@shared/*": ["../shared/*"],
       "@shared/data/*": ["../shared/data/*"]


### PR DESCRIPTION
### Motivation
- Direct native Node execution of the env-contract checker failed with `ERR_MODULE_NOT_FOUND` because the split `shared/lib/env-contract` barrel and its submodules used extensionless relative TypeScript specifiers that Node's ESM resolver cannot resolve when a `.ts` module is dynamically imported.

### Description
- Added explicit `.ts` extensions to the re-exports in `shared/lib/env-contract.ts` so the barrel resolves under native Node.  
- Updated internal env-contract imports to use explicit `.ts` specifiers in `shared/lib/env-contract/registry.ts`, `shared/lib/env-contract/render-env-example.ts`, and `shared/lib/env-contract/render-markdown.ts`.  
- Enabled `allowImportingTsExtensions` in the root `tsconfig.json` and `worker/tsconfig.json` so the explicit `.ts` specifiers remain typecheckable without changing runtime behavior.

### Testing
- Ran `node scripts/ci/check-env-contract.mjs` and it completed successfully.  
- Ran `npm run check:env-contract` (via `tsx`) and it completed successfully.  
- Ran `npm run typecheck` (`tsc --noEmit -p tsconfig.typecheck.json`) and it passed without errors.  
- Ran `npm run check:worker-boundary` and `npm run check:shared-cycles` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0bd3dc8332a9470ba7d3187b52)