### PR TITLE
fix(sync): avoid circuit failures on staleness aborts

### DIFF
--- a/worker/src/cron/__tests__/sync-stablecoins.test.ts
+++ b/worker/src/cron/__tests__/sync-stablecoins.test.ts
@@ -1629,6 +1629,30 @@ describe("syncStablecoins", () => {
     );
   });
 
+  it("does not record a DefiLlama circuit failure when aborted during the staleness check", async () => {
+    const dlData = makeDlResponse(60);
+    const controller = new AbortController();
+    const reportProgress = vi.fn(async (update: { stage?: string | null }) => {
+      if (update.stage === "staleness-check") {
+        controller.abort("test abort during staleness check");
+      }
+    });
+    const db = makeDb();
+
+    mockFetchWithRetry([
+      { match: "api.coingecko.com", body: {} },
+      { match: "stablecoins.llama.fi", body: dlData },
+      { match: "coins.llama.fi/prices", body: { coins: {} } },
+    ]);
+
+    const result = await syncStablecoins(db, controller.signal, { reportProgress });
+
+    expect(result.aborted).toBe(true);
+    expect(vi.mocked(recordOutcome).mock.calls.some((call) => (
+      call[1] === CIRCUIT_SOURCE.DL_STABLECOINS && call[2] === false
+    ))).toBe(false);
+  });
+
   it("degrades cleanly when the previous stablecoins cache is malformed", async () => {
     const dlData = makeDlResponse(60);
     const db = mockD1([

--- a/worker/src/cron/sync-stablecoins.ts
+++ b/worker/src/cron/sync-stablecoins.ts
@@ -133,7 +133,9 @@ export async function syncStablecoins(
     }),
   });
   if (stalenessCheck.blockedResult) {
-    await recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl);
+    if (stalenessCheck.blockedReason === "severe-staleness") {
+      await recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl);
+    }
     return stalenessCheck.blockedResult;
   }
   const { stalenessWarning, stalenessSummary } = stalenessCheck;

--- a/worker/src/cron/sync-stablecoins.ts
+++ b/worker/src/cron/sync-stablecoins.ts
@@ -9,6 +9,7 @@ import {
   abortResult,
   checkStablecoinsPriceStaleness,
   fillStablecoinsSupplyHistoryStage,
+  recordStablecoinsStalenessBlockOutcome,
   reportStablecoinsStage,
   returnIfAborted,
 } from "./sync-stablecoins/runtime";
@@ -17,8 +18,6 @@ import {
   runStablecoinsPricingStage,
 } from "./sync-stablecoins/stages";
 import type { ChainRpcConfig } from "../lib/chain-registry";
-import { recordOutcome } from "../lib/circuit-breaker";
-import { CIRCUIT_SOURCE } from "../lib/constants";
 import type { CronProgressReporter } from "../lib/cron-logger";
 
 export interface SyncStablecoinsOptions {
@@ -133,9 +132,7 @@ export async function syncStablecoins(
     }),
   });
   if (stalenessCheck.blockedResult) {
-    if (stalenessCheck.blockedReason === "severe-staleness") {
-      await recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl);
-    }
+    await recordStablecoinsStalenessBlockOutcome(db, stalenessCheck, alertWebhookUrl);
     return stalenessCheck.blockedResult;
   }
   const { stalenessWarning, stalenessSummary } = stalenessCheck;

