### PR TITLE
Restore FreezeWatch stale snapshot warnings

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -958,10 +958,10 @@ The four `perCoin*` maps power the per-coin "Blacklist Activity" block on stable
   },
   "totalEvents": 13422,
   "methodology": {
-    "version": "3.9972",
-    "versionLabel": "v3.9972",
-    "currentVersion": "3.9972",
-    "currentVersionLabel": "v3.9972",
+    "version": "3.9973",
+    "versionLabel": "v3.9973",
+    "currentVersion": "3.9973",
+    "currentVersionLabel": "v3.9973",
     "changelogPath": "/methodology/blacklist-tracker-changelog/",
     "asOf": 1776729600,
     "isCurrent": true
@@ -969,7 +969,7 @@ The four `perCoin*` maps power the per-coin "Blacklist Activity" block on stable
 }
 ```
 
-`coverage` is the machine-readable tracker coverage inventory. `supported` entries are contract/config-level rows; each row includes the required tracked fields `symbol`, `stablecoinId`, `chainId`, `chainName`, `contractAddress`, `configKey`, `providerSource`, `eventFamilies`, and `eventTypes`. `unsupportedDeferred` identifies known deferred or explicitly de-scoped deployments from the runtime manifest and the reason they are not live; current examples use `chainId` values from the same shared chain registry as event rows. `freezeLedgerMeta` describes the last-known snapshot ledger used by `trackedFrozenTotal`, including scoped-vs-legacy row counts, observed-age bounds, source/status distributions, provider failures, and amount-gap distributions. `freshnessDistribution` covers every historical ledger row; `currentFreshnessDistribution` isolates rows produced by the current-balance provider when present, but old resolved snapshots are diagnostic rather than an actionable stale condition. `dataQuality.status` summarizes recoverable amount-gap thresholds and current-balance provider failures into `ok`, `degraded`, or `stale`; permanent unavailable rows and deferred coverage remain visible in the payload without opening warning state by themselves. Clients should display or alert on `warnings` rather than inferring quality from null amount fields alone.
+`coverage` is the machine-readable tracker coverage inventory. `supported` entries are contract/config-level rows; each row includes the required tracked fields `symbol`, `stablecoinId`, `chainId`, `chainName`, `contractAddress`, `configKey`, `providerSource`, `eventFamilies`, and `eventTypes`. `unsupportedDeferred` identifies known deferred or explicitly de-scoped deployments from the runtime manifest and the reason they are not live; current examples use `chainId` values from the same shared chain registry as event rows. `freezeLedgerMeta` describes the last-known snapshot ledger used by `trackedFrozenTotal`, including scoped-vs-legacy row counts, observed-age bounds, source/status distributions, provider failures, and amount-gap distributions. `freshnessDistribution` covers every historical ledger row; `currentFreshnessDistribution` isolates rows produced by the current-balance provider when present, and stale current-balance rows are actionable because the public tracked frozen total depends on those latest provider snapshots. `dataQuality.status` summarizes stale current-balance snapshots, recoverable amount-gap thresholds, and current-balance provider failures into `ok`, `degraded`, or `stale`; permanent unavailable rows, retained historical/bootstrap row age, and deferred coverage remain visible in the payload without opening warning state by themselves. Clients should display or alert on `warnings` rather than inferring quality from null amount fields alone.
 
 ---
 

--- a/docs/blacklist-tracker-timeline.md
+++ b/docs/blacklist-tracker-timeline.md
@@ -1,6 +1,14 @@
 # Blacklist Tracker Methodology — Version Timeline
 
-Internal changelog reconstructed from git history. Covers Blacklist Tracker `v1.0` through `v3.9972` (2026-02-09 -> 2026-07-01).
+Internal changelog reconstructed from git history. Covers Blacklist Tracker `v1.0` through `v3.9973` (2026-02-09 -> 2026-07-02).
+
+---
+
+## v3.9973 — Current-balance stale warning restoration (2026-07-02)
+
+- **Current-balance stale snapshots are actionable** — stale rows produced by the current-balance provider again populate `dataQuality.freezeLedger.staleSnapshotCount`, emit `stale-current-balance-snapshots`, and set `dataQuality.status` to `stale`
+- **Historical diagnostics stay scoped** — retained bootstrap/history rows, permanently unavailable amount rows, and deferred coverage inventory remain diagnostic-only unless their existing actionable thresholds are crossed
+- **FreezeWatch banner restored** — the public data-quality banner now warns when tracked frozen totals rely on stale current-balance snapshots
 
 ---
 

--- a/docs/blacklist-tracker.md
+++ b/docs/blacklist-tracker.md
@@ -799,8 +799,8 @@ The handler now exposes only unsuppressed rows for the live-supported symbols: U
   "methodology": {
     "version": "3.9",
     "versionLabel": "v3.9",
-    "currentVersion": "3.9972",
-    "currentVersionLabel": "v3.9972",
+    "currentVersion": "3.9973",
+    "currentVersionLabel": "v3.9973",
     "changelogPath": "/methodology/blacklist-tracker-changelog/",
     "asOf": 1704067200,
     "isCurrent": false
@@ -821,7 +821,7 @@ The summary now mixes two intentionally distinct lenses:
 - recent activity stats such as `recentCount` (30d) and `recentCount24h`
 - local event-state stats such as `activeFrozenTotal`, sourced from Pharos' active blacklist state machine
 - tracked freeze-ledger stats such as `trackedFrozenTotal`, sourced from last-known successful `blacklist_current_balances` snapshots
-- data-quality metadata when available, including snapshot age, source/status distributions, provider failures, and manifest-derived deferred coverage; retained snapshot age, permanent unavailable rows, and deferred coverage are diagnostics unless recoverable gaps or provider failures cross warning criteria
+- data-quality metadata when available, including snapshot age, source/status distributions, provider failures, and manifest-derived deferred coverage; stale current-balance snapshots, recoverable gaps, and provider failures drive public warnings, while retained historical/bootstrap snapshot age, permanent unavailable rows, and deferred coverage remain diagnostics
 - quarterly chart buckets sourced from the tracked freeze ledger and attributed to each row's latest recorded blacklist quarter
 
 Coverage entries are contract/config-level records. Every supported row is expected to carry the required tracked fields `symbol`, `stablecoinId`, `chainId`, `chainName`, `contractAddress`, `configKey`, `providerSource`, `eventFamilies`, and `eventTypes`; deferred rows carry `symbol`, `chainId`, and `reason`.

--- a/shared/data/methodology-changelogs/blacklist-tracker/v3.ts
+++ b/shared/data/methodology-changelogs/blacklist-tracker/v3.ts
@@ -5,11 +5,26 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 // INTEGER, not a decimal fraction — so `3.997` parses to [3, 997] and sorts after
 // `3.99` ([3, 99]) and `3.9` ([3, 9]). The minor segment is therefore an
 // open-ended integer counter within the v3 bucket; routine changes bump it
-// (…3.9 → 3.99 → 3.997 → 3.9971 → 3.9972 …) and stay in this file. Create a new `v4.ts`
+// (…3.9 → 3.99 → 3.997 → 3.9971 → 3.9972 → 3.9973 …) and stay in this file. Create a new `v4.ts`
 // (and a sibling vN file array) only for a genuine major/breaking change to the
 // blacklist-tracker methodology, not merely to "roll over" the counter. There is
 // no implicit cap that forces a v4; entries below are newest-first by version.
 export const BLACKLIST_TRACKER_V3: readonly MethodologyChangelogEntry[] = [
+  {
+    version: "3.9973",
+    title: "Current-balance stale warning restoration",
+    date: "2026-07-02",
+    effectiveAt: 1782950400, // 2026-07-02T00:00:00Z
+    summary:
+      "Restores stale current-balance freeze-ledger snapshots as public data-quality warnings while keeping historical bootstrap rows, permanent limitations, and deferred coverage diagnostic-only.",
+    impact: [
+      "Current-balance rows older than the blacklist-summary stale threshold again set `dataQuality.freezeLedger.staleSnapshotCount` and emit `stale-current-balance-snapshots`",
+      "FreezeWatch data-quality status becomes `stale` when stale current-balance snapshots are present, so the public banner warns before stale tracked frozen totals are presented as healthy",
+      "Bootstrap/history-preserved rows, permanently unavailable amount rows, and deferred coverage inventory remain diagnostics unless their existing actionable thresholds are crossed",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
   {
     version: "3.9972",
     title: "Actionable data-quality warning scope",

--- a/shared/lib/methodology-versions/blacklist-tracker.ts
+++ b/shared/lib/methodology-versions/blacklist-tracker.ts
@@ -4,7 +4,7 @@ import { BLACKLIST_TRACKER_V3 } from "../../data/methodology-changelogs/blacklis
 import { createMethodologyVersion } from "./base";
 
 const blacklistTracker = createMethodologyVersion({
-  currentVersion: "3.9972",
+  currentVersion: "3.9973",
   changelogPath: "/methodology/blacklist-tracker-changelog/",
   changelog: [
     ...BLACKLIST_TRACKER_V3,

--- a/worker/src/api/__tests__/blacklist-summary.test.ts
+++ b/worker/src/api/__tests__/blacklist-summary.test.ts
@@ -778,7 +778,7 @@ describe("handleBlacklistSummary", () => {
     expect(json.dataQuality.status).toBe("ok");
   });
 
-  it("keeps resolved old snapshots and permanent limitations out of the warning state", async () => {
+  it("surfaces stale current-balance snapshots while keeping permanent limitations out of the warning state", async () => {
     const now = Math.floor(Date.now() / 1000);
     const db = mockD1([
       { match: "GROUP BY stablecoin, event_type", rows: [] },
@@ -855,9 +855,9 @@ describe("handleBlacklistSummary", () => {
     expect(json.freezeLedgerMeta.currentFreshnessDistribution.stale).toBe(1);
     expect(json.dataQuality.amountGaps.unrecoverable).toBe(2);
     expect(json.dataQuality.coverage.unsupportedDeferredConfigs).toBeGreaterThan(0);
-    expect(json.dataQuality.freezeLedger.staleSnapshotCount).toBe(0);
-    expect(json.dataQuality.status).toBe("ok");
-    expect(json.dataQuality.warnings).toEqual([]);
+    expect(json.dataQuality.freezeLedger.staleSnapshotCount).toBe(1);
+    expect(json.dataQuality.status).toBe("stale");
+    expect(json.dataQuality.warnings).toEqual(["stale-current-balance-snapshots"]);
   });
 
   it("excludes suppression_reason != null from public aggregates", async () => {

--- a/worker/src/api/blacklist-summary.ts
+++ b/worker/src/api/blacklist-summary.ts
@@ -263,12 +263,8 @@ function buildDataQuality(
     missingRatio: gapMetrics.missingRatio,
     recentMissingAmounts: gapMetrics.recentMissingAmounts,
   });
-  // Resolved freeze-ledger rows are retained historical snapshots by design.
-  // Their age remains visible in freezeLedgerMeta.currentFreshnessDistribution,
-  // but it is not an actionable stale condition unless the provider is failing
-  // or recoverable amount gaps cross the shared gap thresholds.
-  const actionableStaleSnapshotCount = 0;
-  const status = gapStatus === "stale"
+  const actionableStaleSnapshotCount = freezeLedgerMeta.currentFreshnessDistribution.stale;
+  const status = actionableStaleSnapshotCount > 0 || gapStatus === "stale"
     ? "stale"
     : gapStatus === "degraded" || freezeLedgerMeta.providerFailedCount > 0
       ? "degraded"
@@ -276,6 +272,7 @@ function buildDataQuality(
   const warnings: string[] = [];
   if (gapStatus !== "healthy" && gapMetrics.missingAmounts > 0) warnings.push("recoverable-amount-gaps");
   if (freezeLedgerMeta.providerFailedCount > 0) warnings.push("current-balance-provider-failures");
+  if (actionableStaleSnapshotCount > 0) warnings.push("stale-current-balance-snapshots");
 
   return {
     status,


### PR DESCRIPTION
### Motivation
- A recent change suppressed actionable stale current-balance freeze-ledger signals by forcing `dataQuality.freezeLedger.staleSnapshotCount` to zero, which prevented the UI/API from warning when current-balance snapshots are stale.
- This PR restores the original warning behavior so stale current-balance snapshots again surface as actionable data-quality issues when they exceed the freshness threshold.

### Description
- Re-enabled actionable stale-snapshot detection by setting `staleSnapshotCount` to `freezeLedgerMeta.currentFreshnessDistribution.stale` in `worker/src/api/blacklist-summary.ts` and making `dataQuality.status` consider that count when deciding `stale`/`degraded`/`ok`.
- Emit the `stale-current-balance-snapshots` warning when stale current-balance snapshots are present and include the count in the `freezeLedger` payload field returned by the API.
- Updated the focused regression in `worker/src/api/__tests__/blacklist-summary.test.ts` to assert the stale snapshot count, `stale` status, and the `stale-current-balance-snapshots` warning for the reproduced case.
- Bumped the blacklist-tracker methodology to `v3.9973` and updated the changelog/timeline and API/tracker docs (`shared/data/methodology-changelogs/blacklist-tracker/v3.ts`, `shared/lib/methodology-versions/blacklist-tracker.ts`, `docs/blacklist-tracker.md`, `docs/blacklist-tracker-timeline.md`, `docs/api-reference.md`) to document the restored behavior while preserving that bootstrap/history rows, permanent limitations, and deferred coverage remain diagnostic-only.

### Testing
- Ran the unit suites: `npx vitest run worker/src/api/__tests__/blacklist-summary.test.ts src/components/__tests__/blacklist-stats.test.tsx`, and both test files passed.
- Performed TypeScript worker build check: `cd worker && npx tsc --noEmit`, which completed without errors.
- Ran repository lint/check `git diff --check` (local verification step) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a465c74f0348332a4ba8fd3c17f49d5)