### PR TITLE
fix(curation): preserve ambiguous annotation labels

### DIFF
--- a/docs/agent-code-map.md
+++ b/docs/agent-code-map.md
@@ -745,4 +745,4 @@ Use this as a compact discovery aid. It lists source entrypoints and top-level e
 - `scripts/__tests__/parse-version-upload.test.ts`
 - `scripts/__tests__/pharos-change-contract.test.ts`
 - `scripts/__tests__/public-api-artifact-catalog.test.ts`
-- ... 206 more files omitted; use `rg --files scripts` for the full list.
+- ... 207 more files omitted; use `rg --files scripts` for the full list.

--- a/scripts/maintenance/__tests__/build-annotation-candidates.test.ts
+++ b/scripts/maintenance/__tests__/build-annotation-candidates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildCoinIdResolver } from "../build-annotation-candidates";
+import type { StablecoinMeta } from "../../../shared/types";
+
+function coin(id: string, symbol: string, name = symbol): StablecoinMeta {
+  return { id, symbol, name, flags: {} } as StablecoinMeta;
+}
+
+describe("buildCoinIdResolver", () => {
+  it("keeps shared labels ambiguous after later duplicate fields", () => {
+    const resolveCoinId = buildCoinIdResolver([
+      coin("usdx-hex-trust", "USDX", "Hex Trust USDX"),
+      coin("usdx-kava", "USDX", "USDX"),
+    ]);
+
+    expect(resolveCoinId("USDX")).toBeNull();
+    expect(resolveCoinId("usdx-hex-trust")).toBe("usdx-hex-trust");
+    expect(resolveCoinId("usdx-kava")).toBe("usdx-kava");
+  });
+
+  it("resolves labels that belong to only one stablecoin", () => {
+    const resolveCoinId = buildCoinIdResolver([coin("unique-usd", "UUSD", "Unique USD")]);
+
+    expect(resolveCoinId(" uusd ")).toBe("unique-usd");
+    expect(resolveCoinId("Unique USD")).toBe("unique-usd");
+  });
+});

--- a/scripts/maintenance/build-annotation-candidates.ts
+++ b/scripts/maintenance/build-annotation-candidates.ts
@@ -123,13 +123,17 @@ function mapDepegCandidate(event: TapeEventLite): Candidate | null {
   };
 }
 
-function buildCoinIdResolver(coins: readonly StablecoinMeta[]): (symbolOrName: unknown) => string | null {
+export function buildCoinIdResolver(coins: readonly StablecoinMeta[]): (symbolOrName: unknown) => string | null {
   const byLabel = new Map<string, string | null>();
   const add = (label: string, coinId: string) => {
     const key = label.trim().toLowerCase();
     if (!key) return;
+    if (!byLabel.has(key)) {
+      byLabel.set(key, coinId);
+      return;
+    }
     const existing = byLabel.get(key);
-    byLabel.set(key, existing && existing !== coinId ? null : coinId);
+    if (existing !== coinId) byLabel.set(key, null);
   };
   for (const coin of coins) {
     add(coin.id, coin.id);
@@ -370,4 +374,6 @@ async function main(): Promise<void> {
   );
 }
 
-void main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}


### PR DESCRIPTION
### Motivation

- Prevent ambiguous stablecoin labels discovered in freeze-tape events from being deterministically misattributed to a single coin when the same label appears on multiple catalog entries.

### Description

- Change `buildCoinIdResolver` in `scripts/maintenance/build-annotation-candidates.ts` so a detected collision sets and preserves a `null` ambiguity marker instead of allowing later entries to overwrite it. 
- Export the resolver (`export function buildCoinIdResolver`) so it can be imported for unit tests and add a direct-run guard around `main()` (`if (import.meta.url === ... ) { void main(); }`).
- Add targeted Vitest coverage at `scripts/maintenance/__tests__/build-annotation-candidates.test.ts` validating the USDX-style collision and unique-label resolution.

### Testing

- Ran `npm test -- scripts/maintenance/__tests__/build-annotation-candidates.test.ts` and the new tests passed.
- Ran `npm run check:stablecoin-data` and the stablecoin data validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a366484490c8332937cd59bbdd5b18f)