### PR TITLE
fix(ci): fail test typecheck on unparsed tsc errors

### DIFF
--- a/docs/agent-code-map.md
+++ b/docs/agent-code-map.md
@@ -716,6 +716,7 @@ Use this as a compact discovery aid. It lists source entrypoints and top-level e
 - `scripts/__tests__/check-shared-types-imports.test.ts`
 - `scripts/__tests__/check-table-primitives.test.ts` - Page
 - `scripts/__tests__/check-telegram-load.test.ts`
+- `scripts/__tests__/check-test-typecheck.test.ts`
 - `scripts/__tests__/check-worker-migrations.test.ts`
 - `scripts/__tests__/classify-deploy-changes.test.ts`
 - `scripts/__tests__/client-registry-field-contract.test.ts`
@@ -744,5 +745,4 @@ Use this as a compact discovery aid. It lists source entrypoints and top-level e
 - `scripts/__tests__/mint-authority-review-audit.test.ts`
 - `scripts/__tests__/night-watch-worker.test.ts`
 - `scripts/__tests__/oracle-risk-coverage.test.ts`
-- `scripts/__tests__/parse-version-upload.test.ts`
-- ... 216 more files omitted; use `rg --files scripts` for the full list.
+- ... 217 more files omitted; use `rg --files scripts` for the full list.

