### PR TITLE
fix(reserves): constrain Frax FPI name-only mappings

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/frax.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/frax.test.ts
@@ -268,6 +268,41 @@ describe("adaptFraxFpiCollateral", () => {
     );
   });
 
+  it("does not treat arbitrary name-only rows as trusted token symbols", () => {
+    const result = adaptFraxFpiCollateral({
+      ...FPI_COLLATERAL_SAMPLE,
+      assets: [
+        ...FPI_COLLATERAL_SAMPLE.assets!,
+        {
+          key: "asset:fpi_comptroller:spoofed_frax_name",
+          name: "FRAX",
+          valueUsd: 500_000,
+        },
+      ],
+    });
+
+    expect(result.metadata).toMatchObject({
+      unknownCollateralUsd: 500_000,
+      immediateRedeemableUsd: 5_000_000,
+    });
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "unknown-token",
+          message: expect.stringContaining("FRAX"),
+        }),
+      ]),
+    );
+    expect(result.slices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Unmapped Frax FPI collateral assets",
+          risk: "high",
+        }),
+      ]),
+    );
+  });
+
   it("maps stkcvxFPIFRAX by tokenSymbol", () => {
     const result = adaptFraxFpiCollateral({
       ...FPI_COLLATERAL_SAMPLE,

--- a/worker/src/cron/reserve-adapters/frax.ts
+++ b/worker/src/cron/reserve-adapters/frax.ts
@@ -73,10 +73,6 @@ const TOKEN_DISPLAY: Record<string, TokenDisplayConfig> = {
   ETH: { label: "ETH", risk: getCanonicalReserveAssetRisk("ETH") ?? "very-low" },
   FPI: { label: "FPI", risk: "medium" },
   FRAX: { label: "FRAX", risk: getCanonicalReserveAssetRisk("FRAX") ?? "low", coinId: "frax-frax" },
-  // FPI collateral rows for this LP report no tokenSymbol, only a `name` (see
-  // the tokenSymbol-or-name lookup in adaptFraxFpiCollateral); FPIS is FPI's
-  // own governance token, so this is rated like FXS rather than a stable pair.
-  "Fraxswap V2 FRAX/FPIS": { label: "Fraxswap V2 FRAX/FPIS", risk: "high" },
   FXS: { label: "FXS", risk: "high" },
   LFRAX: { label: "LFRAX", risk: "medium" },
   MULTI: { label: "MULTI", risk: "very-high" },
@@ -113,6 +109,15 @@ const TOKEN_DISPLAY: Record<string, TokenDisplayConfig> = {
   stkcvxFPIFRAX: { label: "stkcvxFPIFRAX (staked Convex FPI/FRAX LP)", risk: "medium" },
   wfrxETH: { label: "wfrxETH", risk: "medium" },
   ZZ: { label: "ZZ", risk: "very-high" },
+};
+
+// FPI collateral rows in this allowlist report no tokenSymbol, only a `name`.
+// Keep them separate from tokenSymbol mappings so arbitrary provider row names
+// cannot collide with trusted symbols such as FRAX, DAI, or USDC.
+const FPI_COLLATERAL_NAME_ONLY_DISPLAY: Record<string, TokenDisplayConfig> = {
+  // FPIS is FPI's own governance token, so this LP is rated like FXS rather
+  // than a stable pair.
+  "Fraxswap V2 FRAX/FPIS": { label: "Fraxswap V2 FRAX/FPIS", risk: "high" },
 };
 
 const SOURCE_TOTAL_RECONCILIATION_THRESHOLD_PCT = 0.5;
@@ -247,6 +252,18 @@ function describeFpiCollateralRow(row: FraxFpiCollateralRow): string {
   return row.key?.trim() || "unlabeled-row";
 }
 
+function getFpiCollateralMappingKey(row: FraxFpiCollateralRow): string | undefined {
+  const symbol = row.tokenSymbol?.trim();
+  if (symbol) return symbol;
+
+  const name = row.name?.trim();
+  return name && FPI_COLLATERAL_NAME_ONLY_DISPLAY[name] ? name : undefined;
+}
+
+function getFpiCollateralDisplayConfig(key: string): TokenDisplayConfig | undefined {
+  return TOKEN_DISPLAY[key] ?? FPI_COLLATERAL_NAME_ONLY_DISPLAY[key];
+}
+
 export function adaptFraxFpiCollateral(payload: FraxFpiCollateralResponse): AdapterResult {
   const assets = payload.assets;
   if (!assets?.length) {
@@ -267,10 +284,8 @@ export function adaptFraxFpiCollateral(payload: FraxFpiCollateralResponse): Adap
       continue;
     }
 
-    // Some collateral rows (e.g. LP positions) carry only a display `name`,
-    // no tokenSymbol, so fall back to matching TOKEN_DISPLAY by name.
-    const symbol = asset.tokenSymbol?.trim() || asset.name?.trim();
-    const config = symbol ? TOKEN_DISPLAY[symbol] : undefined;
+    const symbol = getFpiCollateralMappingKey(asset);
+    const config = symbol ? getFpiCollateralDisplayConfig(symbol) : undefined;
     if (symbol && config) {
       bySymbol.set(symbol, (bySymbol.get(symbol) ?? 0) + usd);
     } else {
@@ -300,7 +315,7 @@ export function adaptFraxFpiCollateral(payload: FraxFpiCollateralResponse): Adap
 
   const slices: ReserveSlice[] = [];
   for (const [symbol, usd] of bySymbol) {
-    const config = TOKEN_DISPLAY[symbol];
+    const config = getFpiCollateralDisplayConfig(symbol);
     if (!config) continue;
     slices.push({
       name: config.label,


### PR DESCRIPTION
### Motivation
- Prevent untrusted provider `name` values from colliding with trusted token symbols and misclassifying Frax FPI collateral risk or inflating redeemable capacity.
- Keep the special-case name-only LP row mapping for `Fraxswap V2 FRAX/FPIS` while restoring the previous safety posture where arbitrary name-only rows are treated as unknown.

### Description
- Removed the name-only `"Fraxswap V2 FRAX/FPIS"` entry from the generic `TOKEN_DISPLAY` map and introduced a narrow allowlist `FPI_COLLATERAL_NAME_ONLY_DISPLAY` for name-only FPI collateral rows. 
- Added `getFpiCollateralMappingKey()` to prefer `tokenSymbol` and only fall back to exact-match name-only entries from `FPI_COLLATERAL_NAME_ONLY_DISPLAY`.
- Added `getFpiCollateralDisplayConfig()` to resolve display config from `TOKEN_DISPLAY` or the new name-only allowlist and updated `adaptFraxFpiCollateral()` to use these helpers for mapping and slice construction.
- Added a regression test `does not treat arbitrary name-only rows as trusted token symbols` to verify a name-only `name: "FRAX"` row is treated as unknown collateral and does not increase `immediateRedeemableUsd` while the explicit `Fraxswap V2 FRAX/FPIS` name-only mapping still works.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/cron/reserve-adapters/__tests__/frax.test.ts` and all tests passed (20/20).
- Ran TypeScript checks: `cd worker && npx tsc --noEmit` and the type check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d63e9748332be296d42cc371b2b)