### PR TITLE
fix(worker): preserve weak parent price provenance

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -83,7 +83,7 @@ Cluster selection breaks ties by size, then total cluster weight, then strongest
 Each asset gets tagged with `priceConfidence` (high/single-source/low/fallback) and `supplySource` (`defillama`, `coingecko-fallback`, `onchain-total-supply`, or `onchain-circulating-supply`). The `onchain-total-supply` path is used for supplemental assets whose circulating supply is derived from an on-chain total-supply probe instead of an upstream market-cap field, and for the curated DefiLlama zero-supply repairs that would otherwise publish an active asset with no market cap; `onchain-circulating-supply` uses the same live probe but subtracts configured protocol inventory balances before USD normalization. Preview-only fiat CoinGecko assets can use those paths with the existing FX reference for USD normalization while still keeping `price = null`. Solana total-supply fallback now reuses the same shared multi-endpoint probe used by the reserve-adapter path, so supplemental Solana assets do not depend on a narrower RPC list than the rest of the worker.
 
 #### Consensus source provenance
-After N-source consensus, each asset receives a `consensusSources: string[]` field listing all source names that returned a valid price for that coin during the sync cycle. For enrichment-pass fallbacks, this is a single-element array. Protocol-redeem overrides replace it with `["protocol-redeem"]`.
+After N-source consensus, each asset receives a `consensusSources: string[]` field listing all source names that returned a valid price for that coin during the sync cycle. For enrichment-pass fallbacks, this is a single-element array. Direct protocol-redeem overrides and high-confidence inherited overrides replace it with `["protocol-redeem"]`; scoped inheritance from a fresh replay-safe single-source parent instead keeps the parent's single source so publication guardrails retain the soft upstream provenance.
 
 ### Provider-Specific Normalization
 
@@ -119,7 +119,7 @@ The registry lives under `worker/src/lib/authoritative-price-sources/` and suppo
   - Direct-redeem rows such as SOFID, USBD, USDQ, CHFAU, CADD, JPYm, ZARm, and XOFm can publish `protocol-redeem` parity when active supply is observable; non-USD live parity requires a fresh/static FX reference and falls back to normal market/native-peg history until historical FX replay exists
   - ERC-4626, Aave savings, and Idle CDO wrappers read the contract's asset-per-share value and multiply it by a trusted tracked parent price; ERC-4626 NAV wrappers are prioritized ahead of lower-priority RPC-backed override families inside the live override budget
 - **Reason:** CG/DL can overweight thin secondary-market liquidity for wrapper-style assets whose real executable value is set by direct protocol redemption or by an instantly redeemable base asset
-- **Result:** the final cached asset keeps `priceSource = "protocol-redeem"` and `priceConfidence = "high"` when the quote validates against peg bounds
+- **Result:** the final cached asset keeps `priceSource = "protocol-redeem"` and `priceConfidence = "high"` when a direct protocol/NAV quote or high-confidence inherited parent validates against peg bounds. Scoped inherited prices from fresh replay-safe single-source parents keep the parent source and `single-source` confidence so they do not bypass weak-source publication guardrails.
 
 ### Enrichment Pipeline
 

