### PR TITLE
fix(telegram): backfill per-coin opt-out markers

### DIFF
--- a/worker/migrations/0160_telegram_per_coin_alert_override_markers.sql
+++ b/worker/migrations/0160_telegram_per_coin_alert_override_markers.sql
@@ -7,3 +7,15 @@ ALTER TABLE telegram_subscriptions ADD COLUMN alert_depeg_override INTEGER NOT N
 ALTER TABLE telegram_subscriptions ADD COLUMN alert_safety_override INTEGER NOT NULL DEFAULT 0 CHECK (alert_safety_override IN (0, 1));
 ALTER TABLE telegram_subscriptions ADD COLUMN alert_launch_override INTEGER NOT NULL DEFAULT 0 CHECK (alert_launch_override IN (0, 1));
 ALTER TABLE telegram_subscriptions ADD COLUMN alert_reserve_override INTEGER NOT NULL DEFAULT 0 CHECK (alert_reserve_override IN (0, 1));
+
+-- Rows that already existed before the marker columns used alert_* = 0 as the
+-- only persistent representation for an explicit per-coin off setting. Mark
+-- those zeroes as overrides so the new dispatcher preserves historical opt-outs
+-- while future partial follow writes can continue to rely on the default marker
+-- value of 0 for unmentioned alert types.
+UPDATE telegram_subscriptions
+   SET alert_dews_override = CASE WHEN alert_dews = 0 THEN 1 ELSE alert_dews_override END,
+       alert_depeg_override = CASE WHEN alert_depeg = 0 THEN 1 ELSE alert_depeg_override END,
+       alert_safety_override = CASE WHEN alert_safety = 0 THEN 1 ELSE alert_safety_override END,
+       alert_launch_override = CASE WHEN alert_launch = 0 THEN 1 ELSE alert_launch_override END,
+       alert_reserve_override = CASE WHEN alert_reserve = 0 THEN 1 ELSE alert_reserve_override END;


### PR DESCRIPTION
### Motivation
- A migration added per-coin `alert_*_override` marker columns with `DEFAULT 0` while dispatch now treats explicit opt-outs as `alert_* = 0 AND alert_*_override = 1`, which causes historical explicit per-coin opt-outs (stored as `alert_* = 0`) to stop suppressing global/preset fan-out. 
- The change preserves user intent by ensuring rows that previously used `alert_* = 0` to mean an explicit off remain treated as explicit opt-outs after the schema change.

### Description
- Backfilled existing rows in `worker/migrations/0160_telegram_per_coin_alert_override_markers.sql` by adding an `UPDATE` that sets each `alert_*_override = 1` when the corresponding `alert_* = 0` to preserve historical opt-outs.
- Kept the original `ALTER TABLE` adds and the default marker semantics so future partial/follow writes still use `DEFAULT 0` for unmentioned alert types.

### Testing
- Ran `npm run check:migrations` which validated the updated migrations successfully. 
- Ran unit suites `npx vitest run worker/src/cron/__tests__/dispatch-telegram-subscribers.test.ts worker/src/cron/__tests__/dispatch-telegram-routing.test.ts worker/src/api/telegram-store/__tests__/subscriptions.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3662c757b083328d45943256283558)