### PR TITLE
docs(privacy): disclose homepage shortcut storage

### DIFF
--- a/docs/privacy-page.md
+++ b/docs/privacy-page.md
@@ -49,7 +49,8 @@ The current policy copy covers:
 10. the Mini App auth note: `initData` is never persisted — it is validated request-locally (HMAC signature + freshness window); mutations use a 5-minute auth window plus a per-user mutation cooldown, and session reads use a 24-hour read-only window
 11. self-serve API key requests store verified email plus optional requester/project/use-case metadata for private operator review; request throttling stores salted hashes of IP address and user-agent data
 12. homepage page discovery does not store browser-local route history or a visit-rotation cursor
-13. Resend sends API verification emails and necessarily receives the one-time verification URL in the email body; API key issuance records stay in private operator storage and structured Worker logs rather than public GitHub Issues
+13. homepage saved shortcuts store only the ordered navigation href list in the browser-local `pharos-shortcuts` key; the values are site-scoped, allowlisted before render, and persist until reset or site-data clearing
+14. Resend sends API verification emails and necessarily receives the one-time verification URL in the email body; API key issuance records stay in private operator storage and structured Worker logs rather than public GitHub Issues
 
 Portfolio holdings are explicitly described as browser-local only, which matches the `/portfolio/` implementation. The page now also notes that any delegated feedback contact handle will be visible in the GitHub issues that Pharos creates.
 
@@ -57,7 +58,9 @@ Portfolio holdings are explicitly described as browser-local only, which matches
 
 The homepage page discovery module is deterministic on first render and does not write localStorage. Its manual Refresh
 button rotates suggestions in memory only, so it does not store an IP address, account identifier, wallet address, route
-history, or browser fingerprint.
+history, or browser fingerprint. Homepage saved shortcuts use the browser-local `pharos-shortcuts` localStorage key to
+remember only the ordered list of navigation hrefs the user keeps. The values are scoped to this site, allowlisted before
+render, and remain until the user resets shortcuts or clears browser site data.
 
 ### Stablecoin Picker storage
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -37,8 +37,9 @@ export default function PrivacyPage() {
           <p className="mt-2 text-sm text-foreground">
             Pharos does not ask for accounts or wallet connections. Portfolio data is stored locally by default, share
             links encode holdings in the URL, analytics are anonymized when enabled, and support or API-access requests
-            route through the feedback/contact channels listed below. The homepage discovery module and Stablecoin
-            Picker use functional browser storage, and Picker share snapshots are described below.
+            route through the feedback/contact channels listed below. Homepage saved shortcuts and the Stablecoin
+            Picker use functional browser storage, while homepage discovery rotates in memory only. Picker share
+            snapshots are described below.
           </p>
         </div>
 
@@ -55,9 +56,10 @@ export default function PrivacyPage() {
             access, Pharos stores the email address you verify plus any name, organization, project URL, use-case,
             intended-endpoint, cadence, and volume details you submit; request throttling stores salted hashes of IP
             address and user-agent data. The homepage page discovery module does not store route history or a
-            visit-rotation cursor. The Stablecoin Picker stores local browser state for callout dismissal and
-            tab-scoped result recovery, and share links can store a content-addressed snapshot of the generated selector
-            output in Cloudflare KV.
+            visit-rotation cursor. Homepage saved shortcuts store only the ordered route hrefs you keep in the
+            browser-local pharos-shortcuts key. The Stablecoin Picker stores local browser state for callout dismissal
+            and tab-scoped result recovery, and share links can store a content-addressed snapshot of the generated
+            selector output in Cloudflare KV.
           </p>
         </section>
 
@@ -66,7 +68,11 @@ export default function PrivacyPage() {
           <p>
             The homepage page discovery module is deterministic on first render. Its manual Refresh button rotates
             route suggestions in memory only, so it does not store route history, account identifiers, wallet addresses,
-            IP addresses, or a browser fingerprint.
+            IP addresses, or a browser fingerprint. Homepage saved shortcuts use the browser-local{" "}
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">pharos-shortcuts</code> key to remember your
+            ordered list of navigation hrefs. That key is scoped to this site, is allowlisted before shortcuts render,
+            does not contain account identifiers, wallet addresses, IP addresses, or a browser fingerprint, and remains
+            until you reset shortcuts or clear browser site data.
           </p>
         </section>
 


### PR DESCRIPTION
### Motivation
- The homepage Shortcuts feature persists an ordered list of navigation hrefs in browser-local storage under the `pharos-shortcuts` key, but the visible privacy policy still described homepage discovery as memory-only, creating a documentation/privacy mismatch.

### Description
- Update `src/app/privacy/page.tsx` to disclose that homepage saved shortcuts use browser-local storage (`pharos-shortcuts`) and to clarify the key stores only ordered navigation hrefs, is site-scoped, allowlisted before render, excludes account/wallet/IP/fingerprint data, and persists until reset or clearing site data.
- Update `docs/privacy-page.md` to keep the route contract aligned with the visible policy and enumerate the new `pharos-shortcuts` behavior.
- This change is documentation-only and does not modify runtime behavior or feature code.

### Testing
- Ran `npm run check:verified-doc-links` which passed.
- Ran `npm run check:doc-source-paths` which passed.
- Ran `npx eslint src/app/privacy/page.tsx --max-warnings=0` which passed for the edited route file; running `npm run lint -- src/app/privacy/page.tsx docs/privacy-page.md` produced an ESLint warning because `docs/privacy-page.md` is ignored by the linter, but the targeted page lint succeeded.
- Ran repository diff/consistency checks (`git diff --check`) with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e4d2e3e08332aed3b821bd2331cf)