### PR TITLE
Fix delayed viewport gate observation

### DIFF
--- a/src/hooks/__tests__/use-near-viewport.test.tsx
+++ b/src/hooks/__tests__/use-near-viewport.test.tsx
@@ -30,6 +30,11 @@ function Probe({ rootMargin }: { rootMargin?: string }) {
   return <div ref={ref} data-testid="probe" data-near={String(near)} />;
 }
 
+function DelayedProbe({ show }: { show: boolean }) {
+  const { ref, near } = useNearViewport<HTMLDivElement>();
+  return show ? <div ref={ref} data-testid="probe" data-near={String(near)} /> : <span data-testid="loading" />;
+}
+
 const originalIO = window.IntersectionObserver;
 
 beforeEach(() => {
@@ -66,6 +71,20 @@ describe("useNearViewport", () => {
     // No IO available -> the effect short-circuits and sets near=true so the
     // consumer renders content rather than waiting forever.
     expect(getByTestId("probe").dataset.near).toBe("true");
+  });
+
+  it("observes an element that is attached after the initial hook effect", () => {
+    window.IntersectionObserver = IntersectionObserverMock as unknown as typeof IntersectionObserver;
+
+    const { getByTestId, rerender } = render(<DelayedProbe show={false} />);
+
+    expect(getByTestId("loading")).toBeTruthy();
+    expect(lastObserverInstance).toBeNull();
+
+    rerender(<DelayedProbe show />);
+
+    expect(getByTestId("probe").dataset.near).toBe("false");
+    expect(lastObserverInstance?.observe).toHaveBeenCalledTimes(1);
   });
 
   it("flips near=true and disconnects the observer when the element intersects", () => {

--- a/src/hooks/use-near-viewport.ts
+++ b/src/hooks/use-near-viewport.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Returns a ref + a "near" boolean that flips to `true` once the element
@@ -12,13 +12,14 @@ import { useEffect, useRef, useState } from "react";
  * `near` flag as opaque and not gate critical-for-SEO content on it.
  */
 export function useNearViewport<T extends HTMLElement>(rootMargin = "300px") {
-  const ref = useRef<T | null>(null);
+  const [target, setTarget] = useState<T | null>(null);
   const [near, setNear] = useState(false);
+  const ref = useCallback((el: T | null) => {
+    setTarget(el);
+  }, []);
 
   useEffect(() => {
-    if (near) return;
-    const el = ref.current;
-    if (!el) return;
+    if (near || !target) return;
     if (typeof window === "undefined" || typeof window.IntersectionObserver === "undefined") {
       // Defensive — older browsers + jsdom mount immediately. The setState
       // here is one-shot at first mount (the `near` dep returns early on the
@@ -36,11 +37,11 @@ export function useNearViewport<T extends HTMLElement>(rootMargin = "300px") {
       },
       { rootMargin },
     );
-    io.observe(el);
+    io.observe(target);
     return () => {
       io.disconnect();
     };
-  }, [near, rootMargin]);
+  }, [near, rootMargin, target]);
 
   return { ref, near };
 }


### PR DESCRIPTION
### Motivation
- The viewport-gating hook could initialize while its target DOM nodes were still absent during a cold load, causing `useNearViewport` to never install an `IntersectionObserver` and leaving supplemental detail queries disabled forever.
- Ensure viewport gates retry observation when a gated section is attached after an initial loading shell so mint/burn flows, blacklist summaries, and live reserves can load normally.

### Description
- Change `useNearViewport` to expose a callback ref and track the attached `target` in state so the observer effect re-runs when the element is later attached (`useCallback` + `useState` replacement for the previous `useRef`).
- Add `target` to the effect dependency list and continue to preserve the sticky `near` semantics and the `IntersectionObserver`-missing fallback.
- Add a regression test that renders a component without the gated element, re-renders with the element attached, and verifies `IntersectionObserver.observe()` is called so late-attached gates are observed.
- Files changed: `src/hooks/use-near-viewport.ts` and `src/hooks/__tests__/use-near-viewport.test.tsx`.

### Testing
- Ran `npm test -- --run src/hooks/__tests__/use-near-viewport.test.tsx` and the new + existing viewport tests passed.
- Ran `npm test -- --run src/app/stablecoin/[id]/client.test.tsx src/hooks/__tests__/use-stablecoin-detail-view-model.test.tsx` and those suites passed.
- Ran `npm run typecheck` and the TypeScript checks completed successfully.
- Ran `npx eslint src/hooks/use-near-viewport.ts src/hooks/__tests__/use-near-viewport.test.tsx --max-warnings=0` and linting passed for the touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a2cc55d5c8332a55b0a09f18a95de)