### PR TITLE
Guard DDR repair-debt cache cleanup

### DIFF
--- a/worker/migrations/0169_lusd_ddr_event_90410_split.sql
+++ b/worker/migrations/0169_lusd_ddr_event_90410_split.sql
@@ -131,11 +131,31 @@ WHERE kind = 'ddr-repair-required-event'
   AND EXISTS (
     SELECT 1
     FROM depeg_resolver_incident_event_links l
-    WHERE l.event_id = 90410
+    JOIN depeg_resolver_incidents i ON i.incident_key = l.incident_key
+    WHERE l.incident_key = 'ddr2:c14884852abe024faa4d4b9fc1f84742'
+      AND l.event_id = 90410
+      AND i.first_event_id = 90410
+      AND i.current_event_id = 90410
   );
 
 DELETE FROM cache
 WHERE key = 'ddr:repair-debt:v1'
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_event_links l
+    JOIN depeg_resolver_incidents i ON i.incident_key = l.incident_key
+    WHERE l.incident_key = 'ddr2:c14884852abe024faa4d4b9fc1f84742'
+      AND l.event_id = 90410
+      AND i.first_event_id = 90410
+      AND i.current_event_id = 90410
+  )
+  AND COALESCE(json_extract(value, '$.count'), 0) = 1
+  AND CAST(json_extract(value, '$.events[0].eventId') AS INTEGER) = 90410
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(value, '$.events') event
+    WHERE CAST(json_extract(event.value, '$.eventId') AS INTEGER) != 90410
+  )
   AND NOT EXISTS (
     SELECT 1
     FROM worker_repair_tasks task

--- a/worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts
+++ b/worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts
@@ -379,6 +379,83 @@ describe("DDRv2 storage migrations and stores", () => {
     }
   });
 
+  it("keeps DDR repair-debt cache markers that include unrelated cache-only debt", () => {
+    const sqlite = new DatabaseSync(":memory:");
+    try {
+      applyMigrationsThrough(sqlite, "0168_surface_publication_generations.sql");
+
+      sqlite.exec(`
+        INSERT INTO depeg_events
+          (id, stablecoin_id, symbol, peg_type, direction, peak_deviation_bps,
+           started_at, ended_at, start_price, peak_price, recovery_price, peg_reference, source)
+        VALUES
+          (90410, 'lusd-liquity', 'LUSD', 'peggedUSD', 'above', 100,
+           1782970434, 1782973127, 1.0096702857093371, 1.0096702857093371, 1.0092109177692081, 0.99968, 'live');
+
+        INSERT INTO worker_repair_tasks
+          (task_id, kind, subject_id, priority, state, attempt_count, next_attempt_at,
+           payload_json, created_at, updated_at)
+        VALUES
+          ('repair:ddr-repair-required-event:90410', 'ddr-repair-required-event', '90410', 50, 'open', 0, NULL,
+           '{"eventId":90410,"reason":"explicit repair required"}',
+           1782970440, 1782973133);
+
+        INSERT INTO cache (key, value, updated_at)
+        VALUES (
+          'ddr:repair-debt:v1',
+          '{"checkedAt":1782973133,"count":2,"events":[{"eventId":90410,"reason":"explicit repair required"},{"eventId":99999,"reason":"cache-only repair debt"}],"eventsTruncated":false}',
+          1782973133
+        );
+      `);
+
+      applyMigrationFile(sqlite, "0169_lusd_ddr_event_90410_split.sql");
+
+      expect(
+        sqlite
+          .prepare("SELECT state, closed_at IS NOT NULL AS has_closed_at FROM worker_repair_tasks WHERE subject_id = '90410'")
+          .get(),
+      ).toEqual({ state: "closed", has_closed_at: 1 });
+      expect(
+        sqlite
+          .prepare("SELECT value FROM cache WHERE key = 'ddr:repair-debt:v1'")
+          .get(),
+      ).toEqual({
+        value:
+          '{"checkedAt":1782973133,"count":2,"events":[{"eventId":90410,"reason":"explicit repair required"},{"eventId":99999,"reason":"cache-only repair debt"}],"eventsTruncated":false}',
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("keeps cache-only DDR repair-debt markers when event 90410 is not repaired", () => {
+    const sqlite = new DatabaseSync(":memory:");
+    try {
+      applyMigrationsThrough(sqlite, "0168_surface_publication_generations.sql");
+
+      sqlite.exec(`
+        INSERT INTO cache (key, value, updated_at)
+        VALUES (
+          'ddr:repair-debt:v1',
+          '{"checkedAt":1782973133,"count":1,"events":[{"eventId":99999,"reason":"cache-only repair debt"}],"eventsTruncated":false}',
+          1782973133
+        );
+      `);
+
+      applyMigrationFile(sqlite, "0169_lusd_ddr_event_90410_split.sql");
+
+      expect(
+        sqlite
+          .prepare("SELECT value FROM cache WHERE key = 'ddr:repair-debt:v1'")
+          .get(),
+      ).toEqual({
+        value: '{"checkedAt":1782973133,"count":1,"events":[{"eventId":99999,"reason":"cache-only repair debt"}],"eventsTruncated":false}',
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("repairs APXUSD event 90203 when the earlier relink migration found an accidental link", () => {
     const sqlite = new DatabaseSync(":memory:");
     try {


### PR DESCRIPTION
### Motivation
- Prevent a migration from deleting the global `ddr:repair-debt:v1` cache marker when unrelated cache-only repair debt remains visible in the cache.
- Ensure the LUSD event `90410` repair-task is only closed when the intended canonical incident/link for that event is actually created.

### Description
- Tighten migration `0169_lusd_ddr_event_90410_split.sql` so the `UPDATE worker_repair_tasks` only closes the task when the inserted incident/link is the intended canonical incident and the incident rows show `first_event_id = 90410` and `current_event_id = 90410`.
- Constrain the `DELETE FROM cache WHERE key = 'ddr:repair-debt:v1'` to run only when the cache marker is proven to contain only the repaired event (checks include JSON `count`, the first event id, and that no other events are present) and the intended incident/link exists.
- Add SQLite migration-replay tests in `worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts` that assert (1) mixed cache+task debt keeps unrelated cache-listed events, and (2) cache-only debt is preserved when event `90410` is not repaired.

### Testing
- Ran `npm run check:migrations` which validated the worker migrations (output: "Validated 98 worker migrations").
- Ran `npx vitest run worker/src/lib/__tests__/depeg-resolver-ddrv2-store.test.ts` and the test suite passed (33 tests passed); targeted runs with name-patterns also passed during development (`--testNamePattern "LUSD|cache-only|unrelated"`).
- Verified no `git diff --check` errors and that the new tests exercise the migration replay scenarios and pass locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46560d18308332b25a31e6ff289ea9)