### PR TITLE
Preserve mint/burn event watermark retry window

### DIFF
--- a/worker/src/cron/__tests__/sync-mint-burn.test.ts
+++ b/worker/src/cron/__tests__/sync-mint-burn.test.ts
@@ -347,7 +347,7 @@ describe("syncMintBurn", () => {
     expect(toBlock - fromBlock + 1).toBe(50_000);
   });
 
-  it("advances full-success event scans to the safe scan frontier", async () => {
+  it("keeps full-success event scans anchored to the newest returned event", async () => {
     const db = makeDb();
     const config = MINT_BURN_CONFIGS[0]!;
 
@@ -388,8 +388,8 @@ describe("syncMintBurn", () => {
 
     expect(result.summary.maxBlockSeen).toBe(21_910_000);
     expect(result.summary.advanceReason).toBe("full-success-events");
-    expect(result.summary.advancedTo).toBe(21_949_999);
-    expect(result.newLastBlock).toBe(21_949_999);
+    expect(result.summary.advancedTo).toBe(21_910_000);
+    expect(result.newLastBlock).toBe(21_910_000);
   });
 
   it("resumes from canonical sync-state progress", async () => {

--- a/worker/src/cron/mint-burn/sync-config.ts
+++ b/worker/src/cron/mint-burn/sync-config.ts
@@ -363,10 +363,11 @@ export async function syncMintBurnConfig(input: SyncMintBurnConfigInput): Promis
     summary.txContextShortfalls === 0
   ) {
     if (summary.maxBlockSeen > 0) {
-      newLastBlock = Math.max(
-        summary.maxBlockSeen,
-        Math.min(scanTo, chainHead - safetyMarginBlocks),
-      );
+      // Keep event-containing scans anchored to the newest event we actually
+      // parsed. A successful eth_getLogs response is not independently
+      // provable as exhaustive, so advancing across later empty-looking blocks
+      // could permanently skip provider-omitted events in the same window.
+      newLastBlock = summary.maxBlockSeen;
       summary.advanceReason = "full-success-events";
     } else {
       newLastBlock = Math.max(


### PR DESCRIPTION
### Motivation
- Prevent a data-integrity regression where a truncated-but-successful `eth_getLogs` response could cause later blocks in the same scan window to be permanently skipped by advancing the watermark past unverified blocks.
- Keep retry safety for mint/burn ingestion when provider responses are attacker-controlled or faulty so missing events can be re-fetched on subsequent runs.

### Description
- Change: when a scan has full event coverage but contains parsed events, set the new watermark to the newest parsed event block instead of advancing to the safe scan frontier in `worker/src/cron/mint-burn/sync-config.ts`.
- Rationale comment added explaining that a successful `eth_getLogs` array is not independently provable as exhaustive and advancing across later blocks could permanently skip provider-omitted events.
- Test update: renamed and adjusted the focused regression test in `worker/src/cron/__tests__/sync-mint-burn.test.ts` to assert the event-containing branch remains anchored to the newest returned event.
- Files modified: `worker/src/cron/mint-burn/sync-config.ts` and `worker/src/cron/__tests__/sync-mint-burn.test.ts`.

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/sync-mint-burn.test.ts`, and the suite passed (all relevant tests passed).
- Ran `cd worker && npx tsc --noEmit` to validate TypeScript build integrity and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476714e7588332b7310d7c5d7a69fc)