### PR TITLE
Bound yield history TVL snapshot loading

### DIFF
--- a/worker/src/cron/__tests__/yield-coordinator-metadata.test.ts
+++ b/worker/src/cron/__tests__/yield-coordinator-metadata.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { COMPARISON_ANCHOR_STALE_THRESHOLD_MS } from "../yield-helpers";
-import {
-  buildComparisonAnchorFreshnessMeta,
-  buildYieldSyncMetadata,
-} from "../yield-sync/coordinator-metadata";
+import { buildComparisonAnchorFreshnessMeta, buildYieldSyncMetadata } from "../yield-sync/coordinator-metadata";
 import type { EvaluatedYieldSource } from "../yield-sync/evaluation-types";
 import type { YieldEnvelopeRejection } from "../yield-sync/types";
 
@@ -89,73 +86,77 @@ describe("buildYieldSyncMetadata", () => {
     });
     const envelopeRejections = Array.from({ length: 26 }, (_, index) => makeEnvelopeRejection(index));
 
-    const metadata = JSON.parse(buildYieldSyncMetadata({
-      rowsRead: 1,
-      rowsWritten: 1,
-      rowsRejected: 0,
-      divergenceFlags: 0,
-      sourceSwitches: 0,
-      defaultSafetyCoinCount: 0,
-      safetySnapshot: {
-        kind: "ok",
-        coverageRatio: 1,
-        coveredCount: 1,
-        trackedCount: 1,
-        reason: null,
-      },
-      resolvedYieldBearingCount: 1,
-      expectedYieldBearingCount: 1,
-      publishedYieldBearingCount: 1,
-      previousPublishedYieldBearingCount: 1,
-      publishedOpportunityCount: 0,
-      previousPublishedOpportunityCount: 0,
-      publishedRankingCount: 1,
-      previousPublishedRankingCount: 1,
-      dlPoolsMeta: {
-        mode: "dex-cache",
-        updatedAt: START_SEC,
-        ageSeconds: 0,
-        poolCount: 1,
+    const metadata = JSON.parse(
+      buildYieldSyncMetadata({
+        rowsRead: 1,
+        rowsWritten: 1,
+        rowsRejected: 0,
+        divergenceFlags: 0,
+        sourceSwitches: 0,
+        defaultSafetyCoinCount: 0,
+        safetySnapshot: {
+          kind: "ok",
+          coverageRatio: 1,
+          coveredCount: 1,
+          trackedCount: 1,
+          reason: null,
+        },
+        resolvedYieldBearingCount: 1,
+        expectedYieldBearingCount: 1,
+        publishedYieldBearingCount: 1,
+        previousPublishedYieldBearingCount: 1,
+        publishedOpportunityCount: 0,
+        previousPublishedOpportunityCount: 0,
+        publishedRankingCount: 1,
+        previousPublishedRankingCount: 1,
+        dlPoolsMeta: {
+          mode: "dex-cache",
+          updatedAt: START_SEC,
+          ageSeconds: 0,
+          poolCount: 1,
+          fallbackMode: null,
+        },
+        supplementalMeta: {
+          mode: "cache",
+          updatedAt: START_SEC,
+          ageSeconds: 0,
+          sourceCount: 0,
+          fallbackMode: null,
+        },
+        onChain: {
+          ratesResolved: 0,
+          ratesConfigured: 1,
+          envelopeRejections,
+          attempted: 1,
+          allDeterministicFailed: false,
+          explorerAttempted: 0,
+          explorerResolved: 0,
+          failureMaskedByAlternativeCoverage: false,
+          alternativeCoverageMissingIds: [],
+          failures: null,
+          skippedDueToCooldown: false,
+          cooldownActive: false,
+          cooldownTriggered: false,
+          cooldownUntil: null,
+          cooldownRemainingSec: 0,
+          consecutiveAllFailRuns: 0,
+          consecutiveMaskedAllFailRuns: 0,
+        },
         fallbackMode: null,
-      },
-      supplementalMeta: {
-        mode: "cache",
-        updatedAt: START_SEC,
-        ageSeconds: 0,
-        sourceCount: 0,
-        fallbackMode: null,
-      },
-      onChain: {
-        ratesResolved: 0,
-        ratesConfigured: 1,
-        envelopeRejections,
-        attempted: 1,
-        allDeterministicFailed: false,
-        explorerAttempted: 0,
-        explorerResolved: 0,
-        failureMaskedByAlternativeCoverage: false,
-        alternativeCoverageMissingIds: [],
-        failures: null,
-        skippedDueToCooldown: false,
-        cooldownActive: false,
-        cooldownTriggered: false,
-        cooldownUntil: null,
-        cooldownRemainingSec: 0,
-        consecutiveAllFailRuns: 0,
-        consecutiveMaskedAllFailRuns: 0,
-      },
-      fallbackMode: null,
-      validationFailures: 0,
-      riskFreeRate: 4,
-      cacheWriteSkipped: false,
-      comparisonAnchorFreshness,
-    })) as {
+        validationFailures: 0,
+        riskFreeRate: 4,
+        cacheWriteSkipped: false,
+        comparisonAnchorFreshness,
+        previousTvlRowsTruncated: true,
+      }),
+    ) as {
       sourceCoverage: {
         publishedRankingCountDelta: number;
         onChainEnvelopeRejectionCount: number;
         onChainEnvelopeRejections: YieldEnvelopeRejection[];
         onChainEnvelopeRejectionsTruncated: boolean;
         comparisonAnchorFreshness: typeof comparisonAnchorFreshness;
+        previousTvlRowsTruncated: boolean;
       };
     };
 
@@ -165,5 +166,6 @@ describe("buildYieldSyncMetadata", () => {
     expect(metadata.sourceCoverage.onChainEnvelopeRejections[0]).toEqual(envelopeRejections[0]);
     expect(metadata.sourceCoverage.onChainEnvelopeRejectionsTruncated).toBe(true);
     expect(metadata.sourceCoverage.comparisonAnchorFreshness).toEqual(comparisonAnchorFreshness);
+    expect(metadata.sourceCoverage.previousTvlRowsTruncated).toBe(true);
   });
 });

