### PR TITLE
Scope stale-slot reconciliation to jobs for the slot key

### DIFF
--- a/worker/src/lib/__tests__/cron-leases.test.ts
+++ b/worker/src/lib/__tests__/cron-leases.test.ts
@@ -395,10 +395,11 @@ function makeLeaseDb(seed?: {
             };
           }
           if (sql.includes("FROM cron_run_progress") && sql.includes("slot_started_at = ?")) {
-            const [slotStartedAt] = args as [number];
+            const [slotStartedAt, ...jobs] = args as [number, ...string[]];
             return {
               results: [...progressRows.values()].filter((progress) =>
                 progress.slot_started_at === slotStartedAt &&
+                (jobs.length === 0 || jobs.includes(progress.job)) &&
                 progress.lease_owner != null,
               ),
               success: true,
@@ -1000,7 +1001,7 @@ describe("runScheduledSlotWithFence", () => {
     const currentSlotStartedAt = now;
     const db = makeLeaseDb({
       slots: [{
-        slot_key: "hourlyYield",
+        slot_key: "hourlyYieldSync",
         slot_started_at: staleSlotStartedAt,
         state: "running",
         result_status: null,
@@ -1029,7 +1030,7 @@ describe("runScheduledSlotWithFence", () => {
 
     const result = await runScheduledSlotWithFence(
       db,
-      "hourlyYield",
+      "hourlyYieldSync",
       async () => undefined,
       { slotStartedAt: currentSlotStartedAt, owner: "slot-owner-b", staleAfterSec: 1200 },
     );
@@ -1045,7 +1046,7 @@ describe("runScheduledSlotWithFence", () => {
     ]);
     expect(db.getProgress("sync-yield-data")).toBeUndefined();
     expect(db.getLease("sync-yield-data")).toBeUndefined();
-    const staleSlot = db.getSlot("hourlyYield", staleSlotStartedAt);
+    const staleSlot = db.getSlot("hourlyYieldSync", staleSlotStartedAt);
     expect(staleSlot?.result_status).toBe("error");
     expect(staleSlot?.metadata ? JSON.parse(staleSlot.metadata) : null).toMatchObject({
       error: "scheduled slot heartbeat stale; marked expired by later invocation",
@@ -1063,15 +1064,15 @@ describe("runScheduledSlotWithFence", () => {
         ],
       },
     });
-    const eventMarker = db.getCache("cron:event:hourlyyield:scheduled-slot-abandoned");
+    const eventMarker = db.getCache("cron:event:hourlyyieldsync:scheduled-slot-abandoned");
     expect(eventMarker).toBeDefined();
     expect(eventMarker?.value ? JSON.parse(eventMarker.value) : null).toMatchObject({
       event: "cron_event",
-      job: "hourlyYield",
+      job: "hourlyYieldSync",
       eventType: "scheduled-slot-abandoned",
       severity: "error",
       metadata: {
-        slotKey: "hourlyYield",
+        slotKey: "hourlyYieldSync",
         slotOwner: "slot-owner-a",
         staleSlotReconciliation: {
           abandonedJobs: [
@@ -1151,6 +1152,60 @@ describe("runScheduledSlotWithFence", () => {
     expect(db.getLease("sync-yield-data")).toBeUndefined();
     expect(db.getSlot("hourlyYieldSync", staleSlotStartedAt)?.result_status).toBe("error");
     expect(db.getCache("cron:event:hourlyyieldsync:scheduled-slot-abandoned")).toBeDefined();
+  });
+
+  it("does not reconcile child progress from a different schedule with a colliding slot timestamp", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const staleSlotStartedAt = now - 3600;
+    const db = makeLeaseDb({
+      slots: [{
+        slot_key: "quarterHourly",
+        slot_started_at: staleSlotStartedAt,
+        state: "running",
+        result_status: null,
+        execution_owner: "slot-owner-a",
+        started_at: staleSlotStartedAt,
+        finished_at: null,
+        updated_at: now - 1800,
+        metadata: null,
+      }],
+      leases: [{
+        job: "daily-digest",
+        lease_owner: "digest-owner-a",
+        lease_until: now - 60,
+        heartbeat_at: now - 1800,
+        updated_at: now - 1800,
+      }],
+      progress: [{
+        job: "daily-digest",
+        started_at: staleSlotStartedAt + 20,
+        updated_at: now - 1800,
+        stage: "digest-trigger-poll",
+        lease_owner: "digest-owner-a",
+        slot_started_at: staleSlotStartedAt,
+      }],
+    });
+
+    const summary = await sweepStaleScheduledSlotExecutions(db, { nowSec: now, staleAfterSec: 1200 });
+
+    expect(summary).toMatchObject({
+      candidateSlots: 1,
+      slotsReconciled: 1,
+      syntheticCronRuns: 0,
+      progressRowsCleared: 0,
+      leasesCleared: 0,
+    });
+    expect(summary.abandonedSlots).toEqual([
+      expect.objectContaining({
+        slotKey: "quarterHourly",
+        slotStartedAt: staleSlotStartedAt,
+        abandonedJobs: [],
+      }),
+    ]);
+    expect(db.getRuns()).toEqual([]);
+    expect(db.getProgress("daily-digest")).toBeDefined();
+    expect(db.getLease("daily-digest")).toBeDefined();
+    expect(db.getSlot("quarterHourly", staleSlotStartedAt)?.result_status).toBe("error");
   });
 
   it("does not synthesize a stale child cron run while the matching child lease is still active", async () => {

--- a/worker/src/lib/scheduled-slot-fence.ts
+++ b/worker/src/lib/scheduled-slot-fence.ts
@@ -1,3 +1,8 @@
+import {
+  getScheduledSlotPlanBudgetEntries,
+  SCHEDULED_SLOT_PLANS,
+} from "@shared/lib/scheduled-runner-registry";
+import type { CronScheduleKey } from "@shared/lib/cron-jobs";
 import { createLeaseOwner } from "./cron-lease-primitives";
 import { runWithOverloadRetry } from "./d1-overload-retry";
 import { toErrorMessage } from "./error-utils";
@@ -153,20 +158,31 @@ async function listStaleScheduledSlotExecutions(
 async function listProgressRowsForStaleSlot(
   db: D1Database,
   slotStartedAt: number,
+  jobs: readonly string[],
 ): Promise<StaleSlotProgressRow[]> {
+  if (jobs.length === 0) {
+    return [];
+  }
+  const jobPlaceholders = jobs.map(() => "?").join(", ");
   const rows = await runWithOverloadRetry(() =>
     db
       .prepare(
         `SELECT job, started_at, updated_at, stage, lease_owner, slot_started_at
            FROM cron_run_progress
            WHERE slot_started_at = ?
+             AND job IN (${jobPlaceholders})
              AND lease_owner IS NOT NULL
            ORDER BY updated_at DESC`,
       )
-      .bind(slotStartedAt)
+      .bind(slotStartedAt, ...jobs)
       .all<StaleSlotProgressRow>(),
   );
   return (rows.results ?? []).filter((row) => typeof row.lease_owner === "string" && row.lease_owner.length > 0);
+}
+
+function getExpectedJobsForScheduledSlot(slotKey: string): readonly string[] {
+  const plan = SCHEDULED_SLOT_PLANS[slotKey as CronScheduleKey];
+  return plan ? getScheduledSlotPlanBudgetEntries(plan) : [];
 }
 
 async function getCronLeaseForJob(db: D1Database, job: string): Promise<StaleSlotLeaseRow | null> {
@@ -233,7 +249,11 @@ async function reconcileStaleSlotArtifacts(
     leasesCleared: 0,
     abandonedJobs: [],
   };
-  const progressRows = await listProgressRowsForStaleSlot(db, slot.slot_started_at);
+  const progressRows = await listProgressRowsForStaleSlot(
+    db,
+    slot.slot_started_at,
+    getExpectedJobsForScheduledSlot(slot.slot_key),
+  );
 
   for (const progress of progressRows) {
     const lease = await getCronLeaseForJob(db, progress.job);


### PR DESCRIPTION
### Motivation

- Prevent global stale-slot sweeps from reconciling progress/leases belonging to unrelated schedules that share the same `slot_started_at` timestamp.  This prevents synthesizing erroneous `cron_runs` and deleting unrelated `cron_run_progress`/`cron_leases` rows when timestamps collide across schedules.

### Description

- Restrict progress lookup in stale-slot reconciliation to the jobs declared for the stale slot's schedule by consulting the scheduled-runner registry instead of selecting all `cron_run_progress` rows by `slot_started_at` alone.  This adds a `job IN (...)` filter to the progress query and a helper `getExpectedJobsForScheduledSlot` to resolve the expected jobs for a `slot_key`.
- Update the D1 query binding to accept job placeholders and return no rows when a schedule has no declared jobs to avoid accidental global matches.
- Adjust the test DB fake to support the new job-filtered progress query signature and add a regression test proving a `quarterHourly` stale slot no longer reconciles `daily-digest` progress/lease rows that share the same `slot_started_at` timestamp.

### Testing

- Ran `npx vitest run worker/src/lib/__tests__/cron-leases.test.ts`, all tests passed (`26 passed`).
- Ran TypeScript compile check with `cd worker && npx tsc --noEmit`, which succeeded.
- Ran cron schedule/connection checks with `npm run check:cron-sync` and `npm run check:cron-connections`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c06cfa6c8332be8413637d9992c5)