### PR TITLE
Isolate cron lease observer failures

### DIFF
--- a/worker/src/lib/__tests__/cron-leases.test.ts
+++ b/worker/src/lib/__tests__/cron-leases.test.ts
@@ -705,6 +705,76 @@ describe("runCronWithLease", () => {
     ]);
   });
 
+  it("isolates acquisition observer failures from job execution and lease release", async () => {
+    const db = makeLeaseDb();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const result = await runCronWithLease(
+        db,
+        "sync-stablecoins",
+        async () => "done",
+        {
+          owner: "owner-z",
+          ttlSec: 120,
+          heartbeatSec: 30,
+          onLeaseState: () => {
+            throw new Error("observer failed");
+          },
+        },
+      );
+
+      expect(result).toMatchObject({ status: "ok", result: "done" });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[cron-lease] Lease state observer failed for sync-stablecoins (acquired):",
+        expect.any(Error),
+      );
+      const reacquired = await acquireCronLease(db, "sync-stablecoins", "owner-next", 120);
+      expect(reacquired).toBe(true);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("isolates renewal observer failures from lease health", async () => {
+    const db = makeLeaseDb();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const runPromise = runCronWithLease(
+        db,
+        "sync-stablecoins",
+        async () => new Promise((resolve) => setTimeout(() => resolve("done"), 1500)),
+        {
+          owner: "owner-z",
+          ttlSec: 120,
+          heartbeatSec: 1,
+          maxRenewFailures: 1,
+          onLeaseState: (state) => {
+            if (state.event === "renewed") {
+              throw new Error("observer failed");
+            }
+          },
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(1500);
+      await expect(runPromise).resolves.toMatchObject({
+        status: "ok",
+        result: "done",
+        renewFailures: 0,
+        leaseRenewFailuresTotal: 0,
+        leaseRenewSuccesses: 1,
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[cron-lease] Lease state observer failed for sync-stablecoins (renewed):",
+        expect.any(Error),
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("resets renew failures after a successful heartbeat", async () => {
     const renewOutcomes = [0, 1, 0, 0];
     const sequencedRenewDb = {

--- a/worker/src/lib/cron-lease-primitives.ts
+++ b/worker/src/lib/cron-lease-primitives.ts
@@ -203,14 +203,18 @@ export async function runCronWithLease<T>(
     event: CronLeaseStateUpdate["event"],
     state: { leaseUntil: number; heartbeatAt: number },
   ): Promise<void> => {
-    await opts?.onLeaseState?.({
-      event,
-      job,
-      leaseOwner: owner,
-      leaseUntil: state.leaseUntil,
-      heartbeatAt: state.heartbeatAt,
-      ttlSec,
-    });
+    try {
+      await opts?.onLeaseState?.({
+        event,
+        job,
+        leaseOwner: owner,
+        leaseUntil: state.leaseUntil,
+        heartbeatAt: state.heartbeatAt,
+        ttlSec,
+      });
+    } catch (err) {
+      console.error(`[cron-lease] Lease state observer failed for ${job} (${event}):`, err);
+    }
   };
 
   const acquisition = await runWithOverloadRetry(() => acquireCronLeaseState(db, job, owner, ttlSec), 3, opts?.abortSignal);


### PR DESCRIPTION
### Motivation
- Prevent failures in an optional `onLeaseState` observer from affecting cron lease semantics such that an observer throw cannot strand an acquired lease or be treated as a lease-renewal failure. 

### Description
- Catch and log errors inside `notifyLeaseState` so `opts.onLeaseState` rejections do not propagate into acquisition, renewal, or release flows (change in `worker/src/lib/cron-lease-primitives.ts`).
- Add regression tests covering acquisition-observer failure and renewal-observer failure to assert the job still runs and the lease is released/reacquirable and that renewal observer failures do not increment lease-failure counters (changes in `worker/src/lib/__tests__/cron-leases.test.ts`).
- Keep existing lease behavior unchanged aside from isolating observer side-effects to logging only.

### Testing
- Ran the focused Vitest suite with `npm test -- --run worker/src/lib/__tests__/cron-leases.test.ts` and all tests passed (the file's tests ran successfully).
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit` which succeeded.
- Ran `git diff --check` to ensure no whitespace / diff issues (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3b3a347c833281566fb544e82a57)