### PR TITLE
fix(worker): redact OXR app_id in provider logs

### DIFF
--- a/worker/src/lib/__tests__/safe-error-message.test.ts
+++ b/worker/src/lib/__tests__/safe-error-message.test.ts
@@ -71,6 +71,9 @@ describe("safeErrorMessage", () => {
     expect(
       redactProviderUrls("generic https://example.com/v1/path?token=secret&ok=1 failed"),
     ).toBe("generic https://example.com/v1/path?token=[redacted]&ok=1 failed");
+    expect(
+      redactProviderUrls("oxr https://openexchangerates.org/api/latest.json?app_id=secret&symbols=EUR&base=USD failed"),
+    ).toBe("oxr https://openexchangerates.org/api/latest.json?app_id=[redacted]&symbols=EUR&base=USD failed");
   });
 
   it("truncates messages longer than maxLength", () => {

--- a/worker/src/lib/safe-error-message.ts
+++ b/worker/src/lib/safe-error-message.ts
@@ -51,7 +51,7 @@ const PROVIDER_URL_HOST_PATTERNS = [
 ];
 
 const SECRET_QUERY_PARAM_PATTERN =
-  /([?&](?:api[_-]?key|apikey|key|token|access[_-]?token|auth|authorization|secret)=)[^&#\s]+/gi;
+  /([?&](?:api[_-]?key|apikey|app[_-]?id|key|token|access[_-]?token|auth|authorization|secret)=)[^&#\s]+/gi;
 
 function isKnownProviderHost(hostname: string): boolean {
   return PROVIDER_URL_HOST_PATTERNS.some((pattern) => pattern.test(hostname));


### PR DESCRIPTION
### Motivation
- A recent change moved Open Exchange Rates JSON/body parsing into `fetchJsonWithRetry`, which can log body-read/parse failures with a `logUrl` that contained the OXR `app_id` API key. 
- The existing URL redaction did not treat `app_id`/`app-id` as a secret query parameter, so malformed or slow OXR responses could leak the API key to Worker logs.

### Description
- Extend the provider URL secret regex in `worker/src/lib/safe-error-message.ts` so `app_id`/`app-id` query parameters are treated as secrets and replaced with `[redacted]` by `redactProviderUrls`.
- Add a regression assertion in `worker/src/lib/__tests__/safe-error-message.test.ts` that verifies an Open Exchange Rates URL with `app_id` is redacted as expected.
- Preserve existing redaction semantics and host-context preservation for known provider hosts.

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/safe-error-message.test.ts` and the suite passed.
- Ran `npx vitest run worker/src/lib/__tests__/fx-realtime.test.ts worker/src/lib/__tests__/fetch-retry.test.ts` and both suites passed.
- Ran `cd worker && npx tsc --noEmit` for worker typecheck and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4110a2ec3083328a113852943bb96c)