### PR TITLE
Harden phishing signature script extraction

### DIFF
--- a/scripts/__tests__/check-phishing-signatures.test.ts
+++ b/scripts/__tests__/check-phishing-signatures.test.ts
@@ -47,6 +47,22 @@ describe("check-phishing-signatures", () => {
     ).not.toThrow();
   });
 
+  it("ignores commented fake external scripts before scanning real inline scripts", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><!-- <script src="/ignored.js"> --><script>try { const params = new URLSearchParams(window.location.hash.slice(1)); window.__PHAROS_TOKEN__ = params.get("token"); history.replaceState(null, "", location.pathname); } catch (error) {}</script></body></html>`,
+      ),
+    ).toThrow(/Inline-script phishing-kit signatures detected/);
+  });
+
+  it("does not scan script-looking markup that only appears inside HTML comments", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><!-- <script>window.__PHAROS_TOKEN__ = "comment-only";</script> --><script src="/bundle.js"></script></body></html>`,
+      ),
+    ).not.toThrow();
+  });
+
   it("detects inline phishing signatures when script end tags contain browser-accepted spacing", () => {
     expect(() =>
       runChecker(

--- a/scripts/ci/check-phishing-signatures.mjs
+++ b/scripts/ci/check-phishing-signatures.mjs
@@ -90,6 +90,18 @@ function hasSrcAttribute(openTag) {
   return false;
 }
 
+function isInsideHtmlComment(html, index) {
+  const commentStart = html.lastIndexOf("<!--", index);
+  if (commentStart < 0) return false;
+  const commentEnd = html.lastIndexOf("-->", index);
+  return commentEnd < commentStart;
+}
+
+function isScriptTagOpen(lowerHtml, openStart) {
+  const next = lowerHtml[openStart + "<script".length] ?? "";
+  return next === "" || /[\s/>]/.test(next);
+}
+
 function extractInlineScripts(html) {
   const scripts = [];
   const lowerHtml = html.toLowerCase();
@@ -97,6 +109,10 @@ function extractInlineScripts(html) {
   while (true) {
     const openStart = lowerHtml.indexOf("<script", searchFrom);
     if (openStart < 0) break;
+    if (isInsideHtmlComment(html, openStart) || !isScriptTagOpen(lowerHtml, openStart)) {
+      searchFrom = openStart + "<script".length;
+      continue;
+    }
     const openEnd = lowerHtml.indexOf(">", openStart);
     if (openEnd < 0) break;
     const closeStart = lowerHtml.indexOf("</script", openEnd + 1);


### PR DESCRIPTION
### Motivation

- The lightweight inline-script extractor could be bypassed by a commented fake `<script src=...>` which consumed the `</script>` of the following real inline script and suppressed scanning.

### Description

- Add `isInsideHtmlComment(html, index)` to detect and skip raw `<script` matches that occur inside HTML comments.
- Add `isScriptTagOpen(lowerHtml, openStart)` to require a tag boundary after `<script` before treating a raw match as an opening tag.
- Update `extractInlineScripts` to ignore `<script` markers inside comments or without a valid tag boundary and preserve existing `src`-attribute skipping logic.
- Add regression tests in `scripts/__tests__/check-phishing-signatures.test.ts` to cover the commented fake-script bypass and comment-only script-like markup.

### Testing

- Ran `npx vitest run scripts/__tests__/check-phishing-signatures.test.ts` and all tests passed (1 file, 6 tests).
- Ran `git diff --check` with no issues reported.
- `npm run check:phishing-signatures` could not be executed locally because `out/` is missing without a prior `npm run build`, so the full static-export scan was blocked locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a2fcc3c48332ac18a7e1fad647ce)