### PR TITLE
fix(yield): reject stale FRED SONIA observations

### DIFF
--- a/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
+++ b/worker/src/cron/__tests__/fetch-tbill-rate.test.ts
@@ -327,6 +327,59 @@ describe("fetchTbillRate", () => {
     expect(metadata.gbpRate).toBeCloseTo(4.05556, 5);
   });
 
+  it("falls back to ALFRED when the FRED SONIA index is stale", async () => {
+    mockByUrl({
+      "data-api.ecb.europa.eu": new Response(ECB_ESTR_3M_CSV_SNIPPET, { status: 200 }),
+      "id=DGS3MO": new Response("DATE,DGS3MO\n2026-03-02,3.72\n", { status: 200 }),
+      "oauth/token": new Response(SIX_GUEST_TOKEN_RESPONSE, { status: 200 }),
+      "report-download": new Response(SIX_SAR3MC_CSV_SNIPPET, { status: 200, headers: { "Content-Type": "text/csv" } }),
+      ...okExtendedBenchmarkMocks(),
+      "fred.stlouisfed.org/graph/fredgraph.csv?id=IUDZOS2": new Response(
+        "observation_date,IUDZOS2\n2000-01-01,100\n2000-04-01,101\n",
+        { status: 200 },
+      ),
+      "alfred.stlouisfed.org/graph/alfredgraph.csv?id=IUDZOS2": new Response(
+        ALFRED_SONIA_COMPOUNDED_INDEX_CSV_SNIPPET,
+        { status: 200 },
+      ),
+    });
+
+    const result = await fetchTbillRate(db, undefined, BANXICO_TEST_ENV);
+    const metadata = JSON.parse(result.metadata ?? "{}") as Record<string, unknown>;
+
+    expect(result.status).toBe("ok");
+    expect(metadata.gbpSource).toBe("alfred-sonia-compounded-index");
+    expect(metadata.gbpRecordDate).toBe("2026-04-01");
+    expect(metadata.gbpRate).toBeCloseTo(4.05556, 5);
+  });
+
+  it("falls back to the BoE SONIA index when St. Louis Fed SONIA observations are future dated", async () => {
+    mockByUrl({
+      "data-api.ecb.europa.eu": new Response(ECB_ESTR_3M_CSV_SNIPPET, { status: 200 }),
+      "id=DGS3MO": new Response("DATE,DGS3MO\n2026-03-02,3.72\n", { status: 200 }),
+      "oauth/token": new Response(SIX_GUEST_TOKEN_RESPONSE, { status: 200 }),
+      "report-download": new Response(SIX_SAR3MC_CSV_SNIPPET, { status: 200, headers: { "Content-Type": "text/csv" } }),
+      ...okExtendedBenchmarkMocks(),
+      "fred.stlouisfed.org/graph/fredgraph.csv?id=IUDZOS2": new Response(
+        "observation_date,IUDZOS2\n2099-01-01,100\n2099-04-01,101\n",
+        { status: 200 },
+      ),
+      "alfred.stlouisfed.org/graph/alfredgraph.csv?id=IUDZOS2": new Response(
+        "observation_date,IUDZOS2_20990401\n2099-01-01,100\n2099-04-01,101\n",
+        { status: 200 },
+      ),
+      "bankofengland.co.uk": new Response(BOE_SONIA_COMPOUNDED_INDEX_CSV_SNIPPET, { status: 200 }),
+    });
+
+    const result = await fetchTbillRate(db, undefined, BANXICO_TEST_ENV);
+    const metadata = JSON.parse(result.metadata ?? "{}") as Record<string, unknown>;
+
+    expect(result.status).toBe("ok");
+    expect(metadata.gbpSource).toBe("boe-sonia-compounded-index");
+    expect(metadata.gbpRecordDate).toBe("2026-04-01");
+    expect(metadata.gbpRate).toBeCloseTo(4.05556, 5);
+  });
+
   it("falls back to the BoE SONIA index when the St. Louis Fed mirrors are unreachable", async () => {
     mockByUrl({
       "data-api.ecb.europa.eu": new Response(ECB_ESTR_3M_CSV_SNIPPET, { status: 200 }),

--- a/worker/src/cron/tbill-sources/fred.ts
+++ b/worker/src/cron/tbill-sources/fred.ts
@@ -1,4 +1,8 @@
-import { ALFRED_SONIA_COMPOUNDED_INDEX_CSV_URL, FRED_SONIA_COMPOUNDED_INDEX_CSV_URL, USER_AGENT } from "../../lib/constants";
+import {
+  ALFRED_SONIA_COMPOUNDED_INDEX_CSV_URL,
+  FRED_SONIA_COMPOUNDED_INDEX_CSV_URL,
+  USER_AGENT,
+} from "../../lib/constants";
 import {
   fetchAndParseBenchmark,
   isValidBenchmarkRate,
@@ -6,6 +10,10 @@ import {
   parseRate,
 } from "./shared";
 import { deriveSoniaCompoundedRate } from "./boe";
+
+const ST_LOUIS_FED_SONIA_MAX_OBSERVATION_AGE_DAYS = 140;
+const ST_LOUIS_FED_SONIA_MAX_FUTURE_SKEW_DAYS = 1;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function parseFredLatest(csv: string): { recordDate: string; rate: number } | null {
   const lines = csv.split(/\r?\n/);
@@ -53,7 +61,25 @@ function parseFredSoniaCompoundedIndexCsv(csv: string): { recordDate: string; ra
         : [];
     });
 
-  return deriveSoniaCompoundedRate(observations);
+  const derived = deriveSoniaCompoundedRate(observations);
+  if (!derived) return null;
+
+  // The St. Louis Fed graph endpoints are unbounded historical CSVs; reject
+  // stale/future latest observations so they trigger the next GBP fallback
+  // instead of being stamped as a fresh market benchmark for this cron run.
+  const latestTimestampMs = parseIsoDateMs(derived.recordDate);
+  const nowMs = Date.now();
+  const oldestAllowedMs = nowMs - ST_LOUIS_FED_SONIA_MAX_OBSERVATION_AGE_DAYS * DAY_MS;
+  const newestAllowedMs = nowMs + ST_LOUIS_FED_SONIA_MAX_FUTURE_SKEW_DAYS * DAY_MS;
+  if (
+    !Number.isFinite(latestTimestampMs) ||
+    latestTimestampMs < oldestAllowedMs ||
+    latestTimestampMs > newestAllowedMs
+  ) {
+    return null;
+  }
+
+  return derived;
 }
 
 export async function tryFredSoniaCompoundedIndex(


### PR DESCRIPTION
### Motivation
- The St. Louis Fed (FRED/ALFRED) IUDZOS2 graph CSV is unbounded and could contain an old or future-dated latest observation that was being accepted and stamped as a fresh GBP benchmark, preventing fallbacks and causing stale/attacker-controlled data to be published.

### Description
- Add freshness bounds for St. Louis Fed SONIA derived benchmarks by introducing `ST_LOUIS_FED_SONIA_MAX_OBSERVATION_AGE_DAYS` and `ST_LOUIS_FED_SONIA_MAX_FUTURE_SKEW_DAYS` and rejecting observations outside that window in `parseFredSoniaCompoundedIndexCsv` so the parser returns `null` for stale/future latest rows.
- Keep both FRED and ALFRED mirrors on the guarded parser path so either mirror will be subject to the same freshness checks before acceptance.
- Preserve the existing GBP fallback chain so returning `null` causes the fetcher to try ALFRED and then Bank of England as before, instead of stamping stale data as fresh market metadata.
- Add regression tests to `worker/src/cron/__tests__/fetch-tbill-rate.test.ts` that cover a stale FRED response falling through to ALFRED and future-dated St. Louis Fed observations falling through to the BoE parser.

### Testing
- Ran the focused cron test suite with `npx vitest run worker/src/cron/__tests__/fetch-tbill-rate.test.ts --reporter verbose` and observed all tests pass (`63 passed`).
- Built type checks with `cd worker && npx tsc --noEmit` and the TypeScript compile check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e388874548332a34882067c536a29)