### PR TITLE
fix(reserves): verify USDnr M0 swap route

### DIFF
--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:33db903e5253bd7c7ba401714f488957c98ccc92478b00fd42d99af673bd49db",
+  "sourceChecksum": "sha256:d102321214fee84d6b90e4b940a42be6b0aae4fb79e36ff086ca03ecac8408e1",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:5dbd4dc93233c1b0dcafcf3ebfb878fe6a2c0bfff8f818983663e1b92bfd7c29",
+      "checksum": "sha256:b5f18a3f18f37ef085741acd35027d25529051a211c90c6dc40de5d85642aab8",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/stablecoins/coins.generated.json
+++ b/shared/data/stablecoins/coins.generated.json
@@ -70201,6 +70201,7 @@
         "wrapperAddress": "0xd48e565561416de59da1050ed70b8d75e8ef28f9",
         "expectedMTokenAddress": "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
         "expectedSwapFacilityAddress": "0xB6807116b3B1B321a390594e31ECD6e0076f6278",
+        "swapperAddress": "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
         "slice": {
           "name": "M token held by Nerona USDnr",
           "risk": "very-low",

--- a/shared/data/stablecoins/coins.prevalidated.generated.ts
+++ b/shared/data/stablecoins/coins.prevalidated.generated.ts
@@ -11,7 +11,7 @@
 import type { StablecoinMeta } from "../../types";
 import coinsGenerated from "./coins.generated.json";
 
-// FNV-1a 32-bit fingerprint of `coins.generated.json` at generation time: 70ca69cb.
+// FNV-1a 32-bit fingerprint of `coins.generated.json` at generation time: 380545a9.
 
 /**
  * Pre-validated stablecoin metas, exposed in source order. The snapshot

--- a/shared/data/stablecoins/coins/usdnr-nerona.json
+++ b/shared/data/stablecoins/coins/usdnr-nerona.json
@@ -244,6 +244,7 @@
       "wrapperAddress": "0xd48e565561416de59da1050ed70b8d75e8ef28f9",
       "expectedMTokenAddress": "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
       "expectedSwapFacilityAddress": "0xB6807116b3B1B321a390594e31ECD6e0076f6278",
+      "swapperAddress": "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
       "slice": {
         "name": "M token held by Nerona USDnr",
         "risk": "very-low",

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -374,7 +374,7 @@
   "/stablecoin/usdm-moneta/": "2026-06-23T10:54:01+02:00",
   "/stablecoin/usdn-noble/": "2026-06-23T10:54:01+02:00",
   "/stablecoin/usdn-smardex/": "2026-06-23T10:54:01+02:00",
-  "/stablecoin/usdnr-nerona/": "2026-06-23T20:04:32+02:00",
+  "/stablecoin/usdnr-nerona/": "2026-06-24T10:08:31+02:00",
   "/stablecoin/usdo-openeden/": "2026-06-25T11:44:13+02:00",
   "/stablecoin/usdon-ondo/": "2026-06-23T20:04:32+02:00",
   "/stablecoin/usdp-parallel/": "2026-06-23T20:04:32+02:00",


### PR DESCRIPTION
### Motivation
- USDnr's `m-extension` live reserve config omitted the `swapperAddress`, which prevented the `m0-wrapper-underlying` adapter from probing `canSwapViaPath` and caused the route to be marked `unknown` with a degraded warning.

### Description
- Add the M0 Hub Portal `swapperAddress` to `shared/data/stablecoins/coins/usdnr-nerona.json` and regenerate the stablecoin aggregate (`shared/data/stablecoins/coins.generated.json`) so the adapter can perform the `canSwapViaPath` probe and verify the SwapFacility route.

### Testing
- Ran `tsx scripts/maintenance/generate-stablecoin-per-coin-asset.ts` and `npm run check:stablecoin-data`, which succeeded.
- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/m0-wrapper-underlying.test.ts`, which passed (all tests green).
- Ran `npm run check:generated-artifacts`, which failed due to an unrelated out-of-date `src/generated/sitemap-dates.json` artifact and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a7083c08332a256d71865391f1b)