### PR TITLE
fix(depegs): isolate native-origin pending confirmations

### DIFF
--- a/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
+++ b/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
@@ -86,7 +86,7 @@ interface PendingRow {
   peak_seen_bps: number | null;
   peak_price: number | null;
   peg_reference: number;
-  reason?: "large-cap" | "low-confidence" | "extreme-move";
+  reason?: string;
   updated_at?: number | null;
 }
 
@@ -475,6 +475,57 @@ describe("confirmPendingDepegs", () => {
     expect(deletes).toEqual([22]);
     expect(outcome?.boundValues[15]).toBe("promoted");
     expect(outcome?.boundValues[21]).toBe("confirmed-by:native:brl");
+  });
+
+  it("keeps native-origin pending rows in native units and does not promote them from the same direct quote", async () => {
+    const nowSec = 1_700_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(nowSec * 1000);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(fetchCurrentNativePegQuotes).mockResolvedValue(new Map([
+      ["brz-transfero", {
+        stablecoinId: "brz-transfero",
+        geckoId: "brz",
+        pegCurrency: "BRL",
+        price: 0.9758,
+        updatedAt: nowSec - 60,
+      }],
+    ]));
+
+    await confirmPendingDepegs(
+      makeDb({
+        pendingRows: [
+          makePendingRow({
+            id: 23,
+            stablecoin_id: "brz-transfero",
+            symbol: "BRZ",
+            peg_type: "peggedREAL",
+            direction: "below",
+            first_seen_bps: -242,
+            first_seen_at: nowSec - DEPEG_PENDING_MIN_AGE_SEC - 60,
+            first_price: 0.9758,
+            peak_seen_bps: -242,
+            peak_price: 0.9758,
+            peg_reference: 1,
+            reason: "large-cap+native-origin",
+          }),
+        ],
+      }),
+      [
+        makeAuthoritativeUsdAsset(nowSec, {
+          id: "brz-transfero",
+          name: "Brazilian Digital",
+          symbol: "BRZ",
+          geckoId: "brz",
+          pegType: "peggedREAL",
+          price: 0.191187,
+        }),
+        ...makeNeutralUsdAssets(),
+      ],
+      { peggedREAL: 0.191895 },
+    );
+
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+    expect(batchExecute).not.toHaveBeenCalled();
   });
 
   it("promotes or rejects pending rows based on secondary-source agreement", async () => {

--- a/worker/src/cron/depeg-detection/__tests__/decision-engine.test.ts
+++ b/worker/src/cron/depeg-detection/__tests__/decision-engine.test.ts
@@ -367,7 +367,7 @@ describe("decideDepegAsset", () => {
         bps: -242,
         price: 0.9758,
         pegReference: 1,
-        reason: "large-cap",
+        reason: "large-cap+native-origin",
       },
     });
     expect(decision.diagnostics).toEqual([
@@ -414,7 +414,7 @@ describe("decideDepegAsset", () => {
         bps: -8000,
         price: 0.2,
         pegReference: 1,
-        reason: "extreme-move",
+        reason: "extreme-move+native-origin",
       },
     });
     expect(decision.diagnostics).toEqual([

--- a/worker/src/cron/depeg-detection/decision-engine.ts
+++ b/worker/src/cron/depeg-detection/decision-engine.ts
@@ -17,6 +17,7 @@ import {
   countDexProtocolCorroborations,
   dexPoolIndependentGroupKey,
   isExtremeMovePending,
+  markNativeOriginPending,
   type DepegRow,
   type DexPriceRow,
   type PendingDepegReason,
@@ -538,7 +539,7 @@ function decideNewNativePegDepeg(ctx: DecisionContext): Omit<DepegAssetDecision,
   if (ctx.nativeSignal.absBps >= DEPEG_EXTREME_MOVE_BPS) reasonFlags.push("extreme-move");
 
   if (reasonFlags.length > 0) {
-    const pendingReason = buildPendingReason(reasonFlags);
+    const pendingReason = markNativeOriginPending(buildPendingReason(reasonFlags));
     commands.push(buildPendingCommand(
       ctx.asset,
       ctx.now,

--- a/worker/src/cron/pending-depeg-confirmation-evidence.ts
+++ b/worker/src/cron/pending-depeg-confirmation-evidence.ts
@@ -11,6 +11,7 @@ import { recordOutcomeSafe } from "../lib/circuit-breaker";
 import {
   collectDexProtocolCorroborations,
   dexPoolIndependentGroupKey,
+  isNativeOriginPending,
 } from "../lib/depeg-helpers";
 import {
   chooseIndependentOffchainDepegConfirmer,
@@ -216,7 +217,8 @@ export async function collectConfirmationEvidence(
   };
 
   const geckoId = meta?.geckoId;
-  if (nativeSignal != null) {
+  const isNativeOrigin = isNativeOriginPending(pendingState.reason);
+  if (nativeSignal != null && !isNativeOrigin) {
     evidence.offchainStatus = classifyDirectionalSignal(nativeSignal, secondaryBar, pendingState.direction);
     evidence.offchainSourceKey = nativeSourceKey;
     if (evidence.offchainStatus === "confirm") {
@@ -231,7 +233,7 @@ export async function collectConfirmationEvidence(
       `price=${nativePegQuote?.price ?? "n/a"}, deviation=${nativeSignal.absBps}bps, ` +
       `bar=${secondaryBar}bps, status=${evidence.offchainStatus}`,
     );
-  } else if (geckoId) {
+  } else if (geckoId && !isNativeOrigin) {
     const result = await evaluateOffchainConfirmer({
       db,
       symbol: row.symbol,

--- a/worker/src/cron/pending-depeg-confirmation.ts
+++ b/worker/src/cron/pending-depeg-confirmation.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/constants";
 import {
   dexPoolIndependentGroupKey,
+  isNativeOriginPending,
   loadDexPoolChallengers,
   loadDexPriceRows,
   loadDexPriceSources,
@@ -345,8 +346,9 @@ export function buildConfirmationPlan(input: ConfirmationPlanInput): Confirmatio
     asset && meta && refreshedPegReferenceIsAuthoritative
       ? getPegReference(pegType, pegRates, meta.commodityOunces)
       : Number.NaN;
+  const isNativeOrigin = isNativeOriginPending(pendingState.reason);
   const pegReference =
-    Number.isFinite(refreshedPegRef) && refreshedPegRef > 0
+    !isNativeOrigin && Number.isFinite(refreshedPegRef) && refreshedPegRef > 0
       ? refreshedPegRef
       : row.peg_reference;
   const outcomeState: PendingDepegState = { ...pendingState, pegReference };
@@ -383,7 +385,7 @@ export function buildConfirmationPlan(input: ConfirmationPlanInput): Confirmatio
   const circuitOpenSources: string[] = [];
   const hardOpposingSources: string[] = [];
   const nativeSourceKey = buildNativeConfirmationKey(nativePegQuote?.pegCurrency ?? meta?.flags.pegCurrency);
-  if (nativeSignal != null) {
+  if (nativeSignal != null && !isNativeOrigin) {
     if (nativeSecondaryStatus === "confirm") addSource(confirmingSources, nativeSourceKey);
     if (isOpposingConfirmationStatus(nativeSecondaryStatus)) {
       addSource(opposingSources, nativeSourceKey);

--- a/worker/src/lib/depeg-helpers.ts
+++ b/worker/src/lib/depeg-helpers.ts
@@ -57,6 +57,7 @@ export interface DexPriceRow {
 }
 
 export type PendingDepegReasonFlag = "large-cap" | "low-confidence" | "extreme-move";
+export const NATIVE_ORIGIN_PENDING_REASON_FLAG = "native-origin";
 /**
  * Stored reason is a "+"-joined list of flags in canonical order:
  * extreme-move > large-cap > low-confidence.
@@ -84,6 +85,16 @@ export function parsePendingReason(reason: PendingDepegReason | null | undefined
 
 export function isExtremeMovePending(reason: PendingDepegReason | null | undefined): boolean {
   return parsePendingReason(reason).has("extreme-move");
+}
+
+export function markNativeOriginPending(reason: PendingDepegReason): PendingDepegReason {
+  return reason.split("+").includes(NATIVE_ORIGIN_PENDING_REASON_FLAG)
+    ? reason
+    : `${reason}+${NATIVE_ORIGIN_PENDING_REASON_FLAG}`;
+}
+
+export function isNativeOriginPending(reason: PendingDepegReason | null | undefined): boolean {
+  return reason?.split("+").includes(NATIVE_ORIGIN_PENDING_REASON_FLAG) ?? false;
 }
 
 export async function loadDexPriceRows(db: D1Database): Promise<Map<string, DexPriceRow>> {


### PR DESCRIPTION
### Motivation
- Prevent pending depeg rows created from direct native-fiat quotes from being promoted or converted using the same native/offchain quote that opened them, which can produce confirmed events that mix native-unit prices with refreshed USD/FX peg references.

### Description
- Add a `native-origin` pending flag and helper functions (`markNativeOriginPending`, `isNativeOriginPending`) in `worker/src/lib/depeg-helpers.ts` to mark and detect pending rows created from direct native quotes.
- Mark native-quote pending rows with the `native-origin` suffix when created in `worker/src/cron/depeg-detection/decision-engine.ts` so their origin is recorded alongside existing reason flags.
- Preserve the stored native-unit `peg_reference` for `native-origin` pending rows during confirmation by skipping the refreshed USD/FX peg reference override in `worker/src/cron/pending-depeg-confirmation.ts`.
- Prevent the same direct native/offchain quote path from acting as a confirming soft offchain source for `native-origin` pending rows by excluding native evidence when `isNativeOriginPending(pendingState.reason)` in `worker/src/cron/pending-depeg-confirmation-evidence.ts` and `worker/src/cron/pending-depeg-confirmation.ts`.
- Add focused regression tests to assert native-origin pending creation and to verify that such rows are not promoted by the same native quote in `worker/src/cron/depeg-detection/__tests__/decision-engine.test.ts` and `worker/src/cron/__tests__/confirm-pending-depegs.test.ts`.

### Testing
- Ran the targeted Vitest suites with `npx vitest run worker/src/cron/depeg-detection/__tests__/decision-engine.test.ts worker/src/cron/__tests__/confirm-pending-depegs.test.ts`, and all tests passed (`2 files, 53 tests` passed). 
- Type-checked the Worker code with `cd worker && npx tsc --noEmit`, which succeeded. 
- Verified cron scheduling and connection checks with `npm run check:cron-connections` and `npm run check:cron-sync`, which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d63c4ac8332817baa58438b5713)