### PR TITLE
Remove sticky yield history guardrail

### DIFF
--- a/worker/src/cron/__tests__/yield-history-snapshots.test.ts
+++ b/worker/src/cron/__tests__/yield-history-snapshots.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
 import { createSqliteD1 } from "../../test-helpers/sqlite-d1";
 import {
-  estimateYieldHistoryCandidateCounts,
   loadYieldHistorySnapshots,
 } from "../yield-sync/history";
 
@@ -134,7 +133,7 @@ describe("loadYieldHistorySnapshots", () => {
     expect(snapshots.prevBestRows[0]?.recorded_at).toBe(100);
   });
 
-  it("counts previous-history candidates without materializing them", async () => {
+  it("bounds previous-history materialization without pre-counting old candidates", async () => {
     const fixture = createDb();
     sqlite = fixture.sqlite;
 
@@ -142,12 +141,20 @@ describe("loadYieldHistorySnapshots", () => {
     insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 200, isBest: 1, sourceTvlUsd: 20 });
     insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-b", recordedAt: 150, isBest: 0, sourceTvlUsd: 30 });
 
-    await expect(
-      estimateYieldHistoryCandidateCounts(fixture.db, ["coin-a"], 1_000, 300),
-    ).resolves.toEqual({
-      previousTvlCandidates: 3,
-      previousBestCandidates: 2,
-      totalPreviousCandidates: 5,
-    });
+    const snapshots = await loadYieldHistorySnapshots(fixture.db, ["coin-a"], 1_000, 300);
+
+    expect(snapshots.prevTvlRows.map((row) => ({
+      sourceKey: row.source_key,
+      recordedAt: row.recorded_at,
+    }))).toEqual([
+      { sourceKey: "source-a", recordedAt: 200 },
+      { sourceKey: "source-b", recordedAt: 150 },
+    ]);
+    expect(snapshots.prevBestRows.map((row) => ({
+      sourceKey: row.source_key,
+      recordedAt: row.recorded_at,
+    }))).toEqual([
+      { sourceKey: "source-a", recordedAt: 200 },
+    ]);
   });
 });

