### PR TITLE
Exclude Accountable excluded buckets from normalized reserve slices

### DIFF
--- a/docs/live-reserves.md
+++ b/docs/live-reserves.md
@@ -538,7 +538,7 @@ the `re-metrics` adapter parses Re Protocol's official metrics page and now extr
 `zephyr-scanner` consumes Zephyr's reserve snapshot API for `zsd-zephyr-protocol`, preserving the snapshot capture timestamp, ZEPH reserve value, ZSD supply, reserve ratio, moving-average reserve ratio, and ZSD yield-reserve metadata. It is proof-class because the feed is protocol-published native-chain telemetry over volatile ZEPH collateral rather than independently verified asset-level reserve evidence.
 
 Accountable note:
-`accountable` configs may exclude reviewed buckets from strict `total_reserves` reconciliation when the dashboard publishes auxiliary reserves outside the reported total. Configs may also allow reviewed signed exposure buckets; negative buckets are omitted from reserve slices, recorded in metadata, and degrade the snapshot instead of opening the breaker.
+`accountable` configs may exclude reviewed buckets from strict `total_reserves` reconciliation when the dashboard publishes auxiliary reserves outside the reported total. Those excluded buckets are also omitted from normalized reserve slices so auxiliary values cannot dilute or inflate the published collateral mix. Configs may also allow reviewed signed exposure buckets; negative buckets are omitted from reserve slices, recorded in metadata, and degrade the snapshot instead of opening the breaker.
 
 Chainlink NAV note:
 `chainlink-nav` now supports both standard AggregatorV3 feeds and Ondo router-style NAV lookups. When `oracleMethod = "getAssetPrice"`, the adapter calls `getAssetPrice(token)` on the router and, when available, follows `tokenToRWAOracle(token) -> getPriceData()` to recover a verified freshness timestamp instead of treating the feed as permanently timestampless.

--- a/worker/src/cron/reserve-adapters/__tests__/accountable.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/accountable.test.ts
@@ -477,7 +477,7 @@ describe("adaptAccountableDashboard", () => {
     )).toThrow(/bucket total 100 does not match total_reserves 1000/);
   });
 
-  it("allows configured Accountable buckets to be excluded from total_reserves reconciliation", async () => {
+  it("omits configured Accountable buckets from total_reserves reconciliation and reserve slices", async () => {
     const config = yusd.liveReservesConfig as LiveReservesConfig;
     const primary = config.inputs.primary;
     if (primary.kind !== "http-json") {
@@ -520,10 +520,11 @@ describe("adaptAccountableDashboard", () => {
       totalReserves: 36_193_106.94,
       totalReservesExcludedBuckets: ["Insurance Fund"],
     });
-    expect(result.slices).toContainEqual(expect.objectContaining({
+    expect(result.slices).not.toContainEqual(expect.objectContaining({
       name: "Insurance Fund",
-      risk: "low",
     }));
+    const totalPct = result.slices.reduce((sum, slice) => sum + slice.pct, 0);
+    expect(totalPct).toBeCloseTo(100, 1);
     expect(validateAdapterOutput(result, {
       adapter: getReserveAdapter("accountable") ?? undefined,
       now: Date.UTC(2026, 5, 20, 10) / 1000,

--- a/worker/src/cron/reserve-adapters/accountable.ts
+++ b/worker/src/cron/reserve-adapters/accountable.ts
@@ -238,7 +238,8 @@ export function adaptAccountableDashboard(
   const depTypeMap = params.depTypeMap ?? {};
   const totalReservesExcludeBuckets = new Set(params.totalReservesExcludeBuckets ?? []);
   const signedBuckets = breakdown.filter((entry) => entry.value < 0);
-  const positiveBreakdown = breakdown.filter((entry) => entry.value > 0);
+  const reconciledBreakdown = breakdown.filter((entry) => !(totalReservesExcludeBuckets.has(entry.name)));
+  const positiveBreakdown = reconciledBreakdown.filter((entry) => entry.value > 0);
   const mappedForValidation = breakdown.filter(({ name }) => name in riskMap);
   validateMappedBucketValues(mappedForValidation, bucket, { allowNegativeBuckets });
   const mapped = positiveBreakdown.filter(({ name }) => name in riskMap);


### PR DESCRIPTION
### Motivation
- Prevent auxiliary Accountable dashboard buckets that are intentionally excluded from `total_reserves` reconciliation from inflating or diluting the published normalized reserve composition.
- Preserve the metadata about reviewed exclusions while ensuring the public reserve mix remains bounded by reconciled values.

### Description
- Stop using the full breakdown when building published slices by filtering out `totalReservesExcludeBuckets` into a `reconciledBreakdown` and deriving `positiveBreakdown` from that set in `worker/src/cron/reserve-adapters/accountable.ts`.
- Keep mapped-bucket validation and reconciliation behavior but ensure excluded buckets do not become normalized slices (they remain present in metadata).
- Update the focused Accountable test in `worker/src/cron/reserve-adapters/__tests__/accountable.test.ts` to assert excluded buckets are not present in `slices` and that the published slices sum to ~100%.
- Document the behavioral change in `docs/live-reserves.md` so excluded buckets are described as omitted from normalized reserve slices.

### Testing
- Ran the focused adapter suite with `npx vitest run worker/src/cron/reserve-adapters/__tests__/accountable.test.ts`, which passed (`15/15` tests passed).
- Type-checked the worker build with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a2fce1008332a1a5ed4eea6de658)