--- a/worker/src/cron/sync-stablecoins/runtime.ts
+++ b/worker/src/cron/sync-stablecoins/runtime.ts
@@ -98,6 +98,7 @@ export async function checkStablecoinsPriceStaleness(params: {
   stalenessWarning: boolean;
   stalenessSummary: StablecoinsStalenessSummary | null;
   blockedResult?: CronResult;
+  blockedReason?: "abort" | "severe-staleness";
 }> {
   let stalenessWarning = false;
   let stalenessSummary: StablecoinsStalenessSummary | null = null;
@@ -115,6 +116,7 @@ export async function checkStablecoinsPriceStaleness(params: {
         stalenessWarning,
         stalenessSummary,
         blockedResult: stalenessAbort,
+        blockedReason: "abort",
       };
     }
     const staleness = await detectPriceStaleness(params.db, params.assets, params.signal);
@@ -140,6 +142,7 @@ export async function checkStablecoinsPriceStaleness(params: {
         stalenessWarning,
         stalenessSummary,
         blockedResult: params.blockedResultFactory(stalenessSummary),
+        blockedReason: "severe-staleness",
       };
     }
   } catch (error) {
@@ -148,6 +151,7 @@ export async function checkStablecoinsPriceStaleness(params: {
         stalenessWarning,
         stalenessSummary,
         blockedResult: abortResult(params.signal, params.abortStage),
+        blockedReason: "abort",
       };
     }
     const prefix = params.failureLabel ?? "Staleness check";

--- a/worker/src/cron/sync-stablecoins/runtime.ts
+++ b/worker/src/cron/sync-stablecoins/runtime.ts
@@ -1,5 +1,7 @@
 import { buildSyncMetadata } from "./shared";
 import { detectPriceStaleness, fillMissingSupplyHistory } from "./phase-helpers";
+import { recordOutcome } from "../../lib/circuit-breaker";
+import { CIRCUIT_SOURCE } from "../../lib/constants";
 import { reportCronProgress } from "../../lib/cron-progress";
 import type { CronProgressReporter, CronResult } from "../../lib/cron-logger";
 import type { PeggedAsset } from "./enrich-prices";
@@ -16,6 +18,15 @@ export interface StablecoinsStalenessSummary {
   compared: number;
   identical: number;
   identicalRatio: number;
+}
+
+type StablecoinsStalenessBlockedReason = "abort" | "severe-staleness";
+
+interface StablecoinsStalenessCheckResult {
+  stalenessWarning: boolean;
+  stalenessSummary: StablecoinsStalenessSummary | null;
+  blockedResult?: CronResult;
+  blockedReason?: StablecoinsStalenessBlockedReason;
 }
 
 export async function reportStablecoinsStage(
@@ -94,12 +105,7 @@ export async function checkStablecoinsPriceStaleness(params: {
   warningLabel?: string;
   failureLabel?: string;
   blockedResultFactory: (summary: StablecoinsStalenessSummary) => CronResult;
-}): Promise<{
-  stalenessWarning: boolean;
-  stalenessSummary: StablecoinsStalenessSummary | null;
-  blockedResult?: CronResult;
-  blockedReason?: "abort" | "severe-staleness";
-}> {
+}): Promise<StablecoinsStalenessCheckResult> {
   let stalenessWarning = false;
   let stalenessSummary: StablecoinsStalenessSummary | null = null;
 
@@ -159,4 +165,13 @@ export async function checkStablecoinsPriceStaleness(params: {
   }
 
   return { stalenessWarning, stalenessSummary };
+}
+
+export async function recordStablecoinsStalenessBlockOutcome(
+  db: D1Database,
+  check: Pick<StablecoinsStalenessCheckResult, "blockedReason">,
+  alertWebhookUrl?: string | null,
+): Promise<void> {
+  if (check.blockedReason !== "severe-staleness") return;
+  await recordOutcome(db, CIRCUIT_SOURCE.DL_STABLECOINS, false, alertWebhookUrl);
 }


### PR DESCRIPTION
### Motivation
- The staleness-check returned a generic `blockedResult` for both severe price-staleness and aborts which caused aborts to be misclassified as DefiLlama failures and increment the DL circuit.
- Misclassified aborts could open the DefiLlama circuit and force later syncs to skip DefiLlama, degrading data freshness and availability.

### Description
- Added an explicit `blockedReason?: "abort" | "severe-staleness"` field to the `checkStablecoinsPriceStaleness` return shape and set it for abort and severe-staleness paths in `worker/src/cron/sync-stablecoins/runtime.ts`.
- Changed `syncStablecoins` in `worker/src/cron/sync-stablecoins.ts` to call `recordOutcome(..., DL_STABLECOINS, false)` only when `blockedReason === "severe-staleness"`, preserving abort behavior without counting it as an upstream failure.
- Added a regression test `does not record a DefiLlama circuit failure when aborted during the staleness check` in `worker/src/cron/__tests__/sync-stablecoins.test.ts` that aborts during the staleness progress update and asserts no DL circuit failure was recorded.

### Testing
- Ran focused staleness tests with `npx vitest run worker/src/cron/__tests__/sync-stablecoins.test.ts -t "staleness"` and they passed.
- Ran the full stablecoins test file with `npx vitest run worker/src/cron/__tests__/sync-stablecoins.test.ts` and all tests passed (`56 passed`), and TypeScript checked with `cd worker && npx tsc --noEmit` successfully.
- Committed as `bbf1b98` with the subject `fix(sync): avoid circuit failures on staleness aborts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a2fcaf9483328f2f2cdebdbb242d)