--- a/worker/src/cron/sync-yield-data.ts
+++ b/worker/src/cron/sync-yield-data.ts
@@ -13,10 +13,8 @@ import {
 } from "../lib/yield-history-cleanup";
 import { resolveYieldSources } from "./yield-sync/resolve";
 import {
-  estimateYieldHistoryCandidateCounts,
   loadYieldHistorySnapshots,
   purgeYieldHistoryOwnershipHandoffs,
-  YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS,
 } from "./yield-sync/history";
 import {
   evaluateYieldSourcesCooperative,
@@ -247,36 +245,6 @@ export async function syncYieldData(
   const resolvedCountByCoin = new Map<string, number>();
   for (const entry of resolvedWithYield) {
     resolvedCountByCoin.set(entry.id, (resolvedCountByCoin.get(entry.id) ?? 0) + 1);
-  }
-
-  const historyCandidateCounts = resolvedIds.length > 0
-    ? await estimateYieldHistoryCandidateCounts(db, resolvedIds, startSec, sevenDaysAgoSec, { signal })
-    : { previousTvlCandidates: 0, previousBestCandidates: 0, totalPreviousCandidates: 0 };
-  if (historyCandidateCounts.totalPreviousCandidates > YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS) {
-    await reportYieldProgress("history-guardrail", "Yield history candidate guardrail deferred publication", "yield-history", {
-      itemsDone: 0,
-      itemsTotal: resolvedIds.length,
-      metadata: {
-        guard: "history-candidate-count",
-        countTotals: {
-          resolvedCoins: resolvedIds.length,
-          previousTvlCandidates: historyCandidateCounts.previousTvlCandidates,
-          previousBestCandidates: historyCandidateCounts.previousBestCandidates,
-          totalPreviousCandidates: historyCandidateCounts.totalPreviousCandidates,
-          guardrailRows: YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS,
-        },
-      },
-    });
-    return {
-      status: "degraded",
-      itemCount: 0,
-      metadata: JSON.stringify({
-        reason: "yield_history_candidate_guardrail",
-        ...historyCandidateCounts,
-        guardrailRows: YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS,
-        preservedPreviousRanking: true,
-      }),
-    };
   }
 
   const historySnapshots = resolvedIds.length > 0

--- a/worker/src/cron/yield-sync/history.ts
+++ b/worker/src/cron/yield-sync/history.ts
@@ -13,7 +13,6 @@ export { isSuppressedYieldHistoryRow } from "../../lib/yield-history-ownership-h
 
 const D1_SAFE_SQL_IN_CHUNK_SIZE = 90;
 const YIELD_HISTORY_LOAD_CHUNK_SIZE = 30;
-export const YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS = 500_000;
 
 export async function purgeYieldHistoryOwnershipHandoffs(db: D1Database): Promise<void> {
   for (const [stablecoinId, sourceKeys] of Object.entries(YIELD_HISTORY_OWNERSHIP_HANDOFFS)) {
@@ -54,12 +53,6 @@ export interface YieldHistorySnapshotProgress {
   prevBestRows: number;
 }
 
-export interface YieldHistoryCandidateCounts {
-  previousTvlCandidates: number;
-  previousBestCandidates: number;
-  totalPreviousCandidates: number;
-}
-
 export interface LoadYieldHistorySnapshotOptions {
   signal?: AbortSignal;
   chunkSize?: number;
@@ -84,68 +77,6 @@ function buildSuppressedYieldHistoryExclusion(alias: string): { sql: string; bin
     binds.push(stablecoinId, LEGACY_BEST_YIELD_SOURCE_KEY, ...inClause.binds);
   }
   return clauses.length > 0 ? { sql: clauses.join(" AND "), binds } : { sql: "1 = 1", binds: [] };
-}
-
-function countResult(row: { cnt?: number | null } | null): number {
-  const value = row?.cnt ?? 0;
-  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
-}
-
-export async function estimateYieldHistoryCandidateCounts(
-  db: D1Database,
-  resolvedIds: string[],
-  startSec: number,
-  sevenDaysAgoSec: number,
-  options: Pick<LoadYieldHistorySnapshotOptions, "signal" | "chunkSize" | "yieldToEventLoop"> = {},
-): Promise<YieldHistoryCandidateCounts> {
-  let previousTvlCandidates = 0;
-  let previousBestCandidates = 0;
-  const chunkSize = Math.max(1, Math.min(options.chunkSize ?? YIELD_HISTORY_LOAD_CHUNK_SIZE, D1_SAFE_SQL_IN_CHUNK_SIZE));
-  const idChunks = chunkArray(resolvedIds, chunkSize);
-  const yieldToEventLoop = options.yieldToEventLoop ?? defaultYieldToEventLoop;
-
-  for (const idChunk of idChunks) {
-    throwIfAborted(options.signal);
-    const resolvedIdInClause = buildInClause(idChunk);
-    const exclusion = buildSuppressedYieldHistoryExclusion("h");
-    const previousTvlCount = await db
-      .prepare(
-        `SELECT /* pharos:yield-sync:previous-tvl-candidate-count */
-           COUNT(*) AS cnt
-         FROM yield_history h
-         WHERE h.stablecoin_id IN (${resolvedIdInClause.sql})
-           AND h.recorded_at <= ?
-           AND h.source_tvl_usd IS NOT NULL
-           AND (h.publication_state IS NULL OR h.publication_state = 'published')
-           AND ${exclusion.sql}`,
-      )
-      .bind(...resolvedIdInClause.binds, sevenDaysAgoSec, ...exclusion.binds)
-      .first<{ cnt: number | null }>();
-    previousTvlCandidates += countResult(previousTvlCount);
-    throwIfAborted(options.signal);
-
-    const previousBestCount = await db
-      .prepare(
-        `SELECT /* pharos:yield-sync:previous-best-candidate-count */
-           COUNT(*) AS cnt
-         FROM yield_history h
-         WHERE h.stablecoin_id IN (${resolvedIdInClause.sql})
-           AND h.is_best = 1
-           AND h.recorded_at < ?
-           AND (h.publication_state IS NULL OR h.publication_state = 'published')
-           AND ${exclusion.sql}`,
-      )
-      .bind(...resolvedIdInClause.binds, startSec, ...exclusion.binds)
-      .first<{ cnt: number | null }>();
-    previousBestCandidates += countResult(previousBestCount);
-    await yieldToEventLoop(options.signal);
-  }
-
-  return {
-    previousTvlCandidates,
-    previousBestCandidates,
-    totalPreviousCandidates: previousTvlCandidates + previousBestCandidates,
-  };
 }
 
 export async function loadYieldHistorySnapshots(


### PR DESCRIPTION
### Motivation

- A pre-publication guardrail counted historical `yield_history` candidate rows and could return a degraded status before the publication path ran, which also skipped retention cleanup and made the condition persistent.
- The intent is to keep bounded latest-row selection (the memory guard) while ensuring publication and `pruneYieldTables` remain reachable even when the table has accumulated stale rows.

### Description

- Remove the `YIELD_HISTORY_CANDIDATE_GUARDRAIL_ROWS` constant and the `estimateYieldHistoryCandidateCounts` helper from `worker/src/cron/yield-sync/history.ts` so we no longer pre-count historical candidates. 
- Drop the early degraded-return guard in `worker/src/cron/sync-yield-data.ts` that short-circuited publication based on the historical candidate count. 
- Preserve the bounded loaders in `loadYieldHistorySnapshots` (the `NOT EXISTS` latest-row queries) so previous-TVLand previous-best selection remains memory-bounded and chunked. 
- Update the SQLite-backed test `worker/src/cron/__tests__/yield-history-snapshots.test.ts` to assert bounded historical materialization from `loadYieldHistorySnapshots` instead of checking the removed candidate-count behavior.

### Testing

- Ran `npx vitest run worker/src/cron/__tests__/yield-history-snapshots.test.ts` and all tests passed. 
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation completed without errors. 
- Ran `npm run check:cron-sync` and the cron schedule sync check passed. 
- Ran `npm run check:cron-connections` and the cron connection budget check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a2fcc1648332bd6f03d4ae0f7de2)