### PR TITLE
Fix phishing scanner comment-state bypass

### DIFF
--- a/scripts/__tests__/check-phishing-signatures.test.ts
+++ b/scripts/__tests__/check-phishing-signatures.test.ts
@@ -63,6 +63,14 @@ describe("check-phishing-signatures", () => {
     ).not.toThrow();
   });
 
+  it("scans executable inline scripts after legacy comment markers inside prior scripts", () => {
+    expect(() =>
+      runChecker(
+        `<html><body><script>console.log("<!-- benign legacy marker");</script><script>try { const params = new URLSearchParams(window.location.hash.slice(1)); window.__PHAROS_TOKEN__ = params.get("token"); history.replaceState(null, "", location.pathname); } catch (error) {}</script></body></html>`,
+      ),
+    ).toThrow(/Inline-script phishing-kit signatures detected/);
+  });
+
   it("detects inline phishing signatures when script end tags contain browser-accepted spacing", () => {
     expect(() =>
       runChecker(

--- a/scripts/ci/check-phishing-signatures.mjs
+++ b/scripts/ci/check-phishing-signatures.mjs
@@ -90,16 +90,27 @@ function hasSrcAttribute(openTag) {
   return false;
 }
 
-function isInsideHtmlComment(html, index) {
-  const commentStart = html.lastIndexOf("<!--", index);
-  if (commentStart < 0) return false;
-  const commentEnd = html.lastIndexOf("-->", index);
-  return commentEnd < commentStart;
-}
-
 function isScriptTagOpen(lowerHtml, openStart) {
   const next = lowerHtml[openStart + "<script".length] ?? "";
   return next === "" || /[\s/>]/.test(next);
+}
+
+function findNextScriptOpen(html, lowerHtml, searchFrom) {
+  while (true) {
+    const openStart = lowerHtml.indexOf("<script", searchFrom);
+    if (openStart < 0) return -1;
+
+    const commentStart = html.indexOf("<!--", searchFrom);
+    if (commentStart >= 0 && commentStart < openStart) {
+      const commentEnd = html.indexOf("-->", commentStart + "<!--".length);
+      if (commentEnd < 0) return -1;
+      searchFrom = commentEnd + "-->".length;
+      continue;
+    }
+
+    if (isScriptTagOpen(lowerHtml, openStart)) return openStart;
+    searchFrom = openStart + "<script".length;
+  }
 }
 
 function extractInlineScripts(html) {
@@ -107,12 +118,8 @@ function extractInlineScripts(html) {
   const lowerHtml = html.toLowerCase();
   let searchFrom = 0;
   while (true) {
-    const openStart = lowerHtml.indexOf("<script", searchFrom);
+    const openStart = findNextScriptOpen(html, lowerHtml, searchFrom);
     if (openStart < 0) break;
-    if (isInsideHtmlComment(html, openStart) || !isScriptTagOpen(lowerHtml, openStart)) {
-      searchFrom = openStart + "<script".length;
-      continue;
-    }
     const openEnd = lowerHtml.indexOf(">", openStart);
     if (openEnd < 0) break;
     const closeStart = lowerHtml.indexOf("</script", openEnd + 1);


### PR DESCRIPTION
### Motivation
- The prior `isInsideHtmlComment` used `lastIndexOf("<!--")`/`lastIndexOf("-->")` and could treat a `<!--` that appeared inside an earlier script body as an open HTML comment, causing later executable inline `<script>` blocks to be skipped by the scanner.
- This produced a CI false-negative where a benign prior script containing `"<!--"` could hide a later phishing-shaped inline script from detection.

### Description
- Replace the brittle global comment lookbehind with a forward-scanning helper `findNextScriptOpen(html, lowerHtml, searchFrom)` that advances past actual `<!-- ... -->` ranges before considering a candidate `<script>` tag, preserving tag-boundary checks via `isScriptTagOpen`.
- Remove the `isInsideHtmlComment` global `lastIndexOf` check and route extraction through `findNextScriptOpen` in `extractInlineScripts` so `<!--` inside script bodies does not affect later parsing.
- Add a regression test in `scripts/__tests__/check-phishing-signatures.test.ts` that asserts a benign prior script with a legacy `<!--` marker does not prevent detection of a subsequent phishing-shaped inline script.
- Files changed: `scripts/ci/check-phishing-signatures.mjs` and `scripts/__tests__/check-phishing-signatures.test.ts`.

### Testing
- Ran the unit test file with `npx vitest run scripts/__tests__/check-phishing-signatures.test.ts`, which passed (`1 file, 7 tests` succeeded).
- Verified the manual PoC by running `node scripts/ci/check-phishing-signatures.mjs` against a temporary `out/index.html` containing a prior script with `"<!-- benign legacy marker"` followed by a phishing-shaped inline script; the checker now exits with status `1` and reports detections as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36cc858a9883328fa83e83fc2403fb)