### PR TITLE
fix(backfill): repair partial commodity market-cap gaps

### DIFF
--- a/worker/src/api/__tests__/backfill-supply-history.test.ts
+++ b/worker/src/api/__tests__/backfill-supply-history.test.ts
@@ -612,6 +612,98 @@ describe("handleBackfillSupplyHistory", () => {
     expect(evmRpcMocks.resolveClosestBlockAtOrBeforeTimestamp).toHaveBeenCalledTimes(2);
   });
 
+  it("repairs partial CoinGecko market-cap gaps with historical on-chain totalSupply", async () => {
+    const capturedStatements: Array<{ sql: string; args: unknown[] }> = [];
+
+    const ts1 = 1_775_692_800_000;
+    const ts2 = 1_775_779_200_000;
+    const blockNumber = 22_500_001;
+
+    evmRpcMocks.resolveClosestBlockAtOrBeforeTimestamp.mockResolvedValue(blockNumber);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url.includes("/coins/saturn-dollar/market_chart")) {
+        return new Response(
+          JSON.stringify({
+            market_caps: [[ts1, 1_234_567], [ts2, 0]],
+            prices: [[ts1, 1.0002], [ts2, 1.0011]],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("/coins/saturn-dollar?")) {
+        return new Response(
+          JSON.stringify({ market_data: { circulating_supply: 0 } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("fake-eth-rpc")) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          method?: string;
+          params?: Array<{ data?: string } | string>;
+        };
+        expect(body.method).toBe("eth_call");
+        const call = body.params?.[0];
+        const data = typeof call === "object" && call != null ? call.data?.toLowerCase() : undefined;
+        expect(data).toBe(TOTAL_SUPPLY_SELECTOR);
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: formatUint256Hex(1_100_000_000_000n) }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const chainRpcs = new Map<string, ChainRpcConfig>([
+      [
+        "ethereum",
+        {
+          chainId: "ethereum",
+          chainName: "Ethereum",
+          type: "evm",
+          rpcUrl: "https://fake-eth-rpc.test",
+          explorerUrl: "https://etherscan.io",
+        },
+      ],
+    ]);
+
+    const res = await handleBackfillSupplyHistory(
+      makeDb(capturedStatements),
+      makeApiUrl("/api/backfill-supply-history?stablecoin=usdat-saturn&startDay=2026-04-09&endDay=2026-04-10"),
+      true,
+      makeApiRequest("/api/backfill-supply-history?stablecoin=usdat-saturn&startDay=2026-04-09&endDay=2026-04-10", {
+        adminKey: "secret",
+      }),
+      null,
+      chainRpcs,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      coinsProcessed: number;
+      rowsInserted: number;
+      errors?: string[];
+      skipped?: string[];
+    };
+    expect(body.coinsProcessed).toBe(1);
+    expect(body.rowsInserted).toBe(2);
+    expect(body.errors).toBeUndefined();
+    expect(body.skipped).toBeUndefined();
+
+    const inserts = capturedStatements.filter((stmt) =>
+      stmt.sql.includes("INSERT OR REPLACE INTO supply_history"),
+    );
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].args).toEqual(["usdat-saturn", Math.floor(ts1 / 1000 / 86_400) * 86_400, 1_234_567, 1.0002]);
+    expect(inserts[1].args[0]).toBe("usdat-saturn");
+    expect(inserts[1].args[1]).toBe(Math.floor(ts2 / 1000 / 86_400) * 86_400);
+    expect(inserts[1].args[2] as number).toBeCloseTo(1_101_210, -1);
+    expect(inserts[1].args[3] as number).toBeCloseTo(1.0011, 4);
+    expect(evmRpcMocks.resolveClosestBlockAtOrBeforeTimestamp).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed instead of replaying one EVM lane for multi-deployment supply fallback", async () => {
     const capturedStatements: Array<{ sql: string; args: unknown[] }> = [];
 

--- a/worker/src/api/backfill-supply-history.ts
+++ b/worker/src/api/backfill-supply-history.ts
@@ -442,6 +442,7 @@ async function backfillHistoricalTotalSupply(
     blockSearchCachesByChain?: EvmBlockSearchCacheByChain;
     priceSeries?: TimestampedRatePoint[];
     requirePrice: boolean;
+    skipSnapshotDates?: ReadonlySet<number>;
     window?: SupplyBackfillWindow;
     signal?: AbortSignal;
   },
@@ -497,6 +498,7 @@ async function backfillHistoricalTotalSupply(
   for (let snapshotDate = startDay; snapshotDate <= endDay; snapshotDate += DAY_SECONDS) {
     throwIfAborted(options.signal);
     if (!isWithinBackfillWindow(snapshotDate, options.window)) continue;
+    if (options.skipSnapshotDates?.has(snapshotDate)) continue;
 
     const price = findHistoricalPrice(snapshotDate);
     if (options.requirePrice && price == null) {
@@ -627,8 +629,20 @@ async function backfillCommodity(
     if (stmts.length > 0) {
       await batchExecute(db, stmts);
       if (missingMarketCapDays > 0) {
+        const historicalTotalSupply = await backfillHistoricalTotalSupply(db, meta, {
+          chainRpcs: config.chainRpcs,
+          blockSearchCachesByChain: config.blockSearchCachesByChain,
+          priceSeries: normalizeCoinGeckoDailyPrices(marketHistory.prices),
+          requirePrice: true,
+          skipSnapshotDates: seenSnapshotDates,
+          window: config.window,
+          signal: config.signal,
+        });
+        if (!historicalTotalSupply.error) {
+          return { rows: stmts.length + historicalTotalSupply.rows };
+        }
         console.warn(
-          `[backfill-commodity] ${id}: skipped ${missingMarketCapDays} day(s) without CoinGecko market caps instead of projecting current supply backward`,
+          `[backfill-commodity] ${id}: skipped ${missingMarketCapDays} day(s) without CoinGecko market caps; historical totalSupply fallback failed (${historicalTotalSupply.error})`,
         );
       }
       return { rows: stmts.length };


### PR DESCRIPTION
### Motivation

- Partial CoinGecko market-cap coverage caused the commodity/CoinGecko backfill to write a partial batch and return early, leaving omitted days unrepaired and risking stale rows in `supply_history`.
- The intent is to fall back to historical on-chain `totalSupply()` for those missing days while not overwriting days already sourced from valid CoinGecko market caps.

### Description

- Add a `skipSnapshotDates?: ReadonlySet<number>` option to `backfillHistoricalTotalSupply` so the historical replay can skip dates already written from CoinGecko market caps (file: `worker/src/api/backfill-supply-history.ts`).
- When `backfillCommodity` writes any CoinGecko-sourced rows but detects missing market-cap days, invoke `backfillHistoricalTotalSupply` with `skipSnapshotDates = seenSnapshotDates` and return the combined rows on success, otherwise emit a warning with the fallback error (file: `worker/src/api/backfill-supply-history.ts`).
- Add a regression test `repairs partial CoinGecko market-cap gaps with historical on-chain totalSupply` to `worker/src/api/__tests__/backfill-supply-history.test.ts` that exercises a mixed valid/zero CoinGecko response and verifies the missing day is restored via a single historical `totalSupply()` call.

### Testing

- Ran the focused Vitest suite with `npx vitest run worker/src/api/__tests__/backfill-supply-history.test.ts --reporter=verbose` and all tests in the file passed (18 tests).
- Ran the worker TypeScript check with `npm run typecheck:worker` (`cd worker && npx tsc --noEmit`) and it completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a716e148332bda12db9c04244c2)