### PR TITLE
Release cron leases after lease-loss aborts

### DIFF
--- a/worker/src/lib/__tests__/cron-leases.test.ts
+++ b/worker/src/lib/__tests__/cron-leases.test.ts
@@ -740,6 +740,56 @@ describe("runCronWithLease", () => {
     expect(reacquired).toBe(true);
   });
 
+  it("releases the lease when a lease-loss abort settles during abandonment grace", async () => {
+    const renewOutcomes = [0, 0];
+    let deleteCalls = 0;
+    const renewLostDb = {
+      prepare: (sql: string) => ({
+        bind: (..._args: unknown[]) => ({
+          run: async () => {
+            if (sql.includes("INSERT INTO cron_leases")) {
+              return { success: true, meta: { changes: 1 } };
+            }
+            if (sql.includes("UPDATE cron_leases")) {
+              return { success: true, meta: { changes: renewOutcomes.shift() ?? 0 } };
+            }
+            if (sql.includes("DELETE FROM cron_leases")) {
+              deleteCalls++;
+              return { success: true, meta: { changes: 1 } };
+            }
+            return { success: true, meta: { changes: 0 } };
+          },
+        }),
+      }),
+      batch: async () => [],
+      exec: async () => ({ count: 0, duration: 0 }),
+      dump: async () => new ArrayBuffer(0),
+    } as unknown as D1Database;
+
+    const runPromise = runCronWithLease(
+      renewLostDb,
+      "sync-stablecoins",
+      async ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          const rejectSoon = () => {
+            setTimeout(() => reject(signal.reason), 10);
+          };
+          if (signal.aborted) {
+            rejectSoon();
+            return;
+          }
+          signal.addEventListener("abort", () => rejectSoon(), { once: true });
+        }),
+      { owner: "owner-z", ttlSec: 120, heartbeatSec: 1, maxRenewFailures: 2 },
+    );
+
+    const leaseLostExpectation = expect(runPromise).rejects.toBeInstanceOf(CronLeaseLostError);
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(10);
+    await leaseLostExpectation;
+    expect(deleteCalls).toBe(1);
+  });
+
   it("rejects with CronTimeoutError when the timeout abort wins but the job then fulfills in grace", async () => {
     const db = makeLeaseDb();
     const ac = new AbortController();

--- a/worker/src/lib/cron-lease-primitives.ts
+++ b/worker/src/lib/cron-lease-primitives.ts
@@ -269,7 +269,7 @@ export async function runCronWithLease<T>(
     clearHeartbeat();
     if (shouldReleaseLease) {
       try {
-        await runWithOverloadRetry(() => releaseCronLease(db, job, owner), 2, leaseController.signal);
+        await runWithOverloadRetry(() => releaseCronLease(db, job, owner), 2);
       } catch (releaseErr) {
         // Best-effort release: lease expiry still guarantees eventual progress.
         console.error(`[cron-lease] Failed to release lease for ${job}:`, releaseErr);


### PR DESCRIPTION
### Motivation

- Fix an operational availability bug where a lease-loss abort prevented the best-effort `releaseCronLease` from running, leaving `cron_leases` rows locked until TTL expiry and delaying later scheduled runs.

### Description

- Stop passing the lease-loss `AbortSignal` into the best-effort retry helper by calling `runWithOverloadRetry(() => releaseCronLease(...), 2)` without `leaseController.signal` so the DELETE still runs when a job settles after lease loss.
- Add a regression test `releases the lease when a lease-loss abort settles during abandonment grace` that simulates renewal failures and asserts the lease DELETE is invoked once.
- Change set touches `worker/src/lib/cron-lease-primitives.ts` and `worker/src/lib/__tests__/cron-leases.test.ts` to implement the fix and test coverage.

### Testing

- Ran the focused unit suite with `npx vitest run worker/src/lib/__tests__/cron-leases.test.ts` and all tests passed (`26 passed`).
- Verified TypeScript build with `cd worker && npx tsc --noEmit` which succeeded.
- Ran scheduled/cron guards `npm run check:cron-sync` and `npm run check:cron-connections` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fd1c862083328404be83f3567af5)