### PR TITLE
fix(worker): fence stale slot cleanup after takeover

### DIFF
--- a/worker/src/lib/__tests__/cron-leases.test.ts
+++ b/worker/src/lib/__tests__/cron-leases.test.ts
@@ -93,6 +93,7 @@ function makeLeaseDb(seed?: {
   cache?: CacheRow[];
   attempts?: JobAttemptRow[];
   failSlotHeartbeatRuns?: number;
+  beforeSlotTakeover?: (slots: Map<string, SlotExecutionRow>) => void;
 }): TestLeaseDb {
   const leases = new Map<string, LeaseRow>();
   const slots = new Map<string, SlotExecutionRow>();
@@ -101,6 +102,7 @@ function makeLeaseDb(seed?: {
   const cacheRows = new Map<string, CacheRow>();
   const jobAttempts = new Map<string, JobAttemptRow>();
   let failSlotHeartbeatRuns = seed?.failSlotHeartbeatRuns ?? 0;
+  const beforeSlotTakeover = seed?.beforeSlotTakeover;
 
   for (const lease of seed?.leases ?? []) {
     leases.set(lease.job, lease);
@@ -352,6 +354,7 @@ function makeLeaseDb(seed?: {
               number,
             ];
             const key = makeSlotMapKey(slotKey, slotStartedAt);
+            beforeSlotTakeover?.(slots);
             const existing = slots.get(key);
             if (!existing || existing.state !== "running" || existing.updated_at >= staleBefore) {
               return { success: true, meta: { changes: 0 } };
@@ -365,6 +368,17 @@ function makeLeaseDb(seed?: {
               result_status: null,
               metadata,
             });
+            return { success: true, meta: { changes: 1 } };
+          }
+
+          if (sql.includes("UPDATE cron_slot_executions") && sql.includes("SET metadata = ?")) {
+            const [metadata, slotKey, slotStartedAt, owner] = args as [string, string, number, string];
+            const key = makeSlotMapKey(slotKey, slotStartedAt);
+            const existing = slots.get(key);
+            if (!existing || existing.execution_owner !== owner || existing.state !== "running") {
+              return { success: true, meta: { changes: 0 } };
+            }
+            slots.set(key, { ...existing, metadata });
             return { success: true, meta: { changes: 1 } };
           }
 
@@ -1201,7 +1215,7 @@ describe("runScheduledSlotWithFence", () => {
     });
   });
 
-  it("reconciles child evidence before taking over the same stale slot", async () => {
+  it("reconciles child evidence after winning same-slot stale takeover", async () => {
     const now = Math.floor(Date.now() / 1000);
     const slotStartedAt = now - 3600;
     const db = makeLeaseDb({
@@ -1280,6 +1294,65 @@ describe("runScheduledSlotWithFence", () => {
       },
     });
     expect(db.getCache("cron:event:hourlyyieldsync:scheduled-slot-abandoned")).toBeDefined();
+  });
+
+  it("does not reconcile stale child evidence when a same-slot takeover loses the heartbeat race", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const slotStartedAt = now - 3600;
+    const db = makeLeaseDb({
+      slots: [{
+        slot_key: "hourlyYieldSync",
+        slot_started_at: slotStartedAt,
+        state: "running",
+        result_status: null,
+        execution_owner: "slot-owner-a",
+        started_at: slotStartedAt,
+        finished_at: null,
+        updated_at: now - 1800,
+        metadata: null,
+      }],
+      leases: [{
+        job: "sync-yield-data",
+        lease_owner: "yield-owner-a",
+        lease_until: now - 60,
+        heartbeat_at: now - 1800,
+        updated_at: now - 1800,
+      }],
+      progress: [{
+        job: "sync-yield-data",
+        started_at: slotStartedAt + 20,
+        updated_at: now - 1800,
+        stage: "publication",
+        lease_owner: "yield-owner-a",
+        slot_started_at: slotStartedAt,
+      }],
+      beforeSlotTakeover: (slots) => {
+        const key = makeSlotMapKey("hourlyYieldSync", slotStartedAt);
+        const slot = slots.get(key);
+        if (slot) {
+          slots.set(key, { ...slot, updated_at: now });
+        }
+      },
+    });
+    const fn = vi.fn(async () => ({ jobsErrored: 0, jobsDegraded: 0, jobsSkipped: 0 }));
+
+    const result = await runScheduledSlotWithFence(
+      db,
+      "hourlyYieldSync",
+      fn,
+      { slotStartedAt, owner: "slot-owner-b", staleAfterSec: 1200 },
+    );
+
+    expect(result.status).toBe("skipped_running");
+    expect(fn).not.toHaveBeenCalled();
+    expect(db.getRuns()).toEqual([]);
+    expect(db.getProgress("sync-yield-data")).toBeDefined();
+    expect(db.getLease("sync-yield-data")).toBeDefined();
+    expect(db.getJobAttempt("yield-attempt-a")).toBeUndefined();
+    expect(db.getCache("cron:event:hourlyyieldsync:scheduled-slot-abandoned")).toBeUndefined();
+    const slot = db.getSlot("hourlyYieldSync", slotStartedAt);
+    expect(slot?.execution_owner).toBe("slot-owner-a");
+    expect(slot?.updated_at).toBe(now);
   });
 
   it("uses a 35-minute default scheduled-slot stale window", async () => {

--- a/worker/src/lib/scheduled-slot-fence.ts
+++ b/worker/src/lib/scheduled-slot-fence.ts
@@ -87,7 +87,7 @@ interface StaleSlotTakeoverSummary {
   previousUpdatedAt: number;
   staleBefore: number;
   takenOverAt: number;
-  reconciliation: StaleSlotReconciliationSummary;
+  reconciliation?: StaleSlotReconciliationSummary;
 }
 
 type ScheduledSlotClaimResult =
@@ -571,15 +571,12 @@ async function claimScheduledSlotExecution(
       started_at: existing.started_at,
       updated_at: existing.updated_at,
     };
-    const reconciliation = await reconcileStaleSlotArtifacts(db, staleSlot, nowSec);
-    await writeStaleSlotEventMarker(db, staleSlot, nowSec, reconciliation);
     const staleSlotTakeover: StaleSlotTakeoverSummary = {
       previousOwner: existing.execution_owner,
       previousStartedAt: existing.started_at,
       previousUpdatedAt: existing.updated_at,
       staleBefore,
       takenOverAt: nowSec,
-      reconciliation,
     };
     const takeover = await runWithOverloadRetry(() =>
       db
@@ -600,6 +597,22 @@ async function claimScheduledSlotExecution(
         .run(),
     );
     if ((takeover.meta.changes ?? 0) > 0) {
+      const reconciliation = await reconcileStaleSlotArtifacts(db, staleSlot, nowSec);
+      staleSlotTakeover.reconciliation = reconciliation;
+      await writeStaleSlotEventMarker(db, staleSlot, nowSec, reconciliation);
+      await runWithOverloadRetry(() =>
+        db
+          .prepare(
+            `UPDATE cron_slot_executions
+             SET metadata = ?
+             WHERE slot_key = ?
+               AND slot_started_at = ?
+               AND execution_owner = ?
+               AND state = 'running'`,
+          )
+          .bind(JSON.stringify({ staleSlotTakeover }), slotKey, slotStartedAt, owner)
+          .run(),
+      );
       return { status: "claimed", staleSlotTakeover };
     }
   }


### PR DESCRIPTION
### Motivation

- Prevent destructive stale-child reconciliation from running before a same-slot takeover is atomically claimed, which could delete active progress/lease state and insert synthetic failure evidence when the original owner resumes heartbeating.
- Preserve operational data integrity by ensuring reconciliation and abandoned-slot markers are only applied when the claimant actually wins the slot.

### Description

- Defer `reconcileStaleSlotArtifacts` and the stale-slot event marker until after the conditional `UPDATE` that atomically claims the `cron_slot_executions` row, and persist provisional takeover metadata as part of the atomic claim so it can be enriched after success.
- When the claim succeeds, run reconciliation, write the cache marker, and update the slot `metadata` with the enriched `staleSlotTakeover` reconciliation summary.
- Add a regression test simulating the heartbeat race (claimant loses the heartbeat race) and extend the in-memory D1 test harness with a `beforeSlotTakeover` hook and metadata-update handling to model the atomic claim + enrichment path.
- Modified files: `worker/src/lib/scheduled-slot-fence.ts` and `worker/src/lib/__tests__/cron-leases.test.ts`.

### Testing

- Ran `npx vitest run worker/src/lib/__tests__/cron-leases.test.ts` and all tests passed (`37 passed`).
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation checks passed.
- Ran `npm run check:cron-sync` and `npm run check:cron-connections` and both checks passed.
- Verified no lint/diff-check failures via `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a411d3b233483328dcf50a7f8a39f9c)