### PR TITLE
Clear actor-scoped Telegram flood cache on forget

### DIFF
--- a/worker/src/api/telegram-store/__tests__/forget.test.ts
+++ b/worker/src/api/telegram-store/__tests__/forget.test.ts
@@ -228,6 +228,7 @@ describe("forgetSubscriber", () => {
     sqlite.prepare("INSERT INTO telegram_alert_dead_letters (chat_id) VALUES (?)").run(chatId);
     const deletedCacheKeys = [
       `telegram:command-flood:${chatId}`,
+      `telegram:command-flood:${chatId}:actor:99`,
       `telegram:command-cooldown:${chatId}:/status`,
       `telegram:chat-member:${chatId}:99`,
       `telegram:chat-admins:${chatId}`,
@@ -275,7 +276,7 @@ describe("forgetSubscriber", () => {
       .toEqual([...neighboringCacheKeys].sort().map((key) => ({ key })));
   });
 
-  it("deletes exact command-flood keys without issuing a command-flood prefix delete", async () => {
+  it("deletes exact and actor-scoped command-flood keys", async () => {
     const chatId = "42";
     const db = mockD1();
 
@@ -293,7 +294,7 @@ describe("forgetSubscriber", () => {
         (entry) =>
           entry.sql.includes("WHERE key LIKE ?") && entry.binds[0] === `telegram:command-flood:${chatId}:%`,
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       cacheDeletes.some(
         (entry) =>

--- a/worker/src/api/telegram-store/forget.ts
+++ b/worker/src/api/telegram-store/forget.ts
@@ -90,6 +90,7 @@ const CHAT_CACHE_EXACT_KEY_BUILDERS = [
 ] as const;
 
 const CHAT_CACHE_PREFIX_BUILDERS = [
+  (chatId: string) => `telegram:command-flood:${chatId}:`,
   (chatId: string) => `telegram:command-cooldown:${chatId}:`,
   (chatId: string) => `telegram:chat-member:${chatId}:`,
 ] as const;


### PR DESCRIPTION
### Motivation
- A recent change removed the `telegram:command-flood:<chatId>:` prefix cleanup and left actor-scoped flood keys like `telegram:command-flood:<chatId>:actor:<userId>` orphaned when a group is forgotten. 
- Orphaned actor-scoped flood rows retain chat/user identifiers and short-lived counters past `forgetSubscriber`'s run, violating intended chat cleanup. 

### Description
- Restore the `telegram:command-flood:${chatId}:` entry in `CHAT_CACHE_PREFIX_BUILDERS` so `prepareDeleteTelegramChatCacheStatements` issues a `LIKE` delete for actor-scoped flood keys. 
- Update the focused test `worker/src/api/telegram-store/__tests__/forget.test.ts` to insert an actor-scoped flood key and assert the prefix `DELETE ... LIKE 'telegram:command-flood:<chatId>:%'` is emitted while neighboring-chat keys remain. 
- Preserve the exact-key delete behavior for `telegram:command-flood:<chatId>` and keep other prefix deletes (e.g. `command-cooldown`) unchanged. 

### Testing
- Ran the focused suite with `npx vitest run worker/src/api/telegram-store/__tests__/forget.test.ts --reporter=dot` and all tests in that file passed (8/8). 
- Type-checked the worker with `cd worker && npx tsc --noEmit` which completed without errors. 
- Verified repository checks with `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476a74f1048332bd2a2cc8a085a11d)