### PR TITLE
fix(methodology): compare major versions numerically

### DIFF
--- a/shared/lib/__tests__/methodology-version.test.ts
+++ b/shared/lib/__tests__/methodology-version.test.ts
@@ -15,6 +15,11 @@ describe("compareMethodologyVersions", () => {
     expect(compareMethodologyVersions("6.10", "6.1")).toBe(0);
     expect(compareMethodologyVersions("6.16", "6.11")).toBeGreaterThan(0);
   });
+
+  it("orders multi-digit major versions numerically", () => {
+    expect(compareMethodologyVersions("10.0", "9.99")).toBeGreaterThan(0);
+    expect(compareMethodologyVersions("9.99", "10.0")).toBeLessThan(0);
+  });
 });
 
 describe("createMethodologyVersion", () => {
@@ -60,6 +65,37 @@ describe("createMethodologyVersion", () => {
     });
     expect(methodology.getVersionAt(1000)).toBe("3.9");
     expect(methodology.getVersionAt(999)).toBe("3.7");
+  });
+
+  it("selects a two-digit major version as the latest changelog entry", () => {
+    const methodology = createMethodologyVersion({
+      currentVersion: "10.0",
+      changelogPath: "/methodology/two-digit-major-test/",
+      changelog: [
+        {
+          version: "9.99",
+          title: "",
+          date: "",
+          effectiveAt: 2000,
+          summary: "",
+          impact: [],
+          commits: [],
+          reconstructed: false,
+        },
+        {
+          version: "10.0",
+          title: "",
+          date: "",
+          effectiveAt: 1000,
+          summary: "",
+          impact: [],
+          commits: [],
+          reconstructed: false,
+        },
+      ],
+    });
+
+    expect(methodology.versionLabels).toEqual(["v10.0", "v9.99"]);
   });
 
   it("throws in dev/test when currentVersion drifts from the latest changelog entry", () => {

--- a/shared/lib/methodology-versions/base.ts
+++ b/shared/lib/methodology-versions/base.ts
@@ -60,10 +60,13 @@ export interface MethodologyVersion {
   getVersionAt: (unixSeconds: number) => string;
 }
 
-function normalizeMethodologyVersionSegment(segment: string, width: number): number {
-  const normalized = segment.padEnd(width, "0");
-  const value = Number.parseInt(normalized, 10);
+function parseMethodologyVersionSegment(segment: string): number {
+  const value = Number.parseInt(segment, 10);
   return Number.isFinite(value) ? value : 0;
+}
+
+function normalizeMethodologyMinorVersionSegment(segment: string, width: number): number {
+  return parseMethodologyVersionSegment(segment.padEnd(width, "0"));
 }
 
 export function compareMethodologyVersions(a: string, b: string): number {
@@ -76,8 +79,9 @@ export function compareMethodologyVersions(a: string, b: string): number {
     const bPart = bParts[index] ?? "0";
     const width = Math.max(aPart.length, bPart.length, 1);
     const diff =
-      normalizeMethodologyVersionSegment(aPart, width) -
-      normalizeMethodologyVersionSegment(bPart, width);
+      index === 0
+        ? parseMethodologyVersionSegment(aPart) - parseMethodologyVersionSegment(bPart)
+        : normalizeMethodologyMinorVersionSegment(aPart, width) - normalizeMethodologyMinorVersionSegment(bPart, width);
     if (diff !== 0) return diff;
   }
 
@@ -145,9 +149,7 @@ const METHODOLOGY_DISPLAY_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
 
 export function formatMethodologyDisplayDate(date: string): string {
   const parsed = new Date(`${date}T00:00:00Z`);
-  return Number.isFinite(parsed.getTime())
-    ? METHODOLOGY_DISPLAY_DATE_FORMATTER.format(parsed)
-    : date;
+  return Number.isFinite(parsed.getTime()) ? METHODOLOGY_DISPLAY_DATE_FORMATTER.format(parsed) : date;
 }
 
 export function methodologyChangelogEntryId(version: string): string {


### PR DESCRIPTION
### Motivation
- A previous change right-padded every dot-separated version segment before numeric comparison which incorrectly caused multi-digit major versions (e.g. `10`) to sort behind shorter majors (e.g. `9`) when compared to padded minor segments like `9.99`.
- The intent is to preserve the decimal-minor normalization (so `6.09` sorts relative to `6.1` correctly) while restoring correct numeric ordering for the major segment so future two-digit major releases order correctly.

### Description
- Update `shared/lib/methodology-versions/base.ts` to parse the first (major) segment as a plain integer via `parseMethodologyVersionSegment`, and preserve right-padding normalization only for minor segments via `normalizeMethodologyMinorVersionSegment`.
- Change `compareMethodologyVersions` so index `0` (major) uses integer comparison and later indices use the padded-minor normalization.
- Add regression tests in `shared/lib/__tests__/methodology-version.test.ts` that assert numeric ordering for multi-digit majors (`10.0` vs `9.99`) and that a changelog selecting the latest label prefers `v10.0` over `v9.99` where appropriate.

### Testing
- Ran the focused tests with `npx vitest run shared/lib/__tests__/methodology-version.test.ts` and they passed.
- Ran repository checks `npm run check:worker-boundary` and `npm run check:shared-cycles` which passed.
- Ran the TypeScript typecheck with `npm run typecheck` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36648426748332ba9c591d818831a9)