### PR TITLE
fix(api): skip frozen mint/burn configs in auto backfill

### DIFF
--- a/worker/src/api/__tests__/backfill-mint-burn.test.ts
+++ b/worker/src/api/__tests__/backfill-mint-burn.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../lib/alchemy-logs", () => ({
   resolveBlockTimestamps: vi.fn(async () => new Map()),
 }));
 
+import { FROZEN_IDS } from "@shared/lib/stablecoins/registry";
 import { handleBackfillMintBurn } from "../backfill-mint-burn";
 import {
   fetchAlchemyLogs,
@@ -44,8 +45,12 @@ function makeDb(): D1Database {
 }
 
 describe("handleBackfillMintBurn", () => {
+  const originalFrozenIds = new Set(FROZEN_IDS);
+
   beforeEach(() => {
     vi.clearAllMocks();
+    FROZEN_IDS.clear();
+    for (const id of originalFrozenIds) FROZEN_IDS.add(id);
   });
 
   it("requires admin auth", async () => {
@@ -83,6 +88,35 @@ describe("handleBackfillMintBurn", () => {
     };
     expect(body.configKey).toBe("ethereum-0xdac17f958d2ee523a2206206994597c13d831ec7");
     expect(body.selectedSymbol).toBe("USDT");
+    expect(body.selectionMode).toBe("auto");
+    expect(body.autoSelectedReason).toBe("critical-first-most-behind");
+  });
+
+  it("skips frozen configs during automatic selection", async () => {
+    FROZEN_IDS.add("usdt-tether");
+
+    const response = await handleBackfillMintBurn(
+      makeDb(),
+      makeApiUrl("/api/backfill-mint-burn"),
+      true,
+      makeApiRequest("/api/backfill-mint-burn", {
+        method: "POST",
+        adminKey: "secret",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      "alchemy-key",
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      configKey: string;
+      selectedSymbol: string;
+      selectionMode: string;
+      autoSelectedReason: string | null;
+    };
+    expect(body.configKey).toBe("ethereum-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+    expect(body.selectedSymbol).toBe("USDC");
     expect(body.selectionMode).toBe("auto");
     expect(body.autoSelectedReason).toBe("critical-first-most-behind");
   });

--- a/worker/src/api/backfill-mint-burn.ts
+++ b/worker/src/api/backfill-mint-burn.ts
@@ -4,6 +4,7 @@ import { createBudget, budgetExhausted } from "../lib/evm-logs";
 import { MINT_BURN_CONFIGS, type MintBurnContractConfig, type MintBurnEventDef } from "../lib/mint-burn-contracts";
 import type { MintBurnTxContext } from "../lib/mint-burn-bridge-classifier";
 import { errorResponse, jsonResponse, parseQueryParams } from "../lib/api-utils";
+import { FROZEN_IDS } from "@shared/lib/stablecoins/registry";
 import { assertNotFrozen } from "../lib/frozen-guards";
 import type { TopicFilter } from "../lib/evm-logs";
 import { classifyBridgeBurnRows } from "../lib/mint-burn-pipeline/classification";
@@ -55,7 +56,9 @@ async function resolveBackfillConfig(
     };
   }
 
-  const eligibleConfigs = MINT_BURN_CONFIGS.filter((entry) => entry.enabled !== false);
+  const eligibleConfigs = MINT_BURN_CONFIGS.filter(
+    (entry) => entry.enabled !== false && !FROZEN_IDS.has(entry.stablecoinId),
+  );
   if (eligibleConfigs.length === 0) {
     return { ok: false, response: errorResponse(400, "No eligible mint/burn configs are enabled") };
   }


### PR DESCRIPTION
### Motivation
- Automatic mint/burn backfill selection considered every enabled config eligible and only applied the frozen guard after selecting a single config, causing automatic admin backfills to abort with 403 when a top-ranked config was frozen.
- The goal is to keep explicit frozen-config rejection for exact `configKey` requests while allowing automatic selection to skip frozen stablecoins and continue with the next active config.

### Description
- Filter out frozen stablecoin configs from the automatic eligibility set by importing `FROZEN_IDS` and excluding entries whose `stablecoinId` is frozen in `resolveBackfillConfig` (`worker/src/api/backfill-mint-burn.ts`).
- Preserve the existing `assertNotFrozen` guard for explicit `configKey` requests so direct requests for a frozen config still return 403 (`worker/src/lib/frozen-guards.ts` remains unchanged).
- Add a regression test that injects a frozen `usdt-tether` into `FROZEN_IDS` and verifies automatic selection skips USDT and selects USDC instead, and make the test harness preserve any original frozen IDs across runs (`worker/src/api/__tests__/backfill-mint-burn.test.ts`).

### Testing
- Ran unit tests with `npx vitest run worker/src/api/__tests__/backfill-mint-burn.test.ts worker/src/lib/__tests__/frozen-guards.test.ts`, and all tests passed (2 test files, 12 tests passed).
- Verified TypeScript correctness with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0c3190833296bfd7ac3aeba003)