--- a/docs/pricing-pipeline.md
+++ b/docs/pricing-pipeline.md
@@ -257,18 +257,22 @@ After market/oracle consensus, the provider registry under `worker/src/lib/autho
 | `sgho-aave`              | Aave legacy savings `previewRedeem(1 share)` × tracked `gho-aave` price         |
 | `aa-falconx-mev-capital` | Idle CDO `virtualPrice(address tranche)` × tracked `usdc-circle` price          |
 
-When a live override validates successfully, the cached asset is written with:
+When a live override validates successfully, direct protocol/NAV quotes and high-confidence tracked-base inheritance are written with:
 
 - `priceSource = "protocol-redeem"`
 - `priceConfidence = "high"`
+
+Scoped tracked-base inheritance from a fresh replay-safe single-source parent keeps the parent `priceSource` and
+`priceConfidence = "single-source"` so downstream publication guardrails continue to see the inherited quote's soft
+upstream provenance instead of treating it as depeg-authoritative protocol redemption.
 
 For tracked-base inheritance paths, the authoritative layer does not query a bespoke contract path; it inherits the tracked parent asset's live price and historical replay because Pharos models the child as an instantly redeemable wrapper or extension of that parent rail.
 
 Live tracked-base and NAV-wrapper inheritance only promotes parent prices that are replay-safe and either
 high-confidence or explicitly authoritative themselves. For scoped M0 extension assets, a fresh replay-safe single-source
-M0 parent is also admissible. Low-confidence, fallback, cached, stale-sync, single-source stale,
-or provenance-less parent prices are skipped instead of being upgraded into `protocol-redeem` high-confidence child
-prices. For high-confidence composite parents, a fresh same-run `priceSyncedAt` can satisfy the live inheritance
+M0 parent is also admissible, but it is preserved as a single-source child price with the parent source instead of
+being upgraded into `protocol-redeem` high-confidence provenance. Low-confidence, fallback, cached, stale-sync,
+single-source stale, or provenance-less parent prices are skipped. For high-confidence composite parents, a fresh same-run `priceSyncedAt` can satisfy the live inheritance
 freshness check when the composite's single displayed `observedAt` is older than one short-window component source; this
 preserves source-specific admission from the parent run without falsely rejecting mixed-cadence composites such as
 USDC. When inheritance is accepted, the override carries the parent source, confidence, observed-at timestamp,

--- a/worker/src/lib/__tests__/authoritative-price-sources.test.ts
+++ b/worker/src/lib/__tests__/authoritative-price-sources.test.ts
@@ -1509,7 +1509,7 @@ describe("authoritative-price-sources", () => {
     expect(overrides.has("m-m0")).toBe(false);
   });
 
-  it("allows scoped M0 wrappers to inherit a fresh replay-safe single-source parent", async () => {
+  it("keeps scoped M0 wrapper overrides single-source when inheriting a fresh replay-safe single-source parent", async () => {
     const nowSec = Math.floor(Date.now() / 1000);
     const overrides = await fetchAuthoritativeLivePriceOverrides([
       {
@@ -1538,8 +1538,8 @@ describe("authoritative-price-sources", () => {
 
     expect(overrides.get("usdk-kast")).toMatchObject({
       price: 0.999674,
-      source: "protocol-redeem",
-      confidence: "high",
+      source: "coingecko",
+      confidence: "single-source",
       metadata: {
         inheritedFrom: "wm-m0",
         parentSource: "coingecko",
@@ -1549,8 +1549,8 @@ describe("authoritative-price-sources", () => {
     });
     expect(overrides.get("xo-exodus")).toMatchObject({
       price: 0.999674,
-      source: "protocol-redeem",
-      confidence: "high",
+      source: "coingecko",
+      confidence: "single-source",
       metadata: {
         inheritedFrom: "wm-m0",
         parentSource: "coingecko",
@@ -1583,8 +1583,8 @@ describe("authoritative-price-sources", () => {
 
     expect(overrides.get("usdn-noble")).toMatchObject({
       price: 0.999766,
-      source: "protocol-redeem",
-      confidence: "high",
+      source: "defillama-contract",
+      confidence: "single-source",
       metadata: {
         inheritedFrom: "m-m0",
         parentSource: "defillama-contract",

--- a/worker/src/lib/authoritative-price-sources/helpers.ts
+++ b/worker/src/lib/authoritative-price-sources/helpers.ts
@@ -209,6 +209,8 @@ function resolveTrustedInheritedParent(asset: PeggedAsset, nowSec: number, optio
   observedAt: number;
   observedAtMode: PriceObservedAtMode | null;
   replaySafe: boolean;
+  source: string;
+  confidence: PriceConfidence;
 } | null {
   const price = getFinitePositivePrice(asset);
   if (price == null) return null;
@@ -229,7 +231,8 @@ function resolveTrustedInheritedParent(asset: PeggedAsset, nowSec: number, optio
       sourceParts.length === 1 &&
       !sourceParts.includes("cached")
     );
-  if (!confidenceTrusted) return null;
+  if (!confidenceTrusted || parentConfidence == null) return null;
+  const trustedConfidence = parentConfidence;
 
   if (!replaySafe) {
     if (!options?.allowFreshNonReplaySafeParent || sourceParts.includes("cached")) {
@@ -259,6 +262,8 @@ function resolveTrustedInheritedParent(asset: PeggedAsset, nowSec: number, optio
         observedAt: syncedAt,
         observedAtMode: "local_fetch",
         replaySafe,
+        source: parentSource,
+        confidence: trustedConfidence,
       };
     }
     return null;
@@ -269,6 +274,8 @@ function resolveTrustedInheritedParent(asset: PeggedAsset, nowSec: number, optio
     observedAt: freshness.observedAt,
     observedAtMode: freshness.observedAtMode,
     replaySafe,
+    source: parentSource,
+    confidence: trustedConfidence,
   };
 }
 
@@ -280,6 +287,8 @@ export interface TrustedOverrideParent {
     observedAt: number;
     observedAtMode: PriceObservedAtMode | null;
     replaySafe: boolean;
+    source: string;
+    confidence: PriceConfidence;
   };
 }
 
@@ -313,10 +322,13 @@ export function buildParentDerivedLiveOverride(
   if (!Number.isFinite(price) || price <= 0) return null;
 
   const parentObservedAt = parent.parentAsset.priceObservedAt ?? parent.parentAsset.priceUpdatedAt ?? null;
+  const inheritsSingleSourceSoftParent = parent.trustedParent.confidence === "single-source" &&
+    parent.trustedParent.source !== PROTOCOL_REDEEM_SOURCE;
+
   return {
     price,
-    source: PROTOCOL_REDEEM_SOURCE,
-    confidence: "high",
+    source: inheritsSingleSourceSoftParent ? parent.trustedParent.source : PROTOCOL_REDEEM_SOURCE,
+    confidence: inheritsSingleSourceSoftParent ? "single-source" : "high",
     observedAt: parent.trustedParent.observedAt,
     observedAtMode: parent.trustedParent.observedAtMode,
     metadata: {


### PR DESCRIPTION
### Motivation
- Prevent scoped inherited tracked-price overrides from promoting a fresh replay-safe `single-source` parent into a high-confidence `protocol-redeem` child that can bypass publication guardrails.

### Description
- Add parent `source` and `confidence` to the trusted-parent resolution (`resolveTrustedInheritedParent` / `TrustedOverrideParent`) so provenance is available downstream.
- Change `buildParentDerivedLiveOverride` to emit the parent's `source` and `single-source` `confidence` for scoped replay-safe single-source parents instead of unconditionally stamping `protocol-redeem`/`high`.
- Update authoritative-price tests to assert USDK/XO/USDN inherited overrides retain parent provenance and adjust test names/expectations accordingly.
- Update `docs/pricing-pipeline.md` and `docs/data-pipeline.md` to document that scoped single-source inheritance preserves parent provenance rather than becoming `protocol-redeem`/`high`.

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/authoritative-price-sources.test.ts worker/src/cron/sync-stablecoins/__tests__/protocol-override-application.test.ts` and all tests passed.
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e1b9d0a48332ba25164cebcb4298)