### PR TITLE
Fix Telegram processed-update retention backlog

### DIFF
--- a/worker/src/api/telegram-store/processed-updates.ts
+++ b/worker/src/api/telegram-store/processed-updates.ts
@@ -1,11 +1,8 @@
-import {
-  TELEGRAM_PROCESSED_UPDATE_RETENTION_SEC,
-  TELEGRAM_PROCESSING_STALE_SEC,
-} from "../../lib/telegram-constants";
+import { TELEGRAM_PROCESSED_UPDATE_RETENTION_SEC, TELEGRAM_PROCESSING_STALE_SEC } from "../../lib/telegram-constants";
 import { d1ChangeCount } from "./_internals";
 import { unixNow } from "./subscribers";
 
-const TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT = 5_000;
+export const TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT = 5_000;
 
 export type TelegramProcessedUpdateClaimStatus = "claimed" | "duplicate" | "in_flight";
 
@@ -52,9 +49,7 @@ export async function claimTelegramProcessedUpdate(
   }
 
   const existing = await db
-    .prepare(
-      "SELECT status, received_at FROM telegram_processed_updates WHERE update_id = ?",
-    )
+    .prepare("SELECT status, received_at FROM telegram_processed_updates WHERE update_id = ?")
     .bind(input.updateId)
     .first<ProcessedUpdateRow>();
 
@@ -186,10 +181,7 @@ export async function acquireTelegramCommandCooldown(
     return { allowed: true, retryAfterSec: 0 };
   }
 
-  const row = await db
-    .prepare("SELECT updated_at FROM cache WHERE key = ?")
-    .bind(key)
-    .first<{ updated_at: number }>();
+  const row = await db.prepare("SELECT updated_at FROM cache WHERE key = ?").bind(key).first<{ updated_at: number }>();
   const lastUsedAt = Number(row?.updated_at);
   const retryAfterSec = Number.isFinite(lastUsedAt)
     ? Math.max(1, input.cooldownSec - (input.nowSec - lastUsedAt))

--- a/worker/src/cron/__tests__/telegram-retention-cleanup.test.ts
+++ b/worker/src/cron/__tests__/telegram-retention-cleanup.test.ts
@@ -69,13 +69,9 @@ function createStubDb(state: StubState): D1Database {
     return Number.isFinite(limit) ? limit : Number.POSITIVE_INFINITY;
   }
 
