### PR TITLE
fix(reserves): harden United PoR ripcord details

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/united-por.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/united-por.test.ts
@@ -112,6 +112,23 @@ describe("adaptUnitedPorPayload", () => {
     ]);
   });
 
+  it("treats missing or malformed ripcordDetails as undisclosed provider detail", () => {
+    const payload = { ...UNITED_POR_PAYLOAD, ripcord: true, ripcordDetails: null } as unknown as UnitedPorPayload;
+
+    const result = adaptUnitedPorPayload(payload, SLICE);
+
+    expect(result.metadata!.details).toMatchObject({ ripcord: true });
+    expect(result.metadata!.details).not.toHaveProperty("ripcordDetails");
+    expect(result.warnings).toEqual([
+      {
+        code: "united-por-ripcord",
+        message: "United Stables PoR reports a ripcord data-quality alarm: no further detail disclosed",
+        severity: "warning",
+        effect: "degraded",
+      },
+    ]);
+  });
+
   it("emits a coverage-shortfall degraded warning when reserves cover less than 99.5% of token supply", () => {
     const payload: UnitedPorPayload = {
       ...UNITED_POR_PAYLOAD,

--- a/worker/src/cron/reserve-adapters/united-por.ts
+++ b/worker/src/cron/reserve-adapters/united-por.ts
@@ -28,6 +28,12 @@ interface UnitedPorSliceConfig {
   depType?: ReserveSlice["depType"];
 }
 
+function normalizeRipcordDetails(details: unknown): string[] {
+  return Array.isArray(details)
+    ? details.filter((detail): detail is string => typeof detail === "string")
+    : [];
+}
+
 /**
  * Reads United Stables' public aggregate PoR payload
  * (`https://u.tech/u-client-api/v1/public/u/por`): `totalReserve` vs
@@ -57,6 +63,7 @@ export function adaptUnitedPorPayload(
   }
 
   const collateralizationRatio = totalReserveUsd / supplyUsd;
+  const ripcordDetails = normalizeRipcordDetails(payload.ripcordDetails);
 
   const warnings: LiveReserveWarning[] = buildCoverageShortfallWarnings({
     code: "united-por-reserve-under-token",
@@ -69,8 +76,8 @@ export function adaptUnitedPorPayload(
   // ripcord snapshot never scores as healthy, and carry the disclosed
   // details into the warning message rather than a bare boolean.
   if (payload.ripcord) {
-    const detail = payload.ripcordDetails.length > 0
-      ? payload.ripcordDetails.join("; ")
+    const detail = ripcordDetails.length > 0
+      ? ripcordDetails.join("; ")
       : "no further detail disclosed";
     warnings.push(
       reserveDegradedWarning(
@@ -96,7 +103,7 @@ export function adaptUnitedPorPayload(
       details: {
         accountName: payload.accountName,
         ripcord: payload.ripcord,
-        ...(payload.ripcordDetails.length > 0 ? { ripcordDetails: payload.ripcordDetails } : {}),
+        ...(ripcordDetails.length > 0 ? { ripcordDetails } : {}),
       },
     },
     ...(warnings.length > 0 ? { warnings } : {}),


### PR DESCRIPTION
### Motivation
- The United PoR adapter previously assumed provider JSON always included `ripcordDetails` as a string array and dereferenced array methods directly, which can throw a `TypeError` for missing, null, or otherwise malformed values and crash the scheduled reserve sync.

### Description
- Add `normalizeRipcordDetails(details: unknown): string[]` to coerce and filter `ripcordDetails` into a safe string array.
- Use the normalized `ripcordDetails` for the ripcord degraded warning message and when emitting metadata so malformed provider input is treated as undisclosed details instead of crashing.
- Add a regression test that supplies `ripcordDetails: null` and verifies the adapter still emits the degraded ripcord warning while omitting invalid detail metadata.

### Testing
- Ran `npx vitest run worker/src/cron/reserve-adapters/__tests__/united-por.test.ts` and all tests passed (11 tests).
- Ran `cd worker && npx tsc --noEmit` and TypeScript checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d63f6b483329aa6a61f27f9629b)