### PR TITLE
Reject malformed yield cleanup value flags

### DIFF
--- a/worker/scripts/__tests__/yield-history-cleanup.test.ts
+++ b/worker/scripts/__tests__/yield-history-cleanup.test.ts
@@ -143,6 +143,26 @@ describe("yield-history-cleanup", () => {
     expect(options.operationMode.dryRun).toBe(true);
   });
 
+  it("rejects value-taking cleanup flags when their value is missing", () => {
+    expect(() =>
+      parseYieldHistoryCleanupCliOptions([
+        "--sqlite",
+        "test.sqlite",
+        "--restore",
+        "--execute",
+        "--confirm",
+        "yield-history-cleanup",
+      ]),
+    ).toThrow("--restore requires a value");
+
+    expect(() => parseYieldHistoryCleanupCliOptions(["--sqlite", "--export"])).toThrow(
+      "--sqlite requires a value",
+    );
+    expect(() => parseYieldHistoryCleanupCliOptions(["--export="])).toThrow(
+      "--export requires a non-empty value",
+    );
+  });
+
   it("loads only the targeted parent-owned wrapper rows", () => {
     const path = createTempDbPath();
     tempPaths.push(path);

--- a/worker/scripts/yield-history-cleanup.ts
+++ b/worker/scripts/yield-history-cleanup.ts
@@ -319,6 +319,12 @@ function parseCliArgs(argv: string[]): Map<string, string | true> {
 
 function getCliString(args: Map<string, string | true>, flag: string): string | null {
   const value = args.get(flag);
+  if (value === true) {
+    throw new Error(`${flag} requires a value`);
+  }
+  if (value === "") {
+    throw new Error(`${flag} requires a non-empty value`);
+  }
   return typeof value === "string" ? value : null;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent malformed value-taking CLI flags (e.g. `--restore --execute`) from being treated as present-but-empty and causing a live cleanup when the operator intended a restore. 
- Improve operator-safety by failing early on omitted or empty values for options that require a value.

### Description
- Modify `getCliString` in `worker/scripts/yield-history-cleanup.ts` to throw an error when a parsed flag value is the boolean `true` (meaning a value was omitted) or the empty string (inline empty `--flag=`), so value-taking flags cannot silently become `null`.
- Preserve existing behavior for inline `--flag=value` and normal `--flag value` forms while rejecting malformed invocations.
- Add a focused regression test in `worker/scripts/__tests__/yield-history-cleanup.test.ts` that asserts missing `--restore`/`--sqlite` values and an empty `--export=` produce clear errors.

### Testing
- Ran `npx vitest run worker/scripts/__tests__/yield-history-cleanup.test.ts` and the suite passed (`1 file, 8 tests passed`).
- Ran the TypeScript check with `cd worker && npx tsc --noEmit` and it completed successfully. 
- Executed a runtime eval using `npx tsx --eval` to confirm malformed restore parsing now throws `--restore requires a value` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476c671428833285cf10bb3a550bf1)