### PR TITLE
Clear empty supplemental yield family caches

### DIFF
--- a/worker/src/cron/__tests__/sync-yield-supplemental.test.ts
+++ b/worker/src/cron/__tests__/sync-yield-supplemental.test.ts
@@ -177,7 +177,9 @@ describe("syncYieldSupplemental", () => {
 
     const cacheCall = vi.mocked(setCacheIfNewer).mock.calls[0];
     expect(cacheCall?.[1]).toBe("yield:supplemental-sources:v1");
-    expect(vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:aaveV3")).toBe(true);
+    expect(
+      vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:aaveV3"),
+    ).toBe(true);
 
     const payload = JSON.parse(String(cacheCall?.[2])) as {
       sourceCount: number;
@@ -221,7 +223,7 @@ describe("syncYieldSupplemental", () => {
     expect(metadata.sourceCoverage?.optionalRpcTelemetry?.aaveV3?.missingTargetCount).toBe(0);
   });
 
-  it("skips empty family cache rows to preserve previous non-empty caches", async () => {
+  it("publishes empty family cache rows to clear previous non-empty caches", async () => {
     vi.mocked(fetchBeefySources).mockResolvedValue([
       {
         symbol: "USDC",
@@ -251,26 +253,30 @@ describe("syncYieldSupplemental", () => {
     ).toBe(true);
     expect(
       vi.mocked(setCacheIfNewer).mock.calls.some((call) => call[1] === "yield:supplemental-sources:v1:morpho"),
-    ).toBe(false);
+    ).toBe(true);
 
-    const beefyCall = vi.mocked(setCacheIfNewer).mock.calls.find((call) =>
-      call[1] === "yield:supplemental-sources:v1:beefy"
-    );
+    const beefyCall = vi
+      .mocked(setCacheIfNewer)
+      .mock.calls.find((call) => call[1] === "yield:supplemental-sources:v1:beefy");
     const beefyPayload = JSON.parse(String(beefyCall?.[2])) as { sourceCount: number; data: unknown[] };
     expect(beefyPayload.sourceCount).toBe(1);
 
     const metadata = JSON.parse(result.metadata ?? "{}") as {
-      familyCacheResults?: Record<string, "published" | "skipped-newer" | "empty" | "empty-skipped">;
+      familyCacheResults?: Record<string, "published" | "skipped-newer" | "empty" | "empty-published">;
     };
     expect(metadata.familyCacheResults?.beefy).toBe("published");
-    expect(metadata.familyCacheResults?.morpho).toBe("empty-skipped");
+    const morphoCall = vi
+      .mocked(setCacheIfNewer)
+      .mock.calls.find((call) => call[1] === "yield:supplemental-sources:v1:morpho");
+    const morphoPayload = JSON.parse(String(morphoCall?.[2])) as { sourceCount: number; data: unknown[] };
+    expect(morphoPayload.sourceCount).toBe(0);
+    expect(morphoPayload.data).toEqual([]);
+    expect(metadata.familyCacheResults?.morpho).toBe("empty-published");
   });
 
   it("keeps same-asset Aave markets on different chains when per-target results are available", async () => {
     vi.mocked(fetchAaveV3SupplyRates).mockResolvedValue({
-      rates: new Map([
-        ["usdc-circle", { apy: 4.25, chain: "ethereum", sourceTvlUsd: 100_000_000 }],
-      ]),
+      rates: new Map([["usdc-circle", { apy: 4.25, chain: "ethereum", sourceTvlUsd: 100_000_000 }]]),
       results: [
         {
           stablecoinId: "usdc-circle",
@@ -304,7 +310,10 @@ describe("syncYieldSupplemental", () => {
 
     const payload = JSON.parse(String(vi.mocked(setCacheIfNewer).mock.calls[0]?.[2])) as {
       sourceCount: number;
-      data: Array<{ stablecoinId?: string; yield: { sourceKey: string; currentApy: number; sourceTvlUsd: number | null } }>;
+      data: Array<{
+        stablecoinId?: string;
+        yield: { sourceKey: string; currentApy: number; sourceTvlUsd: number | null };
+      }>;
     };
     expect(payload.sourceCount).toBe(2);
     expect(payload.data).toEqual([
@@ -506,7 +515,8 @@ describe("syncYieldSupplemental", () => {
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.total).toBe(1);
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.bySourceFamily?.beefy).toBe(1);
     expect(
-      metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.exampleSourceKeysBySourceFamily?.beefy,
+      metadata.sourceCoverage?.supplementalSourceAccounting?.malformedSourceDrops?.exampleSourceKeysBySourceFamily
+        ?.beefy,
     ).toEqual(["(missing-source-key)"]);
     expect(metadata.sourceCoverage?.supplementalSourceAccounting?.sizeGatedDrops?.total).toBe(0);
   });
@@ -539,15 +549,19 @@ describe("syncYieldSupplemental", () => {
     vi.mocked(fetchYearnKongSources).mockImplementation(trackFamily("yearnKong", []));
     vi.mocked(fetchBeefySources).mockImplementation(trackFamily("beefy", []));
     vi.mocked(fetchRoycoDawnSources).mockImplementation(trackFamily("roycoDawn", []));
-    vi.mocked(fetchCompoundV3SupplyRates).mockImplementation(trackFamily("compoundV3", {
-      results: [],
-      telemetry: emptyTelemetry,
-    }));
-    vi.mocked(fetchAaveV3SupplyRates).mockImplementation(trackFamily("aaveV3", {
-      rates: new Map(),
-      results: [],
-      telemetry: emptyTelemetry,
-    }));
+    vi.mocked(fetchCompoundV3SupplyRates).mockImplementation(
+      trackFamily("compoundV3", {
+        results: [],
+        telemetry: emptyTelemetry,
+      }),
+    );
+    vi.mocked(fetchAaveV3SupplyRates).mockImplementation(
+      trackFamily("aaveV3", {
+        rates: new Map(),
+        results: [],
+        telemetry: emptyTelemetry,
+      }),
+    );
 
     const loadPromise = loadSupplementalSourceFamilies({ startSec: 1 });
     await flushMicrotasks();

--- a/worker/src/cron/sync-yield-supplemental.ts
+++ b/worker/src/cron/sync-yield-supplemental.ts
@@ -26,9 +26,10 @@ function buildSupplementalCandidateDedupKey(candidate: ResolvedYieldCandidate): 
   return `${sourceKey}|${chain}|${identity}`;
 }
 
-function dedupeCandidates(
-  candidates: ResolvedYieldCandidate[],
-): { candidates: ResolvedYieldCandidate[]; droppedCount: number } {
+function dedupeCandidates(candidates: ResolvedYieldCandidate[]): {
+  candidates: ResolvedYieldCandidate[];
+  droppedCount: number;
+} {
   const byDedupKey = new Map<string, ResolvedYieldCandidate>();
   let droppedCount = 0;
 
@@ -92,17 +93,12 @@ export async function syncYieldSupplemental(
       },
     },
   });
-  const {
-    candidates,
-    familyResults,
-    sourceFamilyCounts,
-    supplementalSourceAccounting,
-    optionalRpcTelemetry,
-  } = await loadSupplementalSourceFamilies({
-    startSec,
-    signal,
-    chainRpcs,
-  });
+  const { candidates, familyResults, sourceFamilyCounts, supplementalSourceAccounting, optionalRpcTelemetry } =
+    await loadSupplementalSourceFamilies({
+      startSec,
+      signal,
+      chainRpcs,
+    });
   await reportSupplementalProgress("source-family-fetch-complete", "Completed supplemental yield source fetches", {
     itemsDone: familyResults.length,
     metadata: {
@@ -146,15 +142,15 @@ export async function syncYieldSupplemental(
         rowsWritten: 0,
         rowsDropped: droppedCount,
         sourceCoverage: {
-        rawSupplementalCandidates: rawCandidateCount,
-        dedupedSupplementalCandidates: 0,
-        supplementalCandidatesWritten: 0,
-        sourceFamilyCounts,
-        supplementalSourceAccounting,
-        optionalRpcTelemetry,
-      },
-      fallbackMode: "empty-snapshot",
-      cacheWriteSkipped: true,
+          rawSupplementalCandidates: rawCandidateCount,
+          dedupedSupplementalCandidates: 0,
+          supplementalCandidatesWritten: 0,
+          sourceFamilyCounts,
+          supplementalSourceAccounting,
+          optionalRpcTelemetry,
+        },
+        fallbackMode: "empty-snapshot",
+        cacheWriteSkipped: true,
       }),
     };
   }
@@ -179,10 +175,10 @@ export async function syncYieldSupplemental(
   );
   const familyCacheResults: Record<
     SupplementalSourceFamilyKey,
-    "published" | "skipped-newer" | "empty" | "empty-skipped"
+    "published" | "skipped-newer" | "empty" | "empty-published"
   > = Object.fromEntries(SUPPLEMENTAL_SOURCE_FAMILY_KEYS.map((key) => [key, "empty"])) as Record<
     SupplementalSourceFamilyKey,
-    "published" | "skipped-newer" | "empty" | "empty-skipped"
+    "published" | "skipped-newer" | "empty" | "empty-published"
   >;
 
   for (const family of familyResults) {
@@ -201,10 +197,6 @@ export async function syncYieldSupplemental(
       },
     });
     const { candidates: dedupedFamilyCandidates } = dedupeCandidates(family.candidates);
-    if (dedupedFamilyCandidates.length === 0) {
-      familyCacheResults[family.key] = "empty-skipped";
-      continue;
-    }
     const familyCacheResult = await setCacheIfNewer(
       db,
       getYieldSupplementalFamilyCacheKey(family.key),
@@ -212,7 +204,14 @@ export async function syncYieldSupplemental(
       startSec,
       signal,
     );
-    familyCacheResults[family.key] = familyCacheResult.written ? "published" : "skipped-newer";
+    familyCacheResults[family.key] =
+      dedupedFamilyCandidates.length === 0
+        ? familyCacheResult.written
+          ? "empty-published"
+          : "skipped-newer"
+        : familyCacheResult.written
+          ? "published"
+          : "skipped-newer";
   }
   await reportSupplementalProgress("complete", "Published supplemental yield source caches", {
     itemsDone: cacheResult.written ? dedupedCandidates.length : 0,


### PR DESCRIPTION
### Motivation
- Fix a data-integrity bug where a successful supplemental source family that resolved to zero candidates did not write an empty per-family cache, which allowed an older non-empty family cache to remain and produce stale supplemental yield candidates at load time.

### Description
- Always write a per-family supplemental cache (including an empty payload) for successful families so a legitimate zero-result clears prior non-empty rows by calling `setCacheIfNewer` with an empty payload. (`worker/src/cron/sync-yield-supplemental.ts`).
- Introduce an `empty-published` family cache status to report when an empty family payload was written and update the family-cache result union accordingly. (`worker/src/cron/sync-yield-supplemental.ts`).
- Update the focused supplemental sync test to assert that empty family cache rows are published with `sourceCount: 0`, an empty `data` array, and `empty-published` metadata. (`worker/src/cron/__tests__/sync-yield-supplemental.test.ts`).

### Testing
- Ran the targeted Vitest suite with `npx vitest run worker/src/cron/__tests__/sync-yield-supplemental.test.ts --reporter=dot`, and all tests in that file passed. 
- Type-checked the worker code with `npx tsc -p worker/tsconfig.json --noEmit`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36648414b48332b08c4025050bcd7b)