### PR TITLE
Fix annotation candidate direct-run guard for escaped paths

### DIFF
--- a/scripts/maintenance/__tests__/build-annotation-candidates.test.ts
+++ b/scripts/maintenance/__tests__/build-annotation-candidates.test.ts
@@ -1,5 +1,6 @@
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
-import { buildCoinIdResolver } from "../build-annotation-candidates";
+import { buildCoinIdResolver, isDirectRun } from "../build-annotation-candidates";
 import type { StablecoinMeta } from "../../../shared/types";
 
 function coin(id: string, symbol: string, name = symbol): StablecoinMeta {
@@ -23,5 +24,20 @@ describe("buildCoinIdResolver", () => {
 
     expect(resolveCoinId(" uusd ")).toBe("unique-usd");
     expect(resolveCoinId("Unique USD")).toBe("unique-usd");
+  });
+});
+
+describe("isDirectRun", () => {
+  it("matches direct execution from URL-escaped checkout paths", () => {
+    const argvPath = "/tmp/pharos watch checkout/scripts/maintenance/build-annotation-candidates.ts";
+
+    expect(isDirectRun(pathToFileURL(argvPath).href, argvPath)).toBe(true);
+  });
+
+  it("rejects imports and missing argv paths", () => {
+    const argvPath = "/tmp/pharos-watch/scripts/maintenance/build-annotation-candidates.ts";
+
+    expect(isDirectRun("file:///tmp/pharos-watch/other.ts", argvPath)).toBe(false);
+    expect(isDirectRun(pathToFileURL(argvPath).href, undefined)).toBe(false);
   });
 });

--- a/scripts/maintenance/build-annotation-candidates.ts
+++ b/scripts/maintenance/build-annotation-candidates.ts
@@ -17,6 +17,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { loadPerCoinStablecoinEntries } from "../lib/stablecoin-catalog-sources";
 import type { StablecoinMeta } from "../../shared/types";
 
@@ -374,6 +375,10 @@ async function main(): Promise<void> {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export function isDirectRun(moduleUrl: string, argvPath: string | undefined): boolean {
+  return argvPath != null && moduleUrl === pathToFileURL(argvPath).href;
+}
+
+if (isDirectRun(import.meta.url, process.argv[1])) {
   void main();
 }


### PR DESCRIPTION
### Motivation
- A direct-execution guard in `scripts/maintenance/build-annotation-candidates.ts` compared `import.meta.url` (URL-encoded) against a manually constructed `file://${process.argv[1]}` (raw path), which causes `main()` to be skipped when the checkout path contains spaces or other characters that are percent-encoded. 
- This only affects a local/maintenance script but prevents the producer from running correctly in those checkouts, so the guard needs to be robust to URL encoding.

### Description
- Replace the manual comparison with a predicate that compares `import.meta.url` to `pathToFileURL(process.argv[1]).href` to correctly normalize the argv path to a file URL. 
- Export the direct-run predicate as `isDirectRun(moduleUrl, argvPath)` and use it for the import-safe guard so the module remains importable without side effects. 
- Add targeted unit tests in `scripts/maintenance/__tests__/build-annotation-candidates.test.ts` covering URL-escaped checkout paths, non-matching imports, and missing `argv` values. 
- Add the `node:url` import required for `pathToFileURL` and preserve existing behavior of the script when invoked directly.

### Testing
- Ran `npx vitest run scripts/maintenance/__tests__/build-annotation-candidates.test.ts` and all tests passed (4 passed). 
- Ran the typecheck via `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fe88a34883328c7d5e88ee21f021)