### PR TITLE
fix(sync-stablecoins): validate frozen snapshots in intake pipeline

### DIFF
--- a/worker/src/cron/sync-stablecoins/__tests__/intake-frozen-injection.test.ts
+++ b/worker/src/cron/sync-stablecoins/__tests__/intake-frozen-injection.test.ts
@@ -28,6 +28,27 @@ describe("mergeFrozenSnapshots", () => {
     expect((merged.find((a) => (a as { id: string }).id === "fixture-frozen") as { name: string }).name).toBe("Fixture (live)");
   });
 
+  it("does not duplicate when an upstream DefiLlama id maps to the snapshot canonical id", () => {
+    const upstream = [
+      { id: "1", name: "Tether (live)", symbol: "USDT" } as never,
+    ];
+    const merged = mergeFrozenSnapshots(upstream, [
+      {
+        id: "usdt-tether",
+        capturedAt: "2026-04-27T00:00:00Z",
+        peggedAssetRow: { id: "usdt-tether", name: "Tether (snapshot)", symbol: "USDT" },
+      },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect((merged[0] as { name: string }).name).toBe("Tether (live)");
+  });
+
+  it("deduplicates repeated snapshots before the canonical dedupe stage", () => {
+    const upstream = [{ id: "usdt-tether", name: "Tether", symbol: "USDT" } as never];
+    const merged = mergeFrozenSnapshots(upstream, [...snapshots, ...snapshots]);
+    expect(merged.filter((a) => (a as { id: string }).id === "fixture-frozen")).toHaveLength(1);
+  });
+
   it("returns input unchanged when no snapshots provided", () => {
     const upstream = [{ id: "usdt-tether", name: "Tether", symbol: "USDT" } as never];
     expect(mergeFrozenSnapshots(upstream, [])).toBe(upstream);

--- a/worker/src/cron/sync-stablecoins/intake.ts
+++ b/worker/src/cron/sync-stablecoins/intake.ts
@@ -124,7 +124,10 @@ async function fetchDefillamaStablecoinsPayload(
 }
 
 /**
- * Append captured frozen-coin rows for any id absent from the upstream payload.
+ * Append captured frozen-coin rows for any canonical id absent from the
+ * upstream payload. This is intentionally run before structural validation,
+ * chain-circulating normalization, canonical-id mapping, and dedupe so frozen
+ * snapshots pass through the same intake safeguards as live DefiLlama rows.
  * Upstream rows always win — if DefiLlama still serves the asset, that's the
  * authoritative copy. Returns the input array unchanged when there is nothing
  * to inject (so existing identity tests pass).
@@ -136,14 +139,20 @@ export function mergeFrozenSnapshots(
   if (snapshots.length === 0) {
     return upstream;
   }
-  const upstreamIds = new Set(upstream.map((a) => String((a as { id?: unknown }).id ?? "")));
+  const upstreamIds = new Set(
+    upstream.flatMap((a) => {
+      const id = String((a as { id?: unknown }).id ?? "");
+      const mapped = REGISTRY_BY_LLAMA_ID.get(id)?.id;
+      return mapped && mapped !== id ? [id, mapped] : [id];
+    }),
+  );
   const additions: PeggedAsset[] = [];
   for (const snapshot of snapshots) {
     if (upstreamIds.has(snapshot.id)) {
       continue;
     }
-    // Cast: PeggedAsset is a structural subset of the snapshot row; column projection elsewhere is the source of truth
     additions.push(snapshot.peggedAssetRow as unknown as PeggedAsset);
+    upstreamIds.add(snapshot.id);
   }
   if (additions.length === 0) {
     return upstream;
@@ -233,7 +242,11 @@ export async function loadStablecoinsIntake(
   // defined and valid by the guards above; the steps below reassign `assets`
   // rather than the upstream payload, so the original parsed response is left
   // intact and the transformation sequence is self-documenting.
-  let assets = llamaData.peggedAssets;
+  let assets = mergeFrozenSnapshots(llamaData.peggedAssets, FROZEN_SNAPSHOTS);
+  const injectedFrozenSnapshots = assets.length - llamaData.peggedAssets.length;
+  if (injectedFrozenSnapshots > 0) {
+    console.log(`[sync-stablecoins] Injected ${injectedFrozenSnapshots} frozen-snapshot row(s)`);
+  }
 
   const { validAssets, droppedMalformedAssets } = filterStructurallyValidAssets(assets);
   if (validAssets.length < MIN_VALID_ASSET_COUNT) {
@@ -327,13 +340,6 @@ export async function loadStablecoinsIntake(
       "7d ceiling (publishing without restored supply): " +
       supplementalResolution.expiredRestoreIds.join(", "),
     );
-  }
-
-  const beforeFrozenInjection = assets.length;
-  assets = mergeFrozenSnapshots(assets, FROZEN_SNAPSHOTS);
-  const injected = assets.length - beforeFrozenInjection;
-  if (injected > 0) {
-    console.log(`[sync-stablecoins] Injected ${injected} frozen-snapshot row(s)`);
   }
 
   // Restore-or-degrade on tracked-id coverage: a DefiLlama list omission must


### PR DESCRIPTION
### Motivation
- Prevent permissive frozen snapshots from bypassing the intake pipeline's structural validation, normalization, canonical mapping, and deduplication and thereby causing the final stablecoins schema validation to fail.
- Ensure injected frozen rows are treated the same as live DefiLlama rows so the stablecoins cache remains publishable when snapshots are present.

### Description
- Move frozen-snapshot injection earlier in the intake flow by calling `mergeFrozenSnapshots()` before structural validation and `normalizeChainCirculating()` so snapshot rows are validated and normalized with the rest of the payload (`worker/src/cron/sync-stablecoins/intake.ts`).
- Update `mergeFrozenSnapshots()` to consider mapped canonical IDs via `REGISTRY_BY_LLAMA_ID` (so raw DefiLlama IDs that map to a canonical ID do not cause duplicates) and to avoid re-injecting duplicate snapshots (`worker/src/cron/sync-stablecoins/intake.ts`).
- Remove the old post-normalization injection point and add a log of injected snapshot count to aid observability (`worker/src/cron/sync-stablecoins/intake.ts`).
- Add focused tests for canonical-ID duplicate prevention and repeated-snapshot deduplication in `worker/src/cron/sync-stablecoins/__tests__/intake-frozen-injection.test.ts`.

### Testing
- Ran the unit tests: `npx vitest run worker/src/cron/sync-stablecoins/__tests__/intake-frozen-injection.test.ts` and observed `Test Files 1 passed, Tests 5 passed`.
- Type-check: `cd worker && npx tsc --noEmit` succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f0c938083329063d47248e7bbe7)