--- a/scripts/__tests__/check-test-typecheck.test.ts
+++ b/scripts/__tests__/check-test-typecheck.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const CHECK_SCRIPT = resolve("scripts/ci/check-test-typecheck.mjs");
+
+function makeWorkdir() {
+  const cwd = mkdtempSync(join(tmpdir(), "pharos-test-typecheck-"));
+  mkdirSync(join(cwd, "scripts/lib"), { recursive: true });
+  writeFileSync(join(cwd, "scripts/lib/test-typecheck-baseline.json"), '{"diagnostics":[]}\n');
+  return cwd;
+}
+
+function makeFakeNpx(cwd: string, body: string) {
+  const binDir = join(cwd, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const npxPath = join(binDir, "npx");
+  writeFileSync(npxPath, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return binDir;
+}
+
+function runCheck(cwd: string, binDir: string, args: string[] = []) {
+  return spawnSync(process.execPath, [CHECK_SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: binDir,
+    },
+  });
+}
+
+describe("check-test-typecheck", () => {
+  it("fails when tsc exits with an unparsed config-level diagnostic", () => {
+    const cwd = makeWorkdir();
+    const binDir = makeFakeNpx(
+      cwd,
+      'echo "tsconfig.test-typecheck.json(1,1): error TS18003: No inputs were found in config file." >&2\nexit 1',
+    );
+
+    const result = runCheck(cwd, binDir);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("unparsed TypeScript diagnostic");
+    expect(result.stderr).toContain("TS18003");
+  });
+
+  it("does not update the baseline when tsc fails before parseable test-file diagnostics", () => {
+    const cwd = makeWorkdir();
+    const baselinePath = join(cwd, "scripts/lib/test-typecheck-baseline.json");
+    const originalBaseline = readFileSync(baselinePath, "utf8");
+    const binDir = makeFakeNpx(cwd, 'echo "npx: command failed" >&2\nexit 1');
+
+    const result = runCheck(cwd, binDir, ["--update-baseline"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("failed without parseable test-file diagnostics");
+    expect(readFileSync(baselinePath, "utf8")).toBe(originalBaseline);
+  });
+
+  it("continues to ratchet parseable test-file diagnostics", () => {
+    const cwd = makeWorkdir();
+    const binDir = makeFakeNpx(cwd, 'echo "scripts/__tests__/sample.test.ts(1,1): error TS9999: Example failure." >&2\nexit 1');
+
+    const result = runCheck(cwd, binDir);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("new scripts/__tests__/sample.test.ts");
+    expect(result.stderr).toContain("TS9999");
+  });
+});

--- a/scripts/ci/check-test-typecheck.mjs
+++ b/scripts/ci/check-test-typecheck.mjs
@@ -17,10 +17,15 @@ const TSC_COMMAND = [
 
 function parseDiagnostics(output) {
   const diagnosticsByKey = new Map();
+  const unparsedErrors = [];
   const diagnosticPattern = /^(.+\.(?:ts|tsx))\((\d+),(\d+)\): error TS(\d+): (.+)$/;
+  const errorPattern = /(^|\s)error TS\d+:/;
   for (const line of output.split("\n")) {
     const match = diagnosticPattern.exec(line);
-    if (!match) continue;
+    if (!match) {
+      if (errorPattern.test(line)) unparsedErrors.push(line);
+      continue;
+    }
     const [, file, lineNumber, columnNumber, code, message] = match;
     const key = `${file}\0${code}\0${message}`;
     const entry = diagnosticsByKey.get(key) ?? {
@@ -36,11 +41,24 @@ function parseDiagnostics(output) {
     }
     diagnosticsByKey.set(key, entry);
   }
-  return [...diagnosticsByKey.values()].sort((a, b) =>
-    a.file.localeCompare(b.file) ||
-    a.code.localeCompare(b.code) ||
-    a.message.localeCompare(b.message),
-  );
+  return {
+    diagnostics: [...diagnosticsByKey.values()].sort((a, b) =>
+      a.file.localeCompare(b.file) ||
+      a.code.localeCompare(b.code) ||
+      a.message.localeCompare(b.message),
+    ),
+    unparsedErrors,
+  };
+}
+
+function failTscExecution(message, output) {
+  console.error(`[typecheck:tests] ${message}`);
+  const trimmedOutput = output.trim();
+  if (trimmedOutput) {
+    console.error("[typecheck:tests] Raw tsc output:");
+    console.error(trimmedOutput);
+  }
+  process.exit(1);
 }
 
 function baselineKey(entry) {
@@ -86,7 +104,26 @@ const tsc = spawnSync("npx", TSC_COMMAND, {
   shell: process.platform === "win32",
 });
 const output = `${tsc.stdout ?? ""}${tsc.stderr ?? ""}`;
-const diagnostics = parseDiagnostics(output);
+const { diagnostics, unparsedErrors } = parseDiagnostics(output);
+
+if (tsc.error) {
+  failTscExecution(`Failed to start ${TSC_COMMAND[0]}: ${tsc.error.message}`, output);
+}
+if (tsc.signal) {
+  failTscExecution(`${TSC_COMMAND[0]} exited after signal ${tsc.signal}.`, output);
+}
+if (tsc.status !== 0 && unparsedErrors.length > 0) {
+  failTscExecution(
+    `${TSC_COMMAND[0]} failed with ${unparsedErrors.length} unparsed TypeScript diagnostic line(s); refusing to treat the test typecheck as a clean ratchet run.`,
+    output,
+  );
+}
+if (tsc.status !== 0 && diagnostics.length === 0) {
+  failTscExecution(
+    `${TSC_COMMAND[0]} failed without parseable test-file diagnostics; refusing to treat the test typecheck as a clean ratchet run.`,
+    output,
+  );
+}
 
 if (UPDATE_BASELINE) {
   writeFileSync(


### PR DESCRIPTION
### Motivation

- The test-typecheck wrapper could silently succeed when `npx tsc` failed or produced non-file-level/config-level diagnostics, allowing `--update-baseline` to write empty/incomplete baselines and weakening the prebuild ratchet.

### Description

- Make `parseDiagnostics()` return both parsed `diagnostics` and `unparsedErrors` and detect lines that look like TypeScript errors even when they don't match the file-location regex in `scripts/ci/check-test-typecheck.mjs`.
- Fail fast on process-level failures by checking `tsc.error`, `tsc.signal`, and nonzero `tsc.status` combined with either `unparsedErrors.length > 0` or `diagnostics.length === 0`, and print raw `tsc` output on failure via a new `failTscExecution()` helper.
- Preserve the existing ratchet behavior for ordinary parseable test-file diagnostics while refusing to treat incomplete `tsc` runs as successful or to write baselines in that case.
- Add focused regression tests (`scripts/__tests__/check-test-typecheck.test.ts`) that exercise config-level diagnostics, missing/failed `npx` (no baseline update), and normal parseable test-file diagnostics using fake `npx` shims.

### Testing

- Ran `npx vitest run scripts/__tests__/check-test-typecheck.test.ts` and the new test file passed (all tests succeeded).
- Ran the combined validation flow `npm run typecheck:tests && npx vitest run scripts/__tests__/check-test-typecheck.test.ts scripts/__tests__/validate-prebuild-surface.test.ts` and it completed successfully. 
- Linted the changes with `npx eslint scripts/ci/check-test-typecheck.mjs scripts/__tests__/check-test-typecheck.test.ts --max-warnings=0` and the lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a71d7b08332ba146dfa8f6bd7ac)