### PR TITLE
Prevent mint/burn watermark regression

### DIFF
--- a/worker/src/cron/__tests__/sync-mint-burn.test.ts
+++ b/worker/src/cron/__tests__/sync-mint-burn.test.ts
@@ -392,6 +392,54 @@ describe("syncMintBurn", () => {
     expect(result.newLastBlock).toBe(21_910_000);
   });
 
+  it("ignores provider logs outside the requested scan range before advancing", async () => {
+    const db = makeDb();
+    const config = MINT_BURN_CONFIGS[0]!;
+
+    vi.mocked(fetchAlchemyLogs)
+      .mockResolvedValueOnce({
+        logs: [makeMintLog({ blockNumber: 21_910_000 })],
+        complete: true,
+        scannedToBlock: 21_960_000,
+        calls: 1,
+        maxDepth: 0,
+      })
+      .mockResolvedValueOnce({
+        logs: [],
+        complete: true,
+        scannedToBlock: 21_960_000,
+        calls: 1,
+        maxDepth: 0,
+      });
+    vi.mocked(resolveBlockTimestamps).mockResolvedValueOnce(new Map([[21_910_000, 1_718_650_752]]));
+
+    const result = await syncMintBurnConfig({
+      db,
+      config,
+      key: "ethereum-0xdac17f958d2ee523a2206206994597c13d831ec7",
+      tier: "critical",
+      fromBlock: 21_955_001,
+      scanTo: 21_960_000,
+      chainHead: 22_000_000,
+      alchemyUrl: "https://eth-mainnet.g.alchemy.com/v2/alchemy-key",
+      configBudgetLimit: 200,
+      runTimestamp: 1_718_650_752,
+      priceContext: { prices: new Map([["usdt-tether", 1]]), priceHistory: new Map() },
+      chainTimestampCache: new Map(),
+      txContextCache: new Map(),
+      affectedHours: new Map(),
+      safetyMarginBlocks: 10_000,
+    });
+
+    expect(result.summary.rowsRead).toBe(1);
+    expect(result.summary.rowsParsed).toBe(1);
+    expect(result.summary.rowsDropped).toBe(0);
+    expect(result.summary.maxBlockSeen).toBe(0);
+    expect(result.summary.advanceReason).toBe("full-success-empty");
+    expect(result.summary.advancedTo).toBe(21_960_000);
+    expect(result.newLastBlock).toBe(21_960_000);
+  });
+
   it("resumes from canonical sync-state progress", async () => {
     const db = makeDb({
       syncRows: [{
@@ -775,7 +823,7 @@ describe("syncMintBurn", () => {
     vi.mocked(fetchAlchemyLogs)
       .mockResolvedValueOnce({
         logs: Array.from({ length: 70 }, (_, index) =>
-          makeMintLog({ txHash: `0xbridge-mint-${index}`, logIndex: index }),
+          makeMintLog({ blockNumber: 21_949_999, txHash: `0xbridge-mint-${index}`, logIndex: index }),
         ),
         complete: true,
         scannedToBlock: 22_000_000,
@@ -784,7 +832,7 @@ describe("syncMintBurn", () => {
       })
       .mockResolvedValueOnce({ logs: [], complete: true, scannedToBlock: 22_000_000, calls: 1, maxDepth: 0 })
       .mockResolvedValueOnce({ logs: [], complete: true, scannedToBlock: 22_000_000, calls: 1, maxDepth: 0 });
-    vi.mocked(resolveBlockTimestamps).mockResolvedValueOnce(new Map([[22_000_000, 1_718_650_752]]));
+    vi.mocked(resolveBlockTimestamps).mockResolvedValueOnce(new Map([[21_949_999, 1_718_650_752]]));
 
     const result = await syncMintBurn(db, "alchemy-key");
     const meta = JSON.parse(result.metadata);

--- a/worker/src/cron/mint-burn/run-configs.ts
+++ b/worker/src/cron/mint-burn/run-configs.ts
@@ -248,8 +248,10 @@ export async function runMintBurnConfigPhase(input: {
     bridgeClassificationDeferredRows += summary.bridgeClassificationDeferredRows;
 
     if (result.newLastBlock != null) {
-      await upsertMintBurnSyncState(input.db, key, result.newLastBlock, "replace");
-      input.lastBlocksAfterRun.set(key, result.newLastBlock);
+      const previousLastBlock = input.lastBlocksAfterRun.get(key) ?? (config.startBlock - 1);
+      const nextLastBlock = Math.max(previousLastBlock, result.newLastBlock);
+      await upsertMintBurnSyncState(input.db, key, nextLastBlock, "monotonic-max");
+      input.lastBlocksAfterRun.set(key, nextLastBlock);
     }
     input.budget.count += summary.requestBudgetUsed;
 

--- a/worker/src/cron/mint-burn/sync-config.ts
+++ b/worker/src/cron/mint-burn/sync-config.ts
@@ -332,7 +332,9 @@ export async function syncMintBurnConfig(input: SyncMintBurnConfigInput): Promis
     : allParsedRows;
 
   for (const row of persistableRows) {
-    summary.maxBlockSeen = Math.max(summary.maxBlockSeen, row.block_number);
+    if (row.block_number >= fromBlock && row.block_number <= scanTo) {
+      summary.maxBlockSeen = Math.max(summary.maxBlockSeen, row.block_number);
+    }
   }
   const persistResult = await persistMintBurnRows(db, persistableRows, affectedHours, { signal });
   summary.rowsInserted += persistResult.inserted;


### PR DESCRIPTION
### Motivation
- An RPC provider can return a syntactically valid log outside the requested scan range and, because parsed logs were not range-validated and the sync-state upsert used a replacing write, an attacker or faulty provider could move the stored `last_block` backwards and regress ingestion.
- The change restores the previous intent: advance the watermark only from provable, in-range signals and persist progress monotonically to avoid regressions while preserving the retry window behavior.

### Description
- Clamp event-derived watermark computation to logs inside the requested scan window by only considering parsed rows with `row.block_number >= fromBlock && row.block_number <= scanTo` when computing `summary.maxBlockSeen` (file: `worker/src/cron/mint-burn/sync-config.ts`).
- Persist run-phase sync state using monotonic semantics and ensure the in-memory watermark never regresses by writing `Math.max(previousLastBlock, result.newLastBlock)` with the `monotonic-max` mode and updating `input.lastBlocksAfterRun` accordingly (file: `worker/src/cron/mint-burn/run-configs.ts`).
- Add a targeted regression test that simulates a provider log below the requested range and verifies out-of-range logs cannot pull the watermark backwards, and adjust a bridge-budget fixture to keep its test data inside the expected range (file: `worker/src/cron/__tests__/sync-mint-burn.test.ts`).

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/__tests__/sync-mint-burn.test.ts --reporter=verbose`, and all tests in that file passed after the changes.
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which completed without errors.
- Verified the modified behavior by exercising the new regression test `ignores provider logs outside the requested scan range before advancing` which asserts that out-of-range provider logs do not update `summary.maxBlockSeen` or regress the persisted watermark.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47ccf0d56c8332b684ddf0b57ebeab)