### PR TITLE
Gate Pages release on validation

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -327,14 +327,14 @@ jobs:
         run: exit 1
 
   pages-release:
-    # Deliberately NOT gated on the validate job: the release job's own
-    # "Wait for validation gate" step (wait_for_validate_job) blocks before
-    # anything publishes, so build/chromium/pre-publish checks (~10 min) can
-    # overlap validate (~4 min) instead of serializing behind it. A validate
-    # failure still stops the deploy at that internal gate; the only cost is a
-    # discarded build.
+    # Keep the secret-bearing Pages release job behind the validate job. The
+    # reusable workflow still has an internal pre-publish validation wait for
+    # defense in depth/manual callers, but repository-controlled build and
+    # smoke scripts must not run with production secrets before validation
+    # succeeds.
     needs:
       - detect-changes
+      - validate
     if: ${{ needs.detect-changes.outputs.pages_changed == 'true' }}
     uses: ./.github/workflows/pages-release.yml
     with:

--- a/scripts/__tests__/validate-ci-parity.test.ts
+++ b/scripts/__tests__/validate-ci-parity.test.ts
@@ -570,9 +570,9 @@ describe("validate-ci parity", () => {
     const pagesReleaseJob = extractJobBlock(deployWorkflow, "pages-release");
     expect(pagesReleaseJob).toContain("needs:");
     expect(pagesReleaseJob).toContain("- detect-changes");
-    // No needs edge on validate: the release overlaps validation and is gated
-    // before publish by its internal wait_for_validate_job step instead.
-    expect(pagesReleaseJob).not.toContain("- validate");
+    // The secret-bearing Pages release job must not start until validation
+    // succeeds; the reusable workflow's internal wait remains defense in depth.
+    expect(pagesReleaseJob).toContain("- validate");
     expect(pagesReleaseJob).not.toContain("- upload-worker-version");
     expect(pagesReleaseJob).toContain("uses: ./.github/workflows/pages-release.yml");
     expect(pagesReleaseJob).toContain(


### PR DESCRIPTION
### Motivation
- Prevent CI secret-exfiltration by ensuring the production Pages release job cannot start repository-controlled build/smoke steps with production secrets until validation succeeds.  

### Description
- Add a `validate` dependency to the `pages-release` job in `.github/workflows/deploy-cloudflare.yml` so the job waits for the shared validate workflow before running.  
- Keep the reusable Pages release workflow's internal `wait_for_validate_job` step as defense-in-depth for manual or reusable callers.  
- Update the CI parity assertion in `scripts/__tests__/validate-ci-parity.test.ts` to require the `- validate` `needs` edge on the `pages-release` job.

### Testing
- Ran `npx vitest run scripts/__tests__/validate-ci-parity.test.ts` and the test file passed (`1 file, 21 tests`), proving the parity change is correct.  
- Ran `git diff --check` (no whitespace/format issues) to validate the YAML edit did not introduce syntactic problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4687340a2c83328cb6548ae98f6bcc)