### PR TITLE
Fix reUSD mint/burn rebuild cursor reset

### DIFF
--- a/worker/migrations/0159_reusd_mint_burn_source_rebuild.sql
+++ b/worker/migrations/0159_reusd_mint_burn_source_rebuild.sql
@@ -3,8 +3,10 @@
 -- vault Deposited/InstantRedemptionRouted events to canonical token Transfer
 -- events. The old vault rows cannot be distinguished from canonical rows once
 -- inserted because mint_burn_events stores tx/log identity, not source contract,
--- so purge the affected coin/chain and reset the token cursor for a clean
--- backfill from the checked-in startBlock.
+-- so purge the affected coin/chain and reset the legacy vault cursors plus
+-- both possible token cursor formats for a clean backfill from the checked-in
+-- startBlock. Older vault rows used numeric EVM chain IDs, while the active
+-- mintBurnConfigKey() uses the internal chain ID (`ethereum`) prefix.
 
 DELETE FROM mint_burn_hourly
 WHERE stablecoin_id = 'reusd-re-protocol'
@@ -18,5 +20,8 @@ DELETE FROM mint_burn_sync_state
 WHERE config_key IN (
   '1-0x4691c475be804fa85f91c2d6d0adf03114de3093',
   '1-0x8aeb9453ef22cb38abc7a3af9c208f65c1bfe31e',
-  '1-0x5086bf358635b81d8c47c66d1c8b9e567db70c72'
+  '1-0x5086bf358635b81d8c47c66d1c8b9e567db70c72',
+  'ethereum-0x4691c475be804fa85f91c2d6d0adf03114de3093',
+  'ethereum-0x8aeb9453ef22cb38abc7a3af9c208f65c1bfe31e',
+  'ethereum-0x5086bf358635b81d8c47c66d1c8b9e567db70c72'
 );


### PR DESCRIPTION
### Motivation
- The reUSD source-rebuild migration purged historical `mint_burn_hourly`/`mint_burn_events` rows but only removed legacy numeric `1-...` sync-state keys, leaving the active `ethereum-...` cursor intact. 
- If the active `ethereum-...` cursor survives, the pipeline resumes from its high-water mark and will not backfill the deleted history. 
- The migration must clear both legacy numeric-chain and current internal-chain-id sync-state keys so the backfill uses the checked-in `startBlock` fallback.

### Description
- Updated `worker/migrations/0159_reusd_mint_burn_source_rebuild.sql` to add the `ethereum-<address>` sync-state keys alongside the legacy `1-<address>` keys and clarified the migration comment to document both key formats. 
- This change is limited to the migration SQL and documentation comment; no runtime worker code was modified. 
- File changed: `worker/migrations/0159_reusd_mint_burn_source_rebuild.sql`.

### Testing
- Ran `npm run check:migrations` which completed successfully. 
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3664854a2c83328f056fb912228cfe)