### PR TITLE
Fix terminal status for config-missing blacklist recovery retries

### DIFF
--- a/worker/src/cron/blacklist/__tests__/amount-recovery.test.ts
+++ b/worker/src/cron/blacklist/__tests__/amount-recovery.test.ts
@@ -290,6 +290,50 @@ describe("enrichRowBalances", () => {
     expect(update?.binds).not.toContain("drpc");
   });
 
+  it("marks exhausted legacy derived-zero rows permanently unavailable when config cannot be resolved", async () => {
+    const db = mockD1([
+      {
+        match: "FROM blacklist_events",
+        rows: [{
+          id: "row-1",
+          chain_id: "ethereum",
+          event_type: "blacklist",
+          address: "0x1111111111111111111111111111111111111111",
+          block_number: 100,
+          stablecoin: "UNKNOWN",
+          tx_hash: "0xabc",
+          config_key: null,
+          contract_address: null,
+          amount_attempt_count: 2,
+          amount_last_attempted_at: null,
+          amount_last_error_class: null,
+          amount_last_provider: null,
+          amount_source: "derived",
+        }],
+      },
+    ]);
+
+    await backfillAmounts(
+      db,
+      null,
+      null,
+      async <T>(fn: () => Promise<T>) => fn(),
+      makeRunBudget({ subrequestBudget: { count: 0, limit: 10 } }),
+    );
+
+    const update = db.getHistory().find((entry) =>
+      entry.sql.includes("UPDATE blacklist_events")
+      && entry.sql.includes("amount_status = ?"),
+    );
+    expect(update?.binds).toEqual([
+      expect.any(Number),
+      "config_missing",
+      "none",
+      "permanently_unavailable",
+      "row-1",
+    ]);
+  });
+
   it("stops retrying exhausted legacy derived-zero rows after the final failed recovery attempt", async () => {
     const db = mockD1([
       {

--- a/worker/src/cron/blacklist/amount-recovery.ts
+++ b/worker/src/cron/blacklist/amount-recovery.ts
@@ -593,12 +593,16 @@ export async function backfillAmounts(
             return matches.length === 1 ? matches[0] : undefined;
           })();
     if (!config) {
+      const wasLegacyDerived = row.amount_source === "derived";
+      const derivedRetryExhausted =
+        wasLegacyDerived && (row.amount_attempt_count ?? 0) + 1 >= MAX_DERIVED_RECOVERY_ATTEMPTS;
       stmts.push(
         buildAttemptUpdate(
           row.id,
           attemptAt,
           row.contract_address == null && row.config_key == null ? "config_missing" : "ambiguous_config",
           "none",
+          derivedRetryExhausted ? "permanently_unavailable" : undefined,
         ),
       );
       continue;


### PR DESCRIPTION
### Motivation
- Legacy `derived` zero-amount blacklist rows could exhaust the new retry ceiling and be excluded from the selector without ever being marked terminal, leaving stale `amount_status='resolved'` zero rows hidden from unrecoverable-gap accounting.
- The intent is to ensure that final allowed retries for legacy derived-zero candidates always write a terminal `amount_status` when unrecoverable, regardless of whether config resolution or provider recovery failed.

### Description
- In `worker/src/cron/blacklist/amount-recovery.ts` the config-missing/ambiguous branch now detects legacy `derived` rows and, when the next attempt would exceed `MAX_DERIVED_RECOVERY_ATTEMPTS`, passes `"permanently_unavailable"` into `buildAttemptUpdate` so the row is terminalized on its final allowed retry.
- Added a regression test `marks exhausted legacy derived-zero rows permanently unavailable when config cannot be resolved` to `worker/src/cron/blacklist/__tests__/amount-recovery.test.ts` that verifies a legacy derived-zero row with no resolvable config records `config_missing`, provider `none`, and `permanently_unavailable` on its final attempt.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/blacklist/__tests__/amount-recovery.test.ts`, and the tests passed (all 12 tests in the file succeeded).
- Verified TypeScript correctness with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a727ef08332881232ce7c36a02c)