### PR TITLE
Filter bucketed chart annotation event queries

### DIFF
--- a/src/hooks/__tests__/use-chart-annotations.test.tsx
+++ b/src/hooks/__tests__/use-chart-annotations.test.tsx
@@ -164,6 +164,9 @@ describe("useChartAnnotations", () => {
     const firstUrl = new URL(firstPath, "https://pharos.test");
     expect(firstUrl.searchParams.get("since")).toBe(String(bucketStart));
     expect(firstUrl.searchParams.get("until")).toBe(String(bucketStart + 30 * DAY_MS));
+    expect(firstUrl.searchParams.get("severityFloor")).toBe("warning");
+    expect(firstUrl.searchParams.getAll("type")).toEqual(["depeg.opened", "depeg.peak_worsened"]);
+    expect(firstUrl.searchParams.getAll("class")).toEqual(["methodology"]);
 
     rerender({ from: rawFrom + 60_000, to: rawTo + 60_000 });
 
@@ -171,6 +174,23 @@ describe("useChartAnnotations", () => {
     expect(JSON.stringify(secondCall?.[0])).toBe(firstKey);
     expect(secondCall?.[1]).toBe(firstPath);
     expect(result.current.data.map((a) => a.label)).toEqual(["Inside raw window"]);
+  });
+
+  it("pushes chart annotation relevance filters into the bucketed API request", () => {
+    isChartAnnotationsEnabledMock.mockReturnValue(true);
+    useApiQueryWithMetaMock.mockReturnValue({ data: undefined, isLoading: false });
+    getCuratedAnnotationsMock.mockReturnValue([]);
+
+    renderHook(() =>
+      useChartAnnotations("usdc-circle", Date.UTC(2023, 0, 1), Date.UTC(2023, 0, 2)),
+    );
+
+    const path = useApiQueryWithMetaMock.mock.calls.at(-1)?.[1] as string;
+    const url = new URL(path, "https://pharos.test");
+    expect(url.searchParams.get("severityFloor")).toBe("warning");
+    expect(url.searchParams.getAll("type")).toEqual(["depeg.opened", "depeg.peak_worsened"]);
+    expect(url.searchParams.getAll("class")).toEqual(["methodology"]);
+    expect(url.searchParams.get("limit")).toBe("200");
   });
 
   it("merges curated + tape sources and dedupes same-day same-kind (curated wins)", () => {

--- a/src/hooks/use-chart-annotations.ts
+++ b/src/hooks/use-chart-annotations.ts
@@ -52,6 +52,8 @@ type TapeEventsResponseBody = z.infer<typeof TapeEventsResponseBodySchema>;
 
 const TAPE_EVENTS_LIMIT = 200;
 const ANNOTATION_QUERY_BUCKET_MS = 30 * DAY_MS;
+const ANNOTATION_EVENT_TYPES = ["depeg.opened", "depeg.peak_worsened"] as const;
+const ANNOTATION_EVENT_CLASSES = ["methodology"] as const;
 
 function buildAnnotationQueryWindow(fromMs: number, toMs: number): { since: number; until: number } {
   return {
@@ -105,6 +107,27 @@ function isTapeSeverityWorthPlotting(s: TapeEvent["severity"]): boolean {
   return s === "warning" || s === "severe" || s === "critical";
 }
 
+function buildAnnotationEventsPath(
+  stablecoinId: string,
+  queryWindow: { since: number; until: number } | null,
+): string {
+  const params = new URLSearchParams({
+    coin: stablecoinId,
+    severityFloor: "warning",
+    limit: String(TAPE_EVENTS_LIMIT),
+  });
+
+  if (queryWindow) {
+    params.set("since", String(queryWindow.since));
+    params.set("until", String(queryWindow.until));
+  }
+
+  for (const type of ANNOTATION_EVENT_TYPES) params.append("type", type);
+  for (const eventClass of ANNOTATION_EVENT_CLASSES) params.append("class", eventClass);
+
+  return `${API_PATHS.events()}?${params.toString()}`;
+}
+
 export function useChartAnnotations(
   stablecoinId: string,
   fromMs: number | null | undefined,
@@ -119,12 +142,7 @@ export function useChartAnnotations(
   const queryWindow = enabled ? buildAnnotationQueryWindow(fromMs as number, toMs as number) : null;
 
   const path = enabled
-    ? API_PATHS.events({
-        coin: stablecoinId,
-        since: queryWindow?.since,
-        until: queryWindow?.until,
-        limit: TAPE_EVENTS_LIMIT,
-      })
+    ? buildAnnotationEventsPath(stablecoinId, queryWindow)
     : API_PATHS.events();
 
   const query = useApiQueryWithMeta<TapeEventsResponseBody>(


### PR DESCRIPTION
### Motivation
- The hook widened annotation fetches into 30-day buckets but did not push the chart-relevance filters to the Worker, causing the server-side 200-row cap to potentially exclude high-signal `warning`/`severe`/`critical` depeg or methodology events from the client display.

### Description
- Add `ANNOTATION_EVENT_TYPES` and `ANNOTATION_EVENT_CLASSES` constants to enumerate the event `type` and `class` filters used for chart overlays.
- Add `buildAnnotationEventsPath()` to construct the bucketed `/api/events` path including `severityFloor=warning`, `limit=200`, and the `type`/`class` query params so the Worker can apply filters before SQL `LIMIT`.
- Use `buildAnnotationEventsPath()` when annotations are enabled instead of calling `API_PATHS.events()` with only `coin/since/until/limit`.
- Extend `src/hooks/__tests__/use-chart-annotations.test.tsx` with focused assertions that the bucketed request includes `severityFloor`, the depeg event types, the `methodology` class, and the `limit` parameter.

### Testing
- Ran `npx vitest run src/hooks/__tests__/use-chart-annotations.test.tsx` and the file's test suite passed (13 tests passed).
- Ran `npm run typecheck` and TypeScript checks completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d3a1b7908332a4f6c2c6cd6e8a74)