### PR TITLE
fix(dex-liquidity): exclude inactive metrics from global scoring

### DIFF
--- a/worker/src/cron/__tests__/dex-liquidity-scoring.test.ts
+++ b/worker/src/cron/__tests__/dex-liquidity-scoring.test.ts
@@ -336,6 +336,63 @@ describe("dex-liquidity scoring", () => {
     expect(globalAgg.chainTvl.base).toBeCloseTo(87_368.421, 3);
   });
 
+  it("excludes inactive tracked metrics from scores, retained pools, and global aggregates", async () => {
+    const db = makeQueryDb([
+      { match: "FROM dex_liquidity_history", all: [] },
+    ]);
+
+    const activeMetrics = initMetrics("usdt-tether", "USDT");
+    activeMetrics.totalVolume24hUsd = 10_000;
+    activeMetrics.totalVolume7dUsd = 70_000;
+    activeMetrics.topPools = [
+      {
+        poolId: "ethereum:active",
+        project: "curve",
+        chain: "Ethereum",
+        tvlUsd: 100_000,
+        symbol: "USDT-USDC",
+        volumeUsd1d: 10_000,
+        volumeUsd7d: 70_000,
+        poolType: "curve-stableswap",
+        source: "dl",
+      },
+    ];
+
+    const inactiveMetrics = initMetrics("usr-resolv", "USR");
+    inactiveMetrics.totalVolume24hUsd = 90_000;
+    inactiveMetrics.totalVolume7dUsd = 630_000;
+    inactiveMetrics.topPools = [
+      {
+        poolId: "ethereum:inactive",
+        project: "curve",
+        chain: "Ethereum",
+        tvlUsd: 900_000,
+        symbol: "USR-USDC",
+        volumeUsd1d: 90_000,
+        volumeUsd7d: 630_000,
+        poolType: "curve-stableswap",
+        source: "dl",
+      },
+    ];
+
+    const result = await computeStablecoinScores(
+      db,
+      new Map([
+        ["usdt-tether", activeMetrics],
+        ["usr-resolv", inactiveMetrics],
+      ]),
+      new Map(),
+    );
+
+    expect(result.scores.has("usdt-tether")).toBe(true);
+    expect(result.scores.has("usr-resolv")).toBe(false);
+    expect(result.retainedPoolsByStablecoin.has("usr-resolv")).toBe(false);
+    expect(result.globalAgg.totalTvl).toBe(100_000);
+    expect(result.globalAgg.totalVol24h).toBe(10_000);
+    expect(result.globalAgg.totalVol7d).toBe(70_000);
+    expect(result.globalAgg.poolCount).toBe(1);
+  });
+
   it("treats missing stability and volume-history tables as first-run state", async () => {
     const db = makeQueryDb([
       { match: "depth_stability", throwError: new Error("no such table: dex_liquidity") },

--- a/worker/src/cron/dex-liquidity/scoring.ts
+++ b/worker/src/cron/dex-liquidity/scoring.ts
@@ -1,4 +1,4 @@
-import { TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
+import { ACTIVE_IDS, TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import { roundTo } from "@shared/lib/math";
 import { rethrowIfAborted, throwIfAborted } from "../../lib/abort";
 import { batchExecute } from "../../lib/db";
@@ -148,7 +148,7 @@ export async function computeStablecoinScores(
   const globalChains = new Set<string>();
   const protocolCapDiagnostics: ProtocolCapDiagnostics = { cappedPoolCount: 0, cappedProtocols: 0, reducedTvlUsd: 0 };
 
-  for (const [id, m] of metrics) {
+  for (const [id, m] of [...metrics].filter(([stablecoinId]) => ACTIVE_IDS.has(stablecoinId))) {
     m.topPools = filterRetainedPools(m.topPools);
     const capResult = applyProtocolCaps(m.topPools, protocolTvlCaps);
     protocolCapDiagnostics.cappedPoolCount += capResult.cappedPoolCount;


### PR DESCRIPTION
### Motivation

- Prevent frozen/inactive tracked stablecoins from contributing TVL, volume, pool counts, protocol/chain aggregates, and guard inputs in the public DEX global aggregate.
- The previous change filtered per-asset rows at publication time but left the global aggregate and analysis computed from the unfiltered metric set, allowing inactive metrics to poison published totals and guard decisions.

### Description

- Filter `computeStablecoinScores` input loop to ignore non-active IDs by checking `ACTIVE_IDS` before processing each `metrics` entry so scores, retained pools, and global aggregate accumulation only include active stablecoins. (`worker/src/cron/dex-liquidity/scoring.ts`)
- Scope post-scoring analysis to active assets by building `activeScoreResults`, `activeRetainedPoolsByStablecoin`, and `activePriceObservations` and using those for coverage, top-10 guards, price-observation counts, source diagnostics, and drift summaries. (`worker/src/cron/dex-liquidity/orchestrator-analysis.ts`)
- Add a regression test that constructs one active metric and one inactive tracked metric and asserts the inactive metric is excluded from `scores`, `retainedPoolsByStablecoin`, and the `globalAgg` totals. (`worker/src/cron/__tests__/dex-liquidity-scoring.test.ts`)
- Preserve the existing publication/persistence behavior that records inactive-skip metadata at publication time; only the scoring and analysis inputs were narrowed to active IDs.

### Testing

- Ran the scoped Vitest suites with `npm test -- --run worker/src/cron/__tests__/dex-liquidity-scoring.test.ts worker/src/cron/dex-liquidity/__tests__/orchestrator-analysis.test.ts`, and all tests passed. (2 test files, 21 tests passed.)
- Verified TypeScript build for worker code with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3b3ae2508332a383787d5ff3926d)