### PR TITLE
fix(dex-liquidity): reject exchange-only orderbook exact keys

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts
@@ -19,7 +19,19 @@ describe("pool identity dedup", () => {
     expect(identity.exactPoolKey).toBe("ethereum:0xabc0000000000000000000000000000000000000");
   });
 
-  it("preserves synthetic orderbook prefixes for exact dedup identity", () => {
+  it("preserves asset-specific synthetic orderbook prefixes for exact dedup identity", () => {
+    const identity = buildPoolIdentity({
+      chain: "orderbook",
+      protocol: "binance",
+      poolAddressOrId: "orderbook:binance:usdt-tether",
+      tokenAddresses: [],
+    });
+
+    expect(identity.exactPoolKey).toBe("orderbook:orderbook:binance:usdt-tether");
+    expect(identity.identitySource).toBe("native-id");
+  });
+
+  it("does not trust exchange-only orderbook ids as exact dedup identities", () => {
     const identity = buildPoolIdentity({
       chain: "orderbook",
       protocol: "binance",
@@ -27,8 +39,8 @@ describe("pool identity dedup", () => {
       tokenAddresses: [],
     });
 
-    expect(identity.exactPoolKey).toBe("orderbook:orderbook:binance");
-    expect(identity.identitySource).toBe("native-id");
+    expect(identity.exactPoolKey).toBeNull();
+    expect(identity.identitySource).toBe("none");
   });
 
   it("can dedupe an identity-poor Uniswap v4 DL row against one staged exact-pool-id row", () => {

--- a/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts
@@ -926,4 +926,47 @@ describe("mergeStagedPools", () => {
       },
     });
   });
+
+  it("does not exact-dedupe legacy exchange-only orderbook rows across stablecoins", async () => {
+    const now = 1710000000;
+    const makeOrderbookRow = (stablecoinId: string, symbol: string) => ({
+      pool_id: "orderbook:binance",
+      stablecoin_id: stablecoinId,
+      source: "cg_tickers",
+      chain: "orderbook",
+      protocol: "binance",
+      symbol,
+      tvl_usd: 500000,
+      volume_24h: 1000000,
+      fee_tier: null,
+      balance_ratio: null,
+      is_stable: 0,
+      base_token: null,
+      quote_token: null,
+      quote_symbol: "USD",
+      price_usd: 1.0001,
+      locked_liq_pct: null,
+      raw_json: JSON.stringify({
+        orderbookTvlBasis: "coingecko-depth-2pct-capped-by-volume",
+        orderbookDepthUsd: 500000,
+        orderbookDepthUpUsd: 700000,
+      }),
+      discovered_at: now - 86400 * 5,
+      refreshed_at: now,
+    });
+    const mockDb = createMockDb([
+      makeOrderbookRow("usdt-tether", "USDT/USD"),
+      makeOrderbookRow("usdc-circle", "USDC/USD"),
+    ]);
+    const metrics = new Map();
+    const knownPoolIndex = makeKnownPoolIndex();
+
+    const result = await mergeStagedPools(mockDb, metrics as never, knownPoolIndex, now);
+
+    expect(result.mergedCount).toBe(2);
+    expect(result.skippedCount).toBe(0);
+    expect(result.skippedByExactIdentityCount).toBe(0);
+    expect(metrics.get("usdt-tether")?.topPools).toHaveLength(1);
+    expect(metrics.get("usdc-circle")?.topPools).toHaveLength(1);
+  });
 });

--- a/worker/src/cron/dex-liquidity/pool-identity.ts
+++ b/worker/src/cron/dex-liquidity/pool-identity.ts
@@ -40,6 +40,14 @@ function isUniswapV4PoolId(poolId: string, protocol?: string | null): boolean {
   return normalizeProtocol(protocol ?? "") === "uniswap-v4" && /^0x[a-f0-9]{64}$/i.test(poolId);
 }
 
+function isTrustworthyOrderbookPoolId(poolId: string): boolean {
+  if (poolId.startsWith("orderbook:")) {
+    const [, exchangeId, stablecoinId] = poolId.split(":");
+    return Boolean(exchangeId && stablecoinId);
+  }
+  return poolId.startsWith("orderbook-");
+}
+
 function canonicalizeExactPoolId(poolId: string, chain: string): string {
   const trimmed = poolId.trim();
   if (chain.toLowerCase() === "orderbook") return trimmed;
@@ -53,7 +61,7 @@ export function isTrustworthyExactPoolId(poolId: string | null | undefined, prot
   if (!poolId) return false;
   const trimmed = poolId.trim();
   if (!trimmed) return false;
-  if (trimmed.startsWith("orderbook-") || trimmed.startsWith("orderbook:")) return true;
+  if (trimmed.startsWith("orderbook-") || trimmed.startsWith("orderbook:")) return isTrustworthyOrderbookPoolId(trimmed);
   if (/^0x[a-f0-9]{40}$/i.test(trimmed)) return true;
   if (isUniswapV4PoolId(trimmed, protocol)) return true;
   return /^[1-9A-HJ-NP-Za-km-z]{32,64}$/.test(trimmed);


### PR DESCRIPTION
### Motivation
- Legacy or malformed `orderbook:<exchange>` staged rows were being treated as global exact pool identities and could suppress distinct staged pools for different stablecoins on the same exchange. 
- The change ensures that only asset-specific synthetic orderbook identifiers (e.g. `orderbook:<exchange>:<stablecoin>`) can become global exact keys so deduplication remains per-market.

### Description
- Add `isTrustworthyOrderbookPoolId()` to require both an exchange and an asset segment for `orderbook:` pool ids. 
- Update `isTrustworthyExactPoolId()` to call the new helper so exchange-only `orderbook:<exchange>` ids are no longer trusted as exact identities. 
- Adjust `worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts` to assert that `orderbook:binance:usdt-tether` becomes an exact key and that `orderbook:binance` does not. 
- Add a `staging-merge` regression in `worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts` ensuring two legacy exchange-only `orderbook` rows for different stablecoins are both merged (no exact-key suppression).

### Testing
- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/pool-identity.test.ts worker/src/cron/dex-liquidity/__tests__/staging-merge.test.ts` and all tests passed (`40 passed`).
- Ran `cd worker && npx tsc --noEmit` to verify type-checking and the build succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a2feb368833280400c77bcc33521)