### PR TITLE
Fix repair task claim binding count

### DIFF
--- a/worker/src/lib/__tests__/repair-tasks.test.ts
+++ b/worker/src/lib/__tests__/repair-tasks.test.ts
@@ -248,7 +248,32 @@ describe("repair tasks", () => {
     });
 
     const history = db.getHistory();
-    expect(history.filter((entry) => entry.sql.includes("SET state = 'claimed'"))).toHaveLength(2);
+    const claimUpdates = history.filter((entry) => entry.sql.includes("SET state = 'claimed'"));
+    expect(claimUpdates).toHaveLength(2);
+    expect(claimUpdates.map((entry) => entry.binds)).toEqual([
+      [
+        expect.stringContaining(`repair-runner:${NOW}:`),
+        NOW + 15 * 60,
+        NOW,
+        NOW,
+        linkedTaskId,
+        "open",
+        "deferred",
+        NOW,
+        NOW,
+      ],
+      [
+        expect.stringContaining(`repair-runner:${NOW}:`),
+        NOW + 15 * 60,
+        NOW,
+        NOW,
+        unresolvedTaskId,
+        "open",
+        "deferred",
+        NOW,
+        NOW,
+      ],
+    ]);
     expect(history.find((entry) => entry.sql.includes("SET state = 'closed'"))?.binds).toEqual([
       NOW,
       NOW,

--- a/worker/src/lib/repair-tasks.ts
+++ b/worker/src/lib/repair-tasks.ts
@@ -488,7 +488,6 @@ async function claimRepairTask(
         "deferred",
         input.nowSec,
         input.nowSec,
-        input.nowSec,
       )
       .run(),
     3,


### PR DESCRIPTION
### Motivation
- A bind-count mismatch in the D1 `UPDATE` within `claimRepairTask()` caused D1 to reject the prepared statement and abort the repair-runner when repair tasks were due, so the runner could crash before claiming or processing tasks.

### Description
- Remove the extra `input.nowSec` binding from the `claimRepairTask()` `UPDATE` so the number of bound values matches the SQL placeholders (file: `worker/src/lib/repair-tasks.ts`).
- Add a focused regression assertion that verifies each `SET state = 'claimed'` update was bound with the expected nine values to prevent future regressions (file: `worker/src/lib/__tests__/repair-tasks.test.ts`).

### Testing
- Ran the focused test suite with `npx vitest run worker/src/lib/__tests__/repair-tasks.test.ts` and it passed (`7` tests passed). 
- Type-checked the worker with `cd worker && npx tsc --noEmit` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3b3aea708332be346b723942892e)