### PR TITLE
Fix stablecoin detail address fast path

### DIFF
--- a/worker/src/api/__tests__/stablecoin-detail-defillama.test.ts
+++ b/worker/src/api/__tests__/stablecoin-detail-defillama.test.ts
@@ -69,6 +69,25 @@ describe("applyCuratedDetailAddress", () => {
       tokens: [{ totalCirculatingUSD: { peggedUSD: 100 } }],
     });
   });
+
+  it("overrides stale cached addresses when a nested address matches the curated address", () => {
+    const curatedAddress = "0x57ab1e0003f623289cd798b1824be09a793e4bec";
+    const body = JSON.stringify({
+      address: "0x4274cd7277c7bb0806bd5fe84b9adae466a8da0a",
+      tokens: [{ address: curatedAddress, totalCirculatingUSD: { peggedUSD: 100 } }],
+    });
+
+    expect(
+      JSON.parse(
+        applyCuratedDetailAddress(body, {
+          contracts: [{ chain: "ethereum", address: curatedAddress, decimals: 18 }],
+        }),
+      ),
+    ).toEqual({
+      address: curatedAddress,
+      tokens: [{ address: curatedAddress, totalCirculatingUSD: { peggedUSD: 100 } }],
+    });
+  });
 });
 
 describe("normalizeDefiLlamaDetailBody", () => {

--- a/worker/src/api/stablecoin-detail/defillama.ts
+++ b/worker/src/api/stablecoin-detail/defillama.ts
@@ -76,12 +76,44 @@ function getCuratedPrimaryAddress(meta: DetailMeta | undefined): string | null {
   return contract?.address ?? null;
 }
 
+function hasTopLevelSerializedAddress(body: string, serializedAddress: string): boolean {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      if (depth === 1 && body.startsWith(serializedAddress, index)) return true;
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+    }
+  }
+
+  return false;
+}
+
 export function applyCuratedDetailAddress(body: string, meta: DetailMeta | undefined): string {
   const curatedAddress = getCuratedPrimaryAddress(meta);
   if (!curatedAddress) return body;
 
   const serializedAddress = `"address":${JSON.stringify(curatedAddress)}`;
-  if (body.includes(serializedAddress)) return body;
+  if (hasTopLevelSerializedAddress(body, serializedAddress)) return body;
 
   try {
     const parsed = JSON.parse(body) as unknown;


### PR DESCRIPTION
### Motivation
- A substring fast path used `String.includes` on the cached DefiLlama detail JSON to skip parsing when the curated `address` was already present, which could falsely trigger if the curated address appeared in a nested field and leave a stale top-level `address` uncorrected.
- The change must preserve the optimization for genuine top-level hits while ensuring cached responses are normalized correctly when only nested occurrences exist.

### Description
- Replace the broad `body.includes(serializedAddress)` check with `hasTopLevelSerializedAddress(body, serializedAddress)`, a lightweight scanner that confirms the serialized `"address":<addr>` occurs at the top-level JSON object before skipping parsing. (file: `worker/src/api/stablecoin-detail/defillama.ts`)
- Keep the existing parse-and-overwrite normalization path for cases that do not contain the top-level serialized address so stale top-level `address` fields are corrected. (file: `worker/src/api/stablecoin-detail/defillama.ts`)
- Add a regression test that verifies a cached body with a stale top-level `address` and a nested token `address` equal to the curated address is normalized to the curated top-level address. (file: `worker/src/api/__tests__/stablecoin-detail-defillama.test.ts`)

### Testing
- Ran the targeted Vitest suite with `npm test -- --run worker/src/api/__tests__/stablecoin-detail-defillama.test.ts`, and all tests passed. 
- Type-checked the worker with `cd worker && npx tsc --noEmit`, which completed without errors. 
- The change is intentionally minimal and preserves the original behavior for genuine top-level fast-path hits while fixing the nested-address false-positive regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476b7bfad883329e0b01d837118d9f)