### PR TITLE
fix(ci): scan all same-line fetch body reads

### DIFF
--- a/scripts/__tests__/check-fetch-body-timeouts.test.ts
+++ b/scripts/__tests__/check-fetch-body-timeouts.test.ts
@@ -58,6 +58,24 @@ describe("fetch body timeout guardrail", () => {
     expect(violations.map((violation) => violation.method)).toEqual(["text", "json"]);
   });
 
+  it("detects later same-line body reads after unrelated json/text calls", () => {
+    const violations = findFetchBodyTimeoutViolations(`
+      import { fetchWithRetry } from "../lib/fetch-retry";
+      export async function run(cache) {
+        const res = await fetchWithRetry("https://example.test");
+        return cache.json(await res.text());
+      }
+    `);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({
+      variable: "res",
+      method: "text",
+      fetchLine: 4,
+      bodyLine: 5,
+    });
+  });
+
   it("detects body reads from destructured Promise.all fetchWithRetry responses", () => {
     const violations = findFetchBodyTimeoutViolations(`
       import { fetchWithRetry } from "../lib/fetch-retry";

--- a/scripts/ci/check-fetch-body-timeouts.mjs
+++ b/scripts/ci/check-fetch-body-timeouts.mjs
@@ -230,22 +230,24 @@ export function findFetchBodyTimeoutViolations(source, file = "<source>") {
       });
     }
 
-    const bodyReadMatch = trimmed.match(/\b([A-Za-z_$][\w$]*)\s*\.\s*(json|text)\s*\(/);
-    if (!bodyReadMatch) continue;
+    const bodyReadMatches = [...trimmed.matchAll(/\b([A-Za-z_$][\w$]*)\s*\.\s*(json|text)\s*\(/g)];
+    if (bodyReadMatches.length === 0) continue;
 
     for (const candidate of tracked) {
       if (index + 1 <= candidate.line) continue;
       if (index + 1 - candidate.line > 80) continue;
-      if (bodyReadMatch[1] !== candidate.name) continue;
-      violations.push({
-        file,
-        fetchLine: candidate.line,
-        bodyLine: index + 1,
-        variable: candidate.name,
-        method: bodyReadMatch[2],
-        assignmentText: candidate.assignmentText,
-        bodyReadText: trimmed,
-      });
+      for (const bodyReadMatch of bodyReadMatches) {
+        if (bodyReadMatch[1] !== candidate.name) continue;
+        violations.push({
+          file,
+          fetchLine: candidate.line,
+          bodyLine: index + 1,
+          variable: candidate.name,
+          method: bodyReadMatch[2],
+          assignmentText: candidate.assignmentText,
+          bodyReadText: trimmed,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- The fetch-body-timeout scanner could miss raw `.json()`/`.text()` reads when an unrelated body-like call appeared earlier on the same source line, producing a CI false negative.

### Description
- Update `findFetchBodyTimeoutViolations` in `scripts/ci/check-fetch-body-timeouts.mjs` to collect all same-line `.json()`/`.text()` matches via `matchAll` and compare each match against tracked `fetchWithRetry` response variables.
- Emit violations for any matching body-read occurrence so an unrelated earlier call cannot hide a later raw read on a tracked variable.
- Add a regression test `scripts/__tests__/check-fetch-body-timeouts.test.ts` covering the `cache.json(await res.text())` bypass pattern.

### Testing
- Ran the focused unit tests with `npx vitest run scripts/__tests__/check-fetch-body-timeouts.test.ts`, which passed. 
- Ran the scanner via `npm run check:fetch-body-timeouts`, which reported success with no unexpected violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4110a2e48883329f7860e4d6361d51)