-  function deleteMatching<T>(
-    rows: T[],
-    predicate: (row: T) => boolean,
-    limit = Number.POSITIVE_INFINITY,
-  ): number {
+  function deleteMatching<T>(rows: T[], predicate: (row: T) => boolean, limit = Number.POSITIVE_INFINITY): number {
     let removed = 0;
-    for (let i = 0; i < rows.length && removed < limit;) {
+    for (let i = 0; i < rows.length && removed < limit; ) {
       if (predicate(rows[i])) {
         rows.splice(i, 1);
         removed += 1;
@@ -101,34 +97,22 @@ function createStubDb(state: StubState): D1Database {
         }
         if (sql.startsWith("DELETE FROM telegram_processed_updates")) {
           const [cutoff] = bound as [number];
-          const removed = deleteMatching(state.processedUpdates, (row) => row.received_at < cutoff);
+          const removed = deleteMatching(state.processedUpdates, (row) => row.received_at < cutoff, 5_000);
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_alert_dead_letters")) {
           const [cutoff] = bound as [number];
-          const removed = deleteMatching(
-            state.deadLetters,
-            (row) => row.expired_at < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.deadLetters, (row) => row.expired_at < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_alert_job_targets")) {
           const [cutoff] = bound as [number];
-          const removed = deleteMatching(
-            state.jobTargets,
-            (row) => row.created_at < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.jobTargets, (row) => row.created_at < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_alert_jobs")) {
           const [cutoff] = bound as [number];
-          const removed = deleteMatching(
-            state.jobs,
-            (row) => row.created_at < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.jobs, (row) => row.created_at < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_usage_daily")) {
@@ -138,11 +122,7 @@ function createStubDb(state: StubState): D1Database {
               `telegram_usage_daily.day is TEXT; cutoff must be a YYYY-MM-DD string, got ${typeof cutoff}`,
             );
           }
-          const removed = deleteMatching(
-            state.usageDaily,
-            (row) => row.day < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.usageDaily, (row) => row.day < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_watcher_lifecycle_daily")) {
@@ -152,20 +132,12 @@ function createStubDb(state: StubState): D1Database {
               `telegram_watcher_lifecycle_daily.day is TEXT; cutoff must be a YYYY-MM-DD string, got ${typeof cutoff}`,
             );
           }
-          const removed = deleteMatching(
-            state.watcherLifecycle,
-            (row) => row.day < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.watcherLifecycle, (row) => row.day < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_chat_delivery_diagnostics")) {
           const [cutoff] = bound as [number];
-          const removed = deleteMatching(
-            state.diagnostics,
-            (row) => row.updated_at < cutoff,
-            boundDeleteLimit(bound),
-          );
+          const removed = deleteMatching(state.diagnostics, (row) => row.updated_at < cutoff, boundDeleteLimit(bound));
           return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM cache")) {
@@ -204,9 +176,7 @@ describe("runTelegramRetentionCleanup", () => {
     const controller = new AbortController();
     controller.abort(new Error("retention cleanup aborted"));
 
-    await expect(runTelegramRetentionCleanup(db, controller.signal)).rejects.toThrow(
-      "retention cleanup aborted",
-    );
+    await expect(runTelegramRetentionCleanup(db, controller.signal)).rejects.toThrow("retention cleanup aborted");
   });
 
   it("prunes telegram_usage_daily rows older than the YYYY-MM-DD cutoff", async () => {
@@ -305,13 +275,33 @@ describe("runTelegramRetentionCleanup", () => {
     expect(metadata.cappedAtLimit.jobs).toBe(false);
   });
 
+  it("drains processed-update retention across multiple capped batches", async () => {
+    const state = makeState();
+    const now = Math.floor(Date.now() / 1000);
+    const staleReceivedAt = now - 8 * 24 * 60 * 60;
+    for (let i = 0; i < 12_001; i += 1) {
+      state.processedUpdates.push({ received_at: staleReceivedAt });
+    }
+    const db = createStubDb(state);
+
+    const result = await runTelegramRetentionCleanup(db);
+
+    expect(state.processedUpdates).toHaveLength(0);
+    const metadata = JSON.parse(result.metadata!) as {
+      processedUpdatesPruned: number;
+      cappedAtLimit: { processedUpdates: boolean };
+    };
+    expect(metadata.processedUpdatesPruned).toBe(12_001);
+    expect(metadata.cappedAtLimit.processedUpdates).toBe(false);
+  });
+
   it("prunes stale Telegram chat cache residue by prefix", async () => {
     const state = makeState();
     const now = Math.floor(Date.now() / 1000);
-    const staleShortLived = now - (8 * 24 * 60 * 60);
+    const staleShortLived = now - 8 * 24 * 60 * 60;
     const freshShortLived = now - 3600;
-    const staleWarning = now - (31 * 24 * 60 * 60);
-    const freshWarning = now - (20 * 24 * 60 * 60);
+    const staleWarning = now - 31 * 24 * 60 * 60;
+    const freshWarning = now - 20 * 24 * 60 * 60;
     state.cache.push(
       { key: "telegram:command-cooldown:42:/status", value: "1", updated_at: staleShortLived },
       { key: "telegram:command-flood:42", value: "1", updated_at: staleShortLived },
@@ -330,14 +320,16 @@ describe("runTelegramRetentionCleanup", () => {
 
     const result = await runTelegramRetentionCleanup(db);
 
-    expect(state.cache.map((row) => row.key).sort()).toEqual([
-      "telegram:command-cooldown:43:/status",
-      "telegram:command-flood:43",
-      "telegram:chat-admins:-43",
-      "telegram:chat-member:43:99",
-      "telegram:group-welcome:-43",
-      "telegram:re-engagement-warned:43",
-    ].sort());
+    expect(state.cache.map((row) => row.key).sort()).toEqual(
+      [
+        "telegram:command-cooldown:43:/status",
+        "telegram:command-flood:43",
+        "telegram:chat-admins:-43",
+        "telegram:chat-member:43:99",
+        "telegram:group-welcome:-43",
+        "telegram:re-engagement-warned:43",
+      ].sort(),
+    );
     const metadata = JSON.parse(result.metadata!) as {
       commandCooldownCachePruned: number;
       commandFloodCachePruned: number;

--- a/worker/src/cron/telegram-retention-cleanup.ts
+++ b/worker/src/cron/telegram-retention-cleanup.ts
@@ -1,7 +1,7 @@
 import { throwIfAborted } from "../lib/abort";
 import type { CronResult } from "../lib/cron-logger";
 import { createCronResult } from "../lib/cron-result";
-import { pruneTelegramProcessedUpdates } from "../api/telegram-webhook-store";
+import { TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT, pruneTelegramProcessedUpdates } from "../api/telegram-webhook-store";
 import { reconcileExpiredTelegramAlertJobTargets } from "./telegram-alert-target-status";
 
 const DAY_SEC = 24 * 60 * 60;
@@ -11,6 +11,26 @@ const CHAT_DIAGNOSTICS_RETENTION_SEC = 90 * DAY_SEC;
 const SHORT_LIVED_CHAT_CACHE_RETENTION_SEC = 7 * DAY_SEC;
 const RE_ENGAGEMENT_WARNING_CACHE_RETENTION_SEC = 30 * DAY_SEC;
 const RETENTION_DELETE_BATCH_LIMIT = 10_000;
+
+async function pruneAllTelegramProcessedUpdates(
+  db: D1Database,
+  nowSec: number,
+  signal?: AbortSignal,
+): Promise<CappedDeleteResult> {
+  let pruned = 0;
+  let lastBatch = 0;
+
+  do {
+    throwIfAborted(signal);
+    lastBatch = await pruneTelegramProcessedUpdates(db, { nowSec });
+    pruned += lastBatch;
+  } while (lastBatch >= TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT);
+
+  return {
+    pruned,
+    cappedAtLimit: lastBatch >= TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT,
+  };
+}
 
 interface CappedDeleteResult {
   pruned: number;
@@ -62,7 +82,7 @@ export async function runTelegramRetentionCleanup(db: D1Database, signal?: Abort
   const expiredTargetsReconciled = await reconcileExpiredTelegramAlertJobTargets(db, nowSec);
   throwIfAborted(signal);
 
-  const processedUpdatesPruned = await pruneTelegramProcessedUpdates(db, { nowSec });
+  const processedUpdates = await pruneAllTelegramProcessedUpdates(db, nowSec, signal);
   throwIfAborted(signal);
 
   const deadLetters = await deleteOlderThanCapped(
@@ -89,9 +109,7 @@ export async function runTelegramRetentionCleanup(db: D1Database, signal?: Abort
   // `day` is TEXT (YYYY-MM-DD) in telegram_usage_daily and
   // telegram_watcher_lifecycle_daily; an integer cutoff would never match. Bind
   // the cutoff as a YYYY-MM-DD string so the comparison is text-vs-text.
-  const cutoffDayString = new Date((nowSec - USAGE_DAILY_RETENTION_SEC) * 1000)
-    .toISOString()
-    .slice(0, 10);
+  const cutoffDayString = new Date((nowSec - USAGE_DAILY_RETENTION_SEC) * 1000).toISOString().slice(0, 10);
 
   const usageDaily = await deleteOlderThanCapped(
     db,
@@ -156,7 +174,7 @@ export async function runTelegramRetentionCleanup(db: D1Database, signal?: Abort
   );
 
   const totalPruned =
-    processedUpdatesPruned +
+    processedUpdates.pruned +
     deadLetters.pruned +
     jobTargets.pruned +
     jobs.pruned +
@@ -174,7 +192,7 @@ export async function runTelegramRetentionCleanup(db: D1Database, signal?: Abort
     status: "ok",
     itemCount: totalPruned,
     metadata: {
-      processedUpdatesPruned,
+      processedUpdatesPruned: processedUpdates.pruned,
       deadLettersPruned: deadLetters.pruned,
       jobTargetsPruned: jobTargets.pruned,
       jobsPruned: jobs.pruned,
@@ -190,6 +208,7 @@ export async function runTelegramRetentionCleanup(db: D1Database, signal?: Abort
       expiredTargetsReconciled,
       deleteBatchLimit: RETENTION_DELETE_BATCH_LIMIT,
       cappedAtLimit: {
+        processedUpdates: processedUpdates.cappedAtLimit,
         deadLetters: deadLetters.cappedAtLimit,
         jobTargets: jobTargets.cappedAtLimit,
         jobs: jobs.cappedAtLimit,


### PR DESCRIPTION
### Motivation

- The webhook path inserts an idempotency row for every valid Telegram update but the scheduled cleanup only performed a single capped 5,000-row delete per day, allowing sustained unique-update traffic to outpace retention and grow the `telegram_processed_updates` table. 
- The change restores sufficient cleanup throughput on the daily cron so expired processed-update rows cannot accumulate indefinitely.

### Description

- Export `TELEGRAM_PROCESSED_UPDATE_PRUNE_LIMIT` from `worker/src/api/telegram-store/processed-updates.ts` so the single-batch helper and cron logic remain aligned. 
- Add `pruneAllTelegramProcessedUpdates` in `worker/src/cron/telegram-retention-cleanup.ts` that loops calling `pruneTelegramProcessedUpdates` until a batch is below the cap, honoring `AbortSignal` between batches. 
- Include processed-updates counts and capped status in the cron `metadata` and wire the final pruned total into `itemCount`. 
- Add a regression test in `worker/src/cron/__tests__/telegram-retention-cleanup.test.ts` that models multiple 5,000-row batches (12,001 rows) and asserts the cron drains them all, and update the D1 stub to simulate the per-batch cap.

### Testing

- Ran the focused unit suites with `npx vitest run worker/src/api/__tests__/telegram-webhook-store.test.ts worker/src/cron/__tests__/telegram-retention-cleanup.test.ts --reporter=dot` and all tests passed (2 files, 16 tests). 
- Type-check succeeded with `cd worker && npx tsc --noEmit`. 
- Cron schedule consistency check `npm run check:cron-sync` passed. 
- Cron connection budget check `npm run check:cron-connections` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a709f54833296d0ad6592eccdfd)