--- a/worker/src/cron/__tests__/yield-history-snapshots.test.ts
+++ b/worker/src/cron/__tests__/yield-history-snapshots.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
 import { createSqliteD1 } from "../../test-helpers/sqlite-d1";
-import {
-  loadYieldHistorySnapshots,
-} from "../yield-sync/history";
+import { loadYieldHistorySnapshots, MAX_PREVIOUS_TVL_HISTORY_ROWS } from "../yield-sync/history";
 
 function createDb(): { sqlite: DatabaseSync; db: D1Database } {
   const sqlite = new DatabaseSync(":memory:");
@@ -38,21 +36,23 @@ function insertHistory(
     publicationState?: string | null;
   },
 ): void {
-  sqlite.prepare(
-    `INSERT INTO yield_history (
+  sqlite
+    .prepare(
+      `INSERT INTO yield_history (
       stablecoin_id, source_key, recorded_at, is_best, apy, apy_base,
       source_tvl_usd, data_source, yield_source, yield_type, exchange_rate,
       publication_state
     ) VALUES (?, ?, ?, ?, ?, NULL, ?, 'defillama', 'Test', 'lending', NULL, ?)`,
-  ).run(
-    row.stablecoinId,
-    row.sourceKey,
-    row.recordedAt,
-    row.isBest ?? 0,
-    row.apy ?? 1,
-    row.sourceTvlUsd ?? null,
-    row.publicationState ?? "published",
-  );
+    )
+    .run(
+      row.stablecoinId,
+      row.sourceKey,
+      row.recordedAt,
+      row.isBest ?? 0,
+      row.apy ?? 1,
+      row.sourceTvlUsd ?? null,
+      row.publicationState ?? "published",
+    );
 }
 
 describe("loadYieldHistorySnapshots", () => {
@@ -81,12 +81,14 @@ describe("loadYieldHistorySnapshots", () => {
       sourceKeysByStablecoin,
     });
 
-    expect(snapshots.prevTvlRows.map((row) => ({
-      stablecoinId: row.stablecoin_id,
-      sourceKey: row.source_key,
-      recordedAt: row.recorded_at,
-      tvl: row.source_tvl_usd,
-    }))).toEqual([
+    expect(
+      snapshots.prevTvlRows.map((row) => ({
+        stablecoinId: row.stablecoin_id,
+        sourceKey: row.source_key,
+        recordedAt: row.recorded_at,
+        tvl: row.source_tvl_usd,
+      })),
+    ).toEqual([
       { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 200, tvl: 20 },
       { stablecoinId: "coin-a", sourceKey: "source-b", recordedAt: 150, tvl: 30 },
       { stablecoinId: "coin-b", sourceKey: null, recordedAt: 190, tvl: 50 },
@@ -97,17 +99,37 @@ describe("loadYieldHistorySnapshots", () => {
     const fixture = createDb();
     sqlite = fixture.sqlite;
 
-    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-old", recordedAt: 100, isBest: 1, sourceTvlUsd: 10 });
-    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-new", recordedAt: 200, isBest: 1, sourceTvlUsd: 20 });
-    insertHistory(sqlite, { stablecoinId: "coin-b", sourceKey: "source-b", recordedAt: 150, isBest: 1, sourceTvlUsd: 30 });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-a",
+      sourceKey: "source-old",
+      recordedAt: 100,
+      isBest: 1,
+      sourceTvlUsd: 10,
+    });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-a",
+      sourceKey: "source-new",
+      recordedAt: 200,
+      isBest: 1,
+      sourceTvlUsd: 20,
+    });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-b",
+      sourceKey: "source-b",
+      recordedAt: 150,
+      isBest: 1,
+      sourceTvlUsd: 30,
+    });
 
     const snapshots = await loadYieldHistorySnapshots(fixture.db, ["coin-a", "coin-b"], 1_000, 300);
 
-    expect(snapshots.prevBestRows.map((row) => ({
-      stablecoinId: row.stablecoin_id,
-      sourceKey: row.source_key,
-      recordedAt: row.recorded_at,
-    }))).toEqual([
+    expect(
+      snapshots.prevBestRows.map((row) => ({
+        stablecoinId: row.stablecoin_id,
+        sourceKey: row.source_key,
+        recordedAt: row.recorded_at,
+      })),
+    ).toEqual([
       { stablecoinId: "coin-a", sourceKey: "source-new", recordedAt: 200 },
       { stablecoinId: "coin-b", sourceKey: "source-b", recordedAt: 150 },
     ]);
@@ -143,25 +165,81 @@ describe("loadYieldHistorySnapshots", () => {
     const fixture = createDb();
     sqlite = fixture.sqlite;
 
-    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 100, isBest: 1, sourceTvlUsd: 10 });
-    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 200, isBest: 1, sourceTvlUsd: 20 });
-    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-b", recordedAt: 150, isBest: 0, sourceTvlUsd: 30 });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-a",
+      sourceKey: "source-a",
+      recordedAt: 100,
+      isBest: 1,
+      sourceTvlUsd: 10,
+    });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-a",
+      sourceKey: "source-a",
+      recordedAt: 200,
+      isBest: 1,
+      sourceTvlUsd: 20,
+    });
+    insertHistory(sqlite, {
+      stablecoinId: "coin-a",
+      sourceKey: "source-b",
+      recordedAt: 150,
+      isBest: 0,
+      sourceTvlUsd: 30,
+    });
 
     const snapshots = await loadYieldHistorySnapshots(fixture.db, ["coin-a"], 1_000, 300, {
       sourceKeysByStablecoin: new Map([["coin-a", new Set(["source-a"])]]),
     });
 
-    expect(snapshots.prevTvlRows.map((row) => ({
-      sourceKey: row.source_key,
-      recordedAt: row.recorded_at,
-    }))).toEqual([
+    expect(
+      snapshots.prevTvlRows.map((row) => ({
+        sourceKey: row.source_key,
+        recordedAt: row.recorded_at,
+      })),
+    ).toEqual([
       { sourceKey: "source-a", recordedAt: 200 },
     ]);
-    expect(snapshots.prevBestRows.map((row) => ({
-      sourceKey: row.source_key,
-      recordedAt: row.recorded_at,
-    }))).toEqual([
-      { sourceKey: "source-a", recordedAt: 200 },
-    ]);
+    expect(
+      snapshots.prevBestRows.map((row) => ({
+        sourceKey: row.source_key,
+        recordedAt: row.recorded_at,
+      })),
+    ).toEqual([{ sourceKey: "source-a", recordedAt: 200 }]);
+  });
+  it("caps previous TVL history rows and reports truncation", async () => {
+    const fixture = createDb();
+    sqlite = fixture.sqlite;
+
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 100, sourceTvlUsd: 10 });
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-b", recordedAt: 110, sourceTvlUsd: 20 });
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-c", recordedAt: 120, sourceTvlUsd: 30 });
+
+    const snapshots = await loadYieldHistorySnapshots(fixture.db, ["coin-a"], 1_000, 300, {
+      maxPreviousTvlRows: 2,
+    });
+
+    expect(snapshots.prevTvlRows.map((row) => row.source_key)).toEqual(["source-a", "source-b"]);
+    expect(snapshots.previousTvlRowsTruncated).toBe(true);
+  });
+
+  it("caps source-key-scoped previous TVL history rows and reports truncation", async () => {
+    const fixture = createDb();
+    sqlite = fixture.sqlite;
+
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-a", recordedAt: 100, sourceTvlUsd: 10 });
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-b", recordedAt: 110, sourceTvlUsd: 20 });
+    insertHistory(sqlite, { stablecoinId: "coin-a", sourceKey: "source-c", recordedAt: 120, sourceTvlUsd: 30 });
+
+    const snapshots = await loadYieldHistorySnapshots(fixture.db, ["coin-a"], 1_000, 300, {
+      maxPreviousTvlRows: 2,
+      sourceKeysByStablecoin: new Map([["coin-a", new Set(["source-a", "source-b", "source-c"])]]),
+    });
+
+    expect(snapshots.prevTvlRows.map((row) => row.source_key)).toEqual(["source-a", "source-b"]);
+    expect(snapshots.previousTvlRowsTruncated).toBe(true);
+  });
+
+  it("uses a default previous TVL cap large enough for normal history", () => {
+    expect(MAX_PREVIOUS_TVL_HISTORY_ROWS).toBeGreaterThan(1_000);
   });
 });

--- a/worker/src/cron/sync-yield-data.ts
+++ b/worker/src/cron/sync-yield-data.ts
@@ -7,18 +7,10 @@ import { getCache } from "../lib/db-cache";
 import { reportCronProgress } from "../lib/cron-progress";
 import { ON_CHAIN_RATE_CONFIGS } from "./yield-config";
 import type { ChainRpcConfig } from "../lib/chain-registry";
-import {
-  YIELD_HISTORY_CLEANUP_WRITER_PAUSE_KEY,
-  parseYieldHistoryWriterPause,
-} from "../lib/yield-history-cleanup";
+import { YIELD_HISTORY_CLEANUP_WRITER_PAUSE_KEY, parseYieldHistoryWriterPause } from "../lib/yield-history-cleanup";
 import { resolveYieldSources } from "./yield-sync/resolve";
-import {
-  loadYieldHistorySnapshots,
-  purgeYieldHistoryOwnershipHandoffs,
-} from "./yield-sync/history";
-import {
-  evaluateYieldSourcesCooperative,
-} from "./yield-sync/evaluation";
+import { loadYieldHistorySnapshots, purgeYieldHistoryOwnershipHandoffs } from "./yield-sync/history";
+import { evaluateYieldSourcesCooperative } from "./yield-sync/evaluation";
 import { buildYieldHistoryEvaluationInputsCooperative } from "./yield-sync/coordinator-history";
 import {
   buildComparisonAnchorFreshnessMeta,
@@ -26,22 +18,11 @@ import {
   buildYieldSafetySnapshotMeta,
   buildYieldSyncMetadata,
 } from "./yield-sync/coordinator-metadata";
-import {
-  loadYieldSyncState,
-} from "./yield-sync/state-loading";
-import {
-  buildPreviewYieldRankingsArtifacts,
-  publishYieldCoordinatorResults,
-} from "./yield-sync/coordinator-persist";
+import { loadYieldSyncState } from "./yield-sync/state-loading";
+import { buildPreviewYieldRankingsArtifacts, publishYieldCoordinatorResults } from "./yield-sync/coordinator-persist";
 import { repairPublishedYieldGenerationFromCache } from "./yield-sync/publication";
-import {
-  guardPublishedYieldCoverage,
-  guardTrackedYieldCoverage,
-} from "./yield-sync/coordinator-guards";
-import {
-  computeDeterministicOnChainHealth,
-  logYieldApyDivergences,
-} from "./yield-sync/coordinator-health";
+import { guardPublishedYieldCoverage, guardTrackedYieldCoverage } from "./yield-sync/coordinator-guards";
+import { computeDeterministicOnChainHealth, logYieldApyDivergences } from "./yield-sync/coordinator-health";
 // -- Main sync function ------------------------------------------------------
 
 export async function syncYieldData(
@@ -57,9 +38,7 @@ export async function syncYieldData(
   const yieldCoins = ACTIVE_YIELD_BEARING_STABLECOINS;
   const yieldCoinIdSet = new Set(yieldCoins.map((coin) => coin.id));
   const opportunityCoinIdSet = new Set(
-    ACTIVE_STABLECOINS
-      .map((coin) => coin.id)
-      .filter((id) => !yieldCoinIdSet.has(id)),
+    ACTIVE_STABLECOINS.map((coin) => coin.id).filter((id) => !yieldCoinIdSet.has(id)),
   );
   const progressTotal = yieldCoins.length + opportunityCoinIdSet.size;
   const reportYieldProgress = async (
@@ -98,9 +77,7 @@ export async function syncYieldData(
     return { itemCount: 0, metadata: "no yield-bearing coins" };
   }
 
-  const writerPause = parseYieldHistoryWriterPause(
-    await getCache(db, YIELD_HISTORY_CLEANUP_WRITER_PAUSE_KEY),
-  );
+  const writerPause = parseYieldHistoryWriterPause(await getCache(db, YIELD_HISTORY_CLEANUP_WRITER_PAUSE_KEY));
   if (writerPause) {
     await reportYieldProgress("writer-paused", "Yield publication is paused by operator", "yield", {
       itemsDone: 0,
@@ -131,7 +108,13 @@ export async function syncYieldData(
   await reportYieldProgress("state-loading", "Loading yield source state and safety snapshots", "yield-source-cache", {
     itemsDone: 0,
     metadata: {
-      providerFamilies: ["defillama-yields", "yield-supplemental", "on-chain-rates", "risk-free-rates", "safety-scores"],
+      providerFamilies: [
+        "defillama-yields",
+        "yield-supplemental",
+        "on-chain-rates",
+        "risk-free-rates",
+        "safety-scores",
+      ],
     },
   });
   const {
@@ -167,7 +150,13 @@ export async function syncYieldData(
   await reportYieldProgress("state-loaded", "Loaded yield source state", "yield-source-cache", {
     itemsDone: dlPools.length + supplementalCandidates.length + onChainRates.size,
     metadata: {
-      providerFamilies: ["defillama-yields", "yield-supplemental", "on-chain-rates", "risk-free-rates", "safety-scores"],
+      providerFamilies: [
+        "defillama-yields",
+        "yield-supplemental",
+        "on-chain-rates",
+        "risk-free-rates",
+        "safety-scores",
+      ],
       countTotals: {
         yieldBearingCoins: yieldCoins.length,
         opportunityCoins: opportunityCoinIdSet.size,
@@ -190,7 +179,7 @@ export async function syncYieldData(
   if (safetySnapshotDegraded) {
     console.warn(
       `[sync-yield-data] Safety snapshot coverage degraded: ${safetySnapshot.coveredCount}/${safetySnapshot.trackedCount} ` +
-      `(${(safetyCoverageRatio * 100).toFixed(1)}%)${safetySnapshot.reason ? ` reason=${safetySnapshot.reason}` : ""}`,
+        `(${(safetyCoverageRatio * 100).toFixed(1)}%)${safetySnapshot.reason ? ` reason=${safetySnapshot.reason}` : ""}`,
     );
   }
 
@@ -225,9 +214,7 @@ export async function syncYieldData(
 
   const resolvedWithYield = resolved.filter((entry) => entry.yield != null);
   const resolvedYieldBearingIds = new Set(
-    resolvedWithYield
-      .filter((entry) => yieldCoinIdSet.has(entry.id))
-      .map((entry) => entry.id),
+    resolvedWithYield.filter((entry) => yieldCoinIdSet.has(entry.id)).map((entry) => entry.id),
   );
   const resolvedIds = [...new Set(resolvedWithYield.map((entry) => entry.id))];
   await reportYieldProgress("source-resolution-complete", "Resolved yield source candidates", "yield", {
@@ -258,29 +245,31 @@ export async function syncYieldData(
     }
   }
 
-  const historySnapshots = resolvedIds.length > 0
-    ? await loadYieldHistorySnapshots(db, resolvedIds, startSec, sevenDaysAgoSec, {
-        signal,
-        sourceKeysByStablecoin: resolvedSourceKeysByCoin,
-        onProgress: async (progress) => {
-          await reportYieldProgress("history-loading", "Loading yield history snapshots", "yield-history", {
-            itemsDone: progress.resolvedIdsDone,
-            itemsTotal: progress.resolvedIdsTotal,
-            metadata: {
-              countTotals: {
-                resolvedSources: resolvedWithYield.length,
-                resolvedCoins: resolvedIds.length,
-                historyRows: progress.historyRows,
-                previousTvlRows: progress.prevTvlRows,
-                previousBestRows: progress.prevBestRows,
+  const historySnapshots =
+    resolvedIds.length > 0
+      ? await loadYieldHistorySnapshots(db, resolvedIds, startSec, sevenDaysAgoSec, {
+          signal,
+          sourceKeysByStablecoin: resolvedSourceKeysByCoin,
+          onProgress: async (progress) => {
+            await reportYieldProgress("history-loading", "Loading yield history snapshots", "yield-history", {
+              itemsDone: progress.resolvedIdsDone,
+              itemsTotal: progress.resolvedIdsTotal,
+              metadata: {
+                countTotals: {
+                  resolvedSources: resolvedWithYield.length,
+                  resolvedCoins: resolvedIds.length,
+                  historyRows: progress.historyRows,
+                  previousTvlRows: progress.prevTvlRows,
+                  previousBestRows: progress.prevBestRows,
+                  previousTvlRowsTruncated: progress.previousTvlRowsTruncated,
+                },
+                chunksDone: progress.chunksDone,
+                chunksTotal: progress.chunksTotal,
               },
-              chunksDone: progress.chunksDone,
-              chunksTotal: progress.chunksTotal,
-            },
-          });
-        },
-      })
-    : { historyRows: [], prevTvlRows: [], prevBestRows: [] };
+            });
+          },
+        })
+      : { historyRows: [], prevTvlRows: [], prevBestRows: [], previousTvlRowsTruncated: false };
   await reportYieldProgress("history-loaded", "Loaded yield history snapshots", "yield-history", {
     itemsDone: resolvedIds.length,
     itemsTotal: resolvedIds.length,
@@ -289,6 +278,7 @@ export async function syncYieldData(
         historyRows: historySnapshots.historyRows.length,
         previousTvlRows: historySnapshots.prevTvlRows.length,
         previousBestRows: historySnapshots.prevBestRows.length,
+        previousTvlRowsTruncated: historySnapshots.previousTvlRowsTruncated,
       },
     },
   });
@@ -304,18 +294,24 @@ export async function syncYieldData(
   } = await buildYieldHistoryEvaluationInputsCooperative(historySnapshots, {
     signal,
     onProgress: async (progress) => {
-      await reportYieldProgress("history-input-construction", "Preparing yield history evaluation inputs", "yield-history", {
-        itemsDone: progress.rowsDone,
-        itemsTotal: progress.rowsTotal,
-        metadata: {
-          phase: progress.phase,
-          countTotals: {
-            historyRows: historySnapshots.historyRows.length,
-            previousTvlRows: historySnapshots.prevTvlRows.length,
-            previousBestRows: historySnapshots.prevBestRows.length,
+      await reportYieldProgress(
+        "history-input-construction",
+        "Preparing yield history evaluation inputs",
+        "yield-history",
+        {
+          itemsDone: progress.rowsDone,
+          itemsTotal: progress.rowsTotal,
+          metadata: {
+            phase: progress.phase,
+            countTotals: {
+              historyRows: historySnapshots.historyRows.length,
+              previousTvlRows: historySnapshots.prevTvlRows.length,
+              previousBestRows: historySnapshots.prevBestRows.length,
+              previousTvlRowsTruncated: historySnapshots.previousTvlRowsTruncated,
+            },
           },
         },
-      });
+      );
     },
   });
 
@@ -336,42 +332,45 @@ export async function syncYieldData(
     divergenceFlags,
     sourceSwitches,
     medianApy,
-  } = await evaluateYieldSourcesCooperative({
-    resolved: resolvedWithYield,
-    startSec,
-    sevenDaysAgoSec,
-    safetyScores,
-    riskFreeRates,
-    tier1PrevRates,
-    sourceHistory,
-    onChainCompatibilityHistoryById,
-    legacyDeterministicOnChainHistoryById,
-    legacyHistoryById,
-    prevTvlBySource,
-    legacyPrevTvlById,
-    prevBestSourceKeyByCoin,
-    sourceSwitchCount30dByCoin,
-    stablecoinSupplyById,
-    dlPoolsMeta,
-  }, {
-    signal,
-    onProgress: async (progress) => {
-      await reportYieldProgress("evaluation", "Evaluating best yield sources and source risk", "yield", {
-        itemsDone: progress.coinsDone,
-        itemsTotal: progress.coinsTotal,
-        metadata: {
-          phase: progress.phase,
-          countTotals: {
-            evaluatedSources: progress.evaluatedSources,
-            bestSourceCoins: progress.bestSourceCoins,
-            rowsRejected: progress.rowsRejected,
-            divergenceFlags: progress.divergenceFlags,
-            sourceSwitches: progress.sourceSwitches,
-          },
-        },
-      });
+  } = await evaluateYieldSourcesCooperative(
+    {
+      resolved: resolvedWithYield,
+      startSec,
+      sevenDaysAgoSec,
+      safetyScores,
+      riskFreeRates,
+      tier1PrevRates,
+      sourceHistory,
+      onChainCompatibilityHistoryById,
+      legacyDeterministicOnChainHistoryById,
+      legacyHistoryById,
+      prevTvlBySource,
+      legacyPrevTvlById,
+      prevBestSourceKeyByCoin,
+      sourceSwitchCount30dByCoin,
+      stablecoinSupplyById,
+      dlPoolsMeta,
     },
-  });
+    {
+      signal,
+      onProgress: async (progress) => {
+        await reportYieldProgress("evaluation", "Evaluating best yield sources and source risk", "yield", {
+          itemsDone: progress.coinsDone,
+          itemsTotal: progress.coinsTotal,
+          metadata: {
+            phase: progress.phase,
+            countTotals: {
+              evaluatedSources: progress.evaluatedSources,
+              bestSourceCoins: progress.bestSourceCoins,
+              rowsRejected: progress.rowsRejected,
+              divergenceFlags: progress.divergenceFlags,
+              sourceSwitches: progress.sourceSwitches,
+            },
+          },
+        });
+      },
+    },
+  );
   await reportYieldProgress("evaluation-complete", "Completed yield source evaluation", "yield", {
     itemsDone: evaluatedSources.length,
     metadata: {
@@ -448,15 +447,20 @@ export async function syncYieldData(
     opportunityCoinIdSet,
   });
   if (publishedCoverageGuard.result) {
-    await reportYieldProgress("coverage-guard", "Yield published coverage guard deferred publication", "yield-publication", {
-      itemsDone: previewRankingsPayload.rankings.length,
-      metadata: {
-        guard: "published-coverage",
-        countTotals: {
-          previewRankings: previewRankingsPayload.rankings.length,
+    await reportYieldProgress(
+      "coverage-guard",
+      "Yield published coverage guard deferred publication",
+      "yield-publication",
+      {
+        itemsDone: previewRankingsPayload.rankings.length,
+        metadata: {
+          guard: "published-coverage",
+          countTotals: {
+            previewRankings: previewRankingsPayload.rankings.length,
+          },
         },
       },
-    });
+    );
     return publishedCoverageGuard.result;
   }
   const {
@@ -477,6 +481,7 @@ export async function syncYieldData(
     maskedAllDeterministicFailure,
     onChainSkippedDueToCooldown,
     onChainAlternativeCoverageMissingIds,
+    previousTvlRowsTruncated: historySnapshots.previousTvlRowsTruncated,
   });
   await reportYieldProgress("publication", "Publishing yield rankings generation", "yield-publication", {
     itemsDone: 0,
@@ -574,7 +579,8 @@ export async function syncYieldData(
         consecutiveAllFailRuns: nextOnChainHealthState.consecutiveAllFailRuns,
         consecutiveMaskedAllFailRuns: nextOnChainHealthState.consecutiveMaskedAllFailRuns,
       },
-      fallbackMode: publicationResult.degradationReasons.length > 0 ? publicationResult.degradationReasons.join(",") : null,
+      fallbackMode:
+        publicationResult.degradationReasons.length > 0 ? publicationResult.degradationReasons.join(",") : null,
       validationFailures: publicationResult.validationFailures,
       riskFreeRate,
       cacheWriteSkipped: publicationResult.cacheWriteSkipped,
@@ -582,6 +588,7 @@ export async function syncYieldData(
         evaluatedSources,
         startSec,
       }),
+      previousTvlRowsTruncated: historySnapshots.previousTvlRowsTruncated,
     }),
   };
 }

--- a/worker/src/cron/yield-sync/coordinator-metadata.ts
+++ b/worker/src/cron/yield-sync/coordinator-metadata.ts
@@ -32,14 +32,16 @@ export function buildComparisonAnchorFreshnessMeta(input: {
     .flatMap((source) => {
       if (source.comparisonAnchorObservedAt == null) return [];
       const anchorAgeSeconds = Math.max(0, input.startSec - source.comparisonAnchorObservedAt);
-      return [{
-        stablecoinId: source.id,
-        symbol: source.symbol,
-        sourceKey: source.sourceKey,
-        dataSource: source.dataSource,
-        anchorAgeSeconds,
-        comparisonAnchorObservedAt: source.comparisonAnchorObservedAt,
-      }];
+      return [
+        {
+          stablecoinId: source.id,
+          symbol: source.symbol,
+          sourceKey: source.sourceKey,
+          dataSource: source.dataSource,
+          anchorAgeSeconds,
+          comparisonAnchorObservedAt: source.comparisonAnchorObservedAt,
+        },
+      ];
     })
     .sort((a, b) => b.anchorAgeSeconds - a.anchorAgeSeconds);
 
@@ -84,6 +86,7 @@ export function buildYieldDegradationReasons(params: {
   maskedAllDeterministicFailure: boolean;
   onChainSkippedDueToCooldown: boolean;
   onChainAlternativeCoverageMissingIds: string[];
+  previousTvlRowsTruncated: boolean;
 }): string[] {
   const degradationReasons: string[] = [];
 
@@ -104,6 +107,9 @@ export function buildYieldDegradationReasons(params: {
   }
   if (params.onChainSkippedDueToCooldown && params.onChainAlternativeCoverageMissingIds.length > 0) {
     degradationReasons.push("onchain-rates:cooldown-coverage-gap");
+  }
+  if (params.previousTvlRowsTruncated) {
+    degradationReasons.push("yield-history:previous-tvl-row-cap");
   }
 
   return degradationReasons;
@@ -158,6 +164,7 @@ export function buildYieldSyncMetadata(input: {
   riskFreeRate: number;
   cacheWriteSkipped: boolean;
   comparisonAnchorFreshness: YieldComparisonAnchorFreshnessMeta;
+  previousTvlRowsTruncated: boolean;
 }): string {
   const onChain = input.onChain;
   const onChainEnvelopeRejections = onChain.envelopeRejections.slice(0, YIELD_METADATA_EXAMPLE_LIMIT);
@@ -208,6 +215,7 @@ export function buildYieldSyncMetadata(input: {
       onChainConsecutiveAllFailRuns: onChain.consecutiveAllFailRuns,
       onChainConsecutiveMaskedAllFailRuns: onChain.consecutiveMaskedAllFailRuns,
       comparisonAnchorFreshness: input.comparisonAnchorFreshness,
+      previousTvlRowsTruncated: input.previousTvlRowsTruncated,
     },
     fallbackMode: input.fallbackMode,
     validationFailures: input.validationFailures,

--- a/worker/src/cron/yield-sync/history.ts
+++ b/worker/src/cron/yield-sync/history.ts
@@ -13,6 +13,7 @@ export { isSuppressedYieldHistoryRow } from "../../lib/yield-history-ownership-h
 
 const D1_SAFE_SQL_IN_CHUNK_SIZE = 90;
 const YIELD_HISTORY_LOAD_CHUNK_SIZE = 30;
+export const MAX_PREVIOUS_TVL_HISTORY_ROWS = 5_000;
 
 export async function purgeYieldHistoryOwnershipHandoffs(db: D1Database): Promise<void> {
   for (const [stablecoinId, sourceKeys] of Object.entries(YIELD_HISTORY_OWNERSHIP_HANDOFFS)) {
@@ -51,6 +52,7 @@ export interface YieldHistorySnapshotProgress {
   historyRows: number;
   prevTvlRows: number;
   prevBestRows: number;
+  previousTvlRowsTruncated: boolean;
 }
 
 export interface LoadYieldHistorySnapshotOptions {
@@ -59,6 +61,7 @@ export interface LoadYieldHistorySnapshotOptions {
   yieldToEventLoop?: (signal?: AbortSignal) => Promise<void>;
   onProgress?: (progress: YieldHistorySnapshotProgress) => void | Promise<void>;
   sourceKeysByStablecoin?: Map<string, ReadonlySet<string | null>>;
+  maxPreviousTvlRows?: number;
 }
 
 function appendRows<T>(target: T[], rows: readonly T[]): void {
@@ -94,14 +97,21 @@ async function loadPreviousTvlRowsForChunk(
   idChunk: readonly string[],
   sevenDaysAgoSec: number,
   sourceKeysByStablecoin: Map<string, ReadonlySet<string | null>> | undefined,
+  maxRows: number,
   signal?: AbortSignal,
-): Promise<YieldHistorySnapshotRow[]> {
-  if (!sourceKeysByStablecoin) return [];
+): Promise<{ rows: YieldHistorySnapshotRow[]; truncated: boolean }> {
+  if (!sourceKeysByStablecoin || maxRows <= 0) return { rows: [], truncated: false };
   const rows: YieldHistorySnapshotRow[] = [];
   const exclusion = buildSuppressedYieldHistoryExclusion("h");
+  let truncated = false;
 
+  outer:
   for (const stablecoinId of idChunk) {
     for (const sourceKey of getRequestedSourceKeys(stablecoinId, sourceKeysByStablecoin)) {
+      if (rows.length >= maxRows) {
+        truncated = true;
+        break outer;
+      }
       throwIfAborted(signal);
       const sourcePredicate = sourceKey == null ? "h.source_key IS NULL" : "h.source_key = ?";
       const sourceBinds = sourceKey == null ? [] : [sourceKey];
@@ -129,7 +139,7 @@ async function loadPreviousTvlRowsForChunk(
     throwIfAborted(signal);
   }
 
-  return rows;
+  return { rows, truncated };
 }
 
 async function loadPreviousBestRowsForChunk(
@@ -177,12 +187,18 @@ export async function loadYieldHistorySnapshots(
   historyRows: YieldHistorySnapshotRow[];
   prevTvlRows: YieldHistorySnapshotRow[];
   prevBestRows: YieldHistorySnapshotRow[];
+  previousTvlRowsTruncated: boolean;
 }> {
   const historyRows: YieldHistorySnapshotRow[] = [];
   const prevTvlRows: YieldHistorySnapshotRow[] = [];
   const prevBestRows: YieldHistorySnapshotRow[] = [];
 
-  const chunkSize = Math.max(1, Math.min(options.chunkSize ?? YIELD_HISTORY_LOAD_CHUNK_SIZE, D1_SAFE_SQL_IN_CHUNK_SIZE));
+  const chunkSize = Math.max(
+    1,
+    Math.min(options.chunkSize ?? YIELD_HISTORY_LOAD_CHUNK_SIZE, D1_SAFE_SQL_IN_CHUNK_SIZE),
+  );
+  const maxPreviousTvlRows = Math.max(1, Math.floor(options.maxPreviousTvlRows ?? MAX_PREVIOUS_TVL_HISTORY_ROWS));
+  let previousTvlRowsTruncated = false;
   const idChunks = chunkArray(resolvedIds, chunkSize);
   const yieldToEventLoop = options.yieldToEventLoop ?? defaultYieldToEventLoop;
 
@@ -195,6 +211,7 @@ export async function loadYieldHistorySnapshots(
       historyRows: historyRows.length,
       prevTvlRows: prevTvlRows.length,
       prevBestRows: prevBestRows.length,
+      previousTvlRowsTruncated,
     });
   };
 
@@ -220,42 +237,67 @@ export async function loadYieldHistorySnapshots(
     throwIfAborted(options.signal);
     await yieldToEventLoop(options.signal);
 
-    const prevTvlChunkRows = options.sourceKeysByStablecoin
-      ? await loadPreviousTvlRowsForChunk(db, idChunk, sevenDaysAgoSec, options.sourceKeysByStablecoin, options.signal)
-      : (await db
-          .prepare(
-            `SELECT /* pharos:yield-sync:previous-tvl */
-               h.stablecoin_id, h.source_key, h.source_tvl_usd, h.recorded_at
-             FROM yield_history h
-             WHERE h.stablecoin_id IN (${resolvedIdInClause.sql})
-               AND h.recorded_at <= ?
-               AND h.source_tvl_usd IS NOT NULL
-               AND (h.publication_state IS NULL OR h.publication_state = 'published')
-               AND ${currentExclusion.sql}
-               AND NOT EXISTS (
-                 SELECT 1
-                 FROM yield_history newer
-                 WHERE newer.stablecoin_id = h.stablecoin_id
-                   AND COALESCE(newer.source_key, '') = COALESCE(h.source_key, '')
-                   AND newer.recorded_at <= ?
-                   AND newer.source_tvl_usd IS NOT NULL
-                   AND (newer.publication_state IS NULL OR newer.publication_state = 'published')
-                   AND ${newerExclusion.sql}
-                   AND (
-                     newer.recorded_at > h.recorded_at
-                     OR (newer.recorded_at = h.recorded_at AND newer.rowid > h.rowid)
-                   )
-               )
-             ORDER BY h.stablecoin_id ASC, h.source_key ASC, h.recorded_at DESC`,
-          )
-          .bind(
-            ...resolvedIdInClause.binds,
-            sevenDaysAgoSec,
-            ...currentExclusion.binds,
-            sevenDaysAgoSec,
-            ...newerExclusion.binds,
-          )
-          .all<YieldHistorySnapshotRow>()).results ?? [];
+    const remainingPreviousTvlRows = Math.max(0, maxPreviousTvlRows - prevTvlRows.length);
+    if (remainingPreviousTvlRows === 0 && chunkIndex < idChunks.length) {
+      previousTvlRowsTruncated = true;
+    }
+    let prevTvlChunkRows: YieldHistorySnapshotRow[] = [];
+    if (remainingPreviousTvlRows > 0 && options.sourceKeysByStablecoin) {
+      const prevTvlResult = await loadPreviousTvlRowsForChunk(
+        db,
+        idChunk,
+        sevenDaysAgoSec,
+        options.sourceKeysByStablecoin,
+        remainingPreviousTvlRows,
+        options.signal,
+      );
+      prevTvlChunkRows = prevTvlResult.rows;
+      previousTvlRowsTruncated ||= prevTvlResult.truncated;
+    } else if (remainingPreviousTvlRows > 0) {
+      const prevTvlResult = await db
+        .prepare(
+          `SELECT /* pharos:yield-sync:previous-tvl */
+             h.stablecoin_id, h.source_key, h.source_tvl_usd, h.recorded_at
+           FROM yield_history h
+           WHERE h.stablecoin_id IN (${resolvedIdInClause.sql})
+             AND h.recorded_at <= ?
+             AND h.source_tvl_usd IS NOT NULL
+             AND (h.publication_state IS NULL OR h.publication_state = 'published')
+             AND ${currentExclusion.sql}
+             AND NOT EXISTS (
+               SELECT 1
+               FROM yield_history newer
+               WHERE newer.stablecoin_id = h.stablecoin_id
+                 AND COALESCE(newer.source_key, '') = COALESCE(h.source_key, '')
+                 AND newer.recorded_at <= ?
+                 AND newer.source_tvl_usd IS NOT NULL
+                 AND (newer.publication_state IS NULL OR newer.publication_state = 'published')
+                 AND ${newerExclusion.sql}
+                 AND (
+                   newer.recorded_at > h.recorded_at
+                   OR (newer.recorded_at = h.recorded_at AND newer.rowid > h.rowid)
+                 )
+             )
+           ORDER BY h.stablecoin_id ASC, h.source_key ASC, h.recorded_at DESC
+           LIMIT ?`,
+        )
+        .bind(
+          ...resolvedIdInClause.binds,
+          sevenDaysAgoSec,
+          ...currentExclusion.binds,
+          sevenDaysAgoSec,
+          ...newerExclusion.binds,
+          remainingPreviousTvlRows + 1,
+        )
+        .all<YieldHistorySnapshotRow>();
+      const filteredPrevTvlRows = (prevTvlResult.results ?? []).filter(
+        (row) => !isSuppressedYieldHistoryRow(row.stablecoin_id, row.source_key),
+      );
+      if (filteredPrevTvlRows.length > remainingPreviousTvlRows) {
+        previousTvlRowsTruncated = true;
+      }
+      prevTvlChunkRows = filteredPrevTvlRows.slice(0, remainingPreviousTvlRows);
+    }
     throwIfAborted(options.signal);
     await yieldToEventLoop(options.signal);
 
@@ -271,19 +313,13 @@ export async function loadYieldHistorySnapshots(
     await yieldToEventLoop(options.signal);
   }
 
-  return { historyRows, prevTvlRows, prevBestRows };
+  return { historyRows, prevTvlRows, prevBestRows, previousTvlRowsTruncated };
 }
 
-export async function deleteStaleYieldRows(
-  db: D1Database,
-  managedYieldIds: string[],
-  startSec: number,
-): Promise<void> {
+export async function deleteStaleYieldRows(db: D1Database, managedYieldIds: string[], startSec: number): Promise<void> {
   const frozenIdsList = [...FROZEN_IDS];
   const frozenClause =
-    frozenIdsList.length > 0
-      ? `AND stablecoin_id NOT IN (${frozenIdsList.map(() => "?").join(",")})`
-      : "";
+    frozenIdsList.length > 0 ? `AND stablecoin_id NOT IN (${frozenIdsList.map(() => "?").join(",")})` : "";
   for (const idChunk of chunkArray(managedYieldIds, D1_SAFE_SQL_IN_CHUNK_SIZE)) {
     const staleRowInClause = buildInClause(idChunk);
     await db
@@ -297,10 +333,7 @@ export async function deleteStaleYieldRows(
   }
 }
 
-export async function deleteOrphanYieldRows(
-  db: D1Database,
-  managedYieldIds: string[],
-): Promise<void> {
+export async function deleteOrphanYieldRows(db: D1Database, managedYieldIds: string[]): Promise<void> {
   const managedYieldIdSet = new Set(managedYieldIds);
   const existingIds = await db
     .prepare("SELECT /* pharos:yield-sync:yield-data-existing-ids */ DISTINCT stablecoin_id FROM yield_data")


### PR DESCRIPTION
### Motivation
- Prevent unbounded materialization of historical `yield_history` previous-TVL buckets which can exhaust Worker memory or D1 resources when external providers churn `source_key` values. 

### Description
- Add a hard cap `MAX_PREVIOUS_TVL_HISTORY_ROWS` and incremental per-chunk limiting in `loadYieldHistorySnapshots()` so the `previous-TVL` query uses `LIMIT` and only materializes up to the configured cap. (`worker/src/cron/yield-sync/history.ts`).
- Surface truncation through cooperative progress and final metadata (`previousTvlRowsTruncated`) so the coordinator and progress reports can observe truncation during the run. (`worker/src/cron/yield-sync/history.ts`, `worker/src/cron/sync-yield-data.ts`).
- Treat a truncated previous-TVL load as a degradation signal by adding a `yield-history:previous-tvl-row-cap` degradation reason and including the `previousTvlRowsTruncated` flag in the published sync metadata. (`worker/src/cron/yield-sync/coordinator-metadata.ts`, `worker/src/cron/sync-yield-data.ts`).
- Add and update focused tests that verify capping/truncation and metadata propagation and export the cap constant for test assertions. (`worker/src/cron/__tests__/yield-history-snapshots.test.ts`, `worker/src/cron/__tests__/yield-coordinator-metadata.test.ts`).

### Testing
- Ran unit tests: `npx vitest run worker/src/cron/__tests__/yield-history-snapshots.test.ts worker/src/cron/__tests__/yield-coordinator-metadata.test.ts`, and both test files passed. 
- Type check: `cd worker && npx tsc --noEmit` completed successfully. 
- Cron policy checks: `npm run check:cron-connections` and `npm run check:cron-sync` both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36cbc7cfac83329a2de56f52c3f041)