### PR TITLE
Guard stale idempotency takeover by request hash

### DIFF
--- a/worker/src/lib/__tests__/idempotency.test.ts
+++ b/worker/src/lib/__tests__/idempotency.test.ts
@@ -64,12 +64,12 @@ function makeIdempotencyDb(
           }
           return { success: true, meta: { changes: 0 } };
         }
-        if (sql.includes("UPDATE admin_idempotency_keys SET request_hash")) {
-          const [requestHash, status, body, createdAt, action, idemKey, expectedStatus, createdBefore] = args as [
-            string,
+        if (sql.includes("UPDATE admin_idempotency_keys SET response_status") && sql.includes("created_at < ?")) {
+          const [status, body, createdAt, action, idemKey, requestHash, expectedStatus, createdBefore] = args as [
             number,
             string,
             number,
+            string,
             string,
             string,
             number,
@@ -77,11 +77,16 @@ function makeIdempotencyDb(
           ];
           const key = `${action}:${idemKey}`;
           const existing = store.get(key);
-          if (!existing || existing.response_status !== expectedStatus || existing.created_at >= createdBefore) {
+          if (
+            !existing ||
+            existing.request_hash !== requestHash ||
+            existing.response_status !== expectedStatus ||
+            existing.created_at >= createdBefore
+          ) {
             return { success: true, meta: { changes: 0 } };
           }
           store.set(key, {
-            request_hash: requestHash,
+            request_hash: existing.request_hash,
             response_status: status,
             response_body: body,
             created_at: createdAt,
@@ -239,24 +244,30 @@ describe("runIdempotentAdminAction", () => {
     expect(calls).toBe(1);
   });
 
-  it("takes over an abandoned pending reservation older than the execution window", async () => {
+  it("takes over an abandoned pending reservation older than the execution window for the same request", async () => {
     const now = 1_800_000_000;
     const dateSpy = vi.spyOn(Date, "now").mockReturnValue(now * 1000);
 
     try {
       const db = makeIdempotencyDb();
-      db.setRecord("backfill-depegs", "abc-abandoned", {
-        request_hash: "stale-request-hash",
-        response_status: -1,
-        response_body: "",
-        created_at: now - 20 * 60 - 1,
-      });
-
       const request = new Request("https://x/api/backfill-depegs?batch=2", {
         method: "POST",
         headers: { "Idempotency-Key": "abc-abandoned" },
         body: JSON.stringify({ batch: 2 }),
       });
+
+      const firstStarted = new Promise<void>((resolve) => {
+        void runIdempotentAdminAction(db, "backfill-depegs", request.clone(), async () => {
+          resolve();
+          return new Promise<Response>(() => {});
+        });
+      });
+      await firstStarted;
+
+      const pending = db.getRecord("backfill-depegs", "abc-abandoned");
+      expect(pending).toBeDefined();
+      pending!.created_at = now - 20 * 60 - 1;
+      const originalHash = pending!.request_hash;
 
       let calls = 0;
       const execute = async () => {
@@ -274,18 +285,53 @@ describe("runIdempotentAdminAction", () => {
       expect(calls).toBe(1);
 
       const record = db.getRecord("backfill-depegs", "abc-abandoned");
-      expect(record?.request_hash).not.toBe("stale-request-hash");
+      expect(record?.request_hash).toBe(originalHash);
       expect(record?.response_status).toBe(202);
       expect(record?.created_at).toBe(now);
 
-      const takeover = db
-        .getHistory()
-        .find((entry) => entry.sql.includes("UPDATE admin_idempotency_keys SET request_hash"));
-      expect(takeover?.binds[3]).toBe(now);
-      expect(takeover?.binds[4]).toBe("backfill-depegs");
-      expect(takeover?.binds[5]).toBe("abc-abandoned");
+      const takeover = db.getHistory().find((entry) => entry.sql.includes("created_at < ?"));
+      expect(takeover?.binds[2]).toBe(now);
+      expect(takeover?.binds[3]).toBe("backfill-depegs");
+      expect(takeover?.binds[4]).toBe("abc-abandoned");
+      expect(takeover?.binds[5]).toBe(originalHash);
       expect(takeover?.binds[6]).toBe(-1);
       expect(takeover?.binds[7]).toBe(now - 20 * 60);
+    } finally {
+      dateSpy.mockRestore();
+    }
+  });
+
+  it("rejects abandoned pending reservation takeover for a different request", async () => {
+    const now = 1_800_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(now * 1000);
+
+    try {
+      const db = makeIdempotencyDb();
+      db.setRecord("backfill-depegs", "abc-abandoned-conflict", {
+        request_hash: "stale-request-hash",
+        response_status: -1,
+        response_body: "",
+        created_at: now - 20 * 60 - 1,
+      });
+
+      const request = new Request("https://x/api/backfill-depegs?batch=2", {
+        method: "POST",
+        headers: { "Idempotency-Key": "abc-abandoned-conflict" },
+        body: JSON.stringify({ batch: 2 }),
+      });
+
+      let calls = 0;
+      const response = await runIdempotentAdminAction(db, "backfill-depegs", request, async () => {
+        calls++;
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({
+        error: "Idempotency key reuse with different request payload",
+      });
+      expect(calls).toBe(0);
+      expect(db.getRecord("backfill-depegs", "abc-abandoned-conflict")?.request_hash).toBe("stale-request-hash");
     } finally {
       dateSpy.mockRestore();
     }

--- a/worker/src/lib/idempotency.ts
+++ b/worker/src/lib/idempotency.ts
@@ -74,9 +74,9 @@ async function takeOverAbandonedPendingReservation(
   try {
     const takeoverResult = await db
       .prepare(
-        "UPDATE admin_idempotency_keys SET request_hash = ?, response_status = ?, response_body = ?, created_at = ? WHERE action = ? AND idempotency_key = ? AND response_status = ? AND created_at < ?",
+        "UPDATE admin_idempotency_keys SET response_status = ?, response_body = ?, created_at = ? WHERE action = ? AND idempotency_key = ? AND request_hash = ? AND response_status = ? AND created_at < ?",
       )
-      .bind(fingerprint, PENDING_RESPONSE_STATUS, "", now, action, key, PENDING_RESPONSE_STATUS, cutoff)
+      .bind(PENDING_RESPONSE_STATUS, "", now, action, key, fingerprint, PENDING_RESPONSE_STATUS, cutoff)
       .run();
 
     return (takeoverResult.meta?.changes ?? 0) > 0;
@@ -122,14 +122,6 @@ export async function runIdempotentAdminAction(
   }
 
   let ownsReservation = insertedReservation;
-  if (existing.response_status === PENDING_RESPONSE_STATUS && !ownsReservation) {
-    ownsReservation = await takeOverAbandonedPendingReservation(db, action, key, fingerprint, now);
-    if (ownsReservation) {
-      existing.request_hash = fingerprint;
-      existing.response_body = "";
-      existing.created_at = now;
-    }
-  }
 
   if (existing.request_hash !== fingerprint) {
     if (insertedReservation) {
@@ -150,6 +142,14 @@ export async function runIdempotentAdminAction(
         });
     }
     return errorResponse(409, "Idempotency key reuse with different request payload");
+  }
+
+  if (existing.response_status === PENDING_RESPONSE_STATUS && !ownsReservation) {
+    ownsReservation = await takeOverAbandonedPendingReservation(db, action, key, fingerprint, now);
+    if (ownsReservation) {
+      existing.response_body = "";
+      existing.created_at = now;
+    }
   }
 
   if (existing.response_status === PENDING_RESPONSE_STATUS && !ownsReservation) {


### PR DESCRIPTION
### Motivation
- Prevent a correctness regression where an abandoned PENDING admin idempotency row could be claimed by a different request payload after the takeover window, weakening idempotency guarantees. 
- Ensure the normal `409` idempotency-key-reuse behavior is preserved for retries with a different fingerprint while still allowing stale same-request retries to recover. 

### Description
- Require the stored `request_hash` to match the retrying request in the takeover `UPDATE` by adding `request_hash = ?` to the `WHERE` clause and stop rewriting `request_hash` during takeover in `worker/src/lib/idempotency.ts`. 
- Move the different-payload conflict check to run before attempting stale-pending takeover so mismatched payloads return `409` and are not allowed to claim the reservation. 
- Update the D1 test double and focused idempotency tests in `worker/src/lib/__tests__/idempotency.test.ts` to enforce the `request_hash` guard and add a test that rejects takeover for a different request while preserving same-request takeover behavior. 

### Testing
- Ran the focused Vitest suite with `cd worker && npx vitest run src/lib/__tests__/idempotency.test.ts --reporter=verbose` and all tests passed (`9 passed`).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit` and the typecheck completed successfully.
- Verified the updated D1 mock exercises the guarded `UPDATE` path and the new/modified tests assert both safe takeover and rejection scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476a7ecde48332a0bbcc4dd70f92c8)