### PR TITLE
Fix news rail date labels after polling refreshes

### DIFF
--- a/src/components/__tests__/tape-for-coin-teaser.test.tsx
+++ b/src/components/__tests__/tape-for-coin-teaser.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { TapeEvent } from "@shared/types/tape-event";
+
+type LatestEventsResult = {
+  data: { events: TapeEvent[]; nextCursor: string | null; total: number | null; totalExact: boolean } | undefined;
+  dataUpdatedAt: number;
+  isLoading: boolean;
+  error: Error | null;
+  meta: null;
+};
+
+const useLatestEventsMock = vi.fn<() => LatestEventsResult>();
+
+vi.mock("@/hooks/use-events", () => ({
+  useLatestEvents: () => useLatestEventsMock(),
+}));
+
+import { TapeForCoinTeaser } from "@/components/tape-for-coin-teaser";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  useLatestEventsMock.mockReset();
+  mockLatestEvents();
+});
+
+function makeTapeEvent(overrides: Partial<TapeEvent> = {}): TapeEvent {
+  return {
+    id: "2026-07-08-depeg-opened",
+    type: "depeg.opened",
+    severity: "warning",
+    ts: Date.parse("2026-07-08T12:00:00Z"),
+    endsAt: null,
+    coinId: "usdc-circle",
+    issuerId: null,
+    pegCurrency: "USD",
+    chain: null,
+    title: "USDC depeg opened (-500 bps)",
+    summary: "USDC drifted to -500 bps versus its USD peg.",
+    payload: {},
+    sourceTable: "depeg_events",
+    sourceRowId: "1",
+    transition: "opened",
+    sourceUrl: "/stablecoin/usdc-circle/#peg-history",
+    methodologyVersion: null,
+    ...overrides,
+  };
+}
+
+function mockLatestEvents(overrides: Partial<LatestEventsResult> = {}) {
+  useLatestEventsMock.mockReturnValue({
+    data: { events: [], nextCursor: null, total: null, totalExact: false },
+    dataUpdatedAt: 0,
+    isLoading: false,
+    error: null,
+    meta: null,
+    ...overrides,
+  });
+}
+
+describe("TapeForCoinTeaser", () => {
+  it("refreshes date labels when polling updates event data after UTC midnight", async () => {
+    const event = makeTapeEvent();
+
+    mockLatestEvents({
+      data: { events: [event], nextCursor: null, total: null, totalExact: false },
+      dataUpdatedAt: Date.parse("2026-07-08T23:50:00Z"),
+    });
+
+    const { rerender } = render(<TapeForCoinTeaser coinId="usdc-circle" />);
+    await waitFor(() => {
+      expect(screen.getByText("Today")).toBeTruthy();
+    });
+
+    mockLatestEvents({
+      data: { events: [event], nextCursor: null, total: null, totalExact: false },
+      dataUpdatedAt: Date.parse("2026-07-09T00:10:00Z"),
+    });
+
+    rerender(<TapeForCoinTeaser coinId="usdc-circle" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeTruthy();
+    });
+    expect(screen.queryByText("Today")).toBeNull();
+  });
+});

--- a/src/components/tape-for-coin-teaser.tsx
+++ b/src/components/tape-for-coin-teaser.tsx
@@ -165,11 +165,13 @@ function NewsEntry({ event, nowMs }: { event: TapeEvent; nowMs: number }) {
 }
 
 export function TapeForCoinTeaser({ coinId }: TapeForCoinTeaserProps) {
-  const { data, isLoading } = useLatestEvents({ coin: coinId, limit: 5 });
+  const { data, dataUpdatedAt, isLoading } = useLatestEvents({ coin: coinId, limit: 5 });
   const events = data?.events ?? [];
-  // Lazy initializer keeps the render pure (react-hooks/purity); freshness
-  // labels only need mount-time "now", matching safety-score-history-section.
+  // Lazy initializer keeps the render pure (react-hooks/purity). TanStack Query
+  // refreshes dataUpdatedAt after successful polling refetches, so keep labels
+  // tied to the latest event payload instead of freezing at mount time.
   const [nowMs] = useState(() => Date.now());
+  const labelNowMs = dataUpdatedAt > 0 ? dataUpdatedAt : nowMs;
 
   if (!isLoading && events.length === 0) {
     return null;
@@ -192,7 +194,7 @@ export function TapeForCoinTeaser({ coinId }: TapeForCoinTeaserProps) {
       ) : (
         <div className="divide-y divide-border/40">
           {events.map((event) => (
-            <NewsEntry key={event.id} event={event} nowMs={nowMs} />
+            <NewsEntry key={event.id} event={event} nowMs={labelNowMs} />
           ))}
         </div>
       )}


### PR DESCRIPTION
### Motivation

- The News rail froze its notion of “now” at mount time using a lazy `Date.now()` initializer, causing Today/Yesterday labels to remain stale across UTC day boundaries while the events query polled and refetched.

### Description

- Use `dataUpdatedAt` from `useLatestEvents` as the label clock when it is available and fall back to the lazy `Date.now()` initializer for render purity.
- Compute `labelNowMs = dataUpdatedAt > 0 ? dataUpdatedAt : nowMs` and pass `labelNowMs` into `NewsEntry` instead of the mount-time `nowMs` in `TapeForCoinTeaser` (`src/components/tape-for-coin-teaser.tsx`).
- Preserve the lazy initializer to keep renders pure and avoid triggering the `react-hooks/purity` lint rule.
- Add a regression test `src/components/__tests__/tape-for-coin-teaser.test.tsx` that simulates a polling refresh crossing a UTC midnight boundary to assert labels update from `Today` to `Yesterday`.

### Testing

- Ran `npx vitest run src/components/__tests__/tape-for-coin-teaser.test.tsx` and the test passed.
- Ran `npx eslint src/components/tape-for-coin-teaser.tsx src/components/__tests__/tape-for-coin-teaser.test.tsx --max-warnings=0` and lint passed.
- Ran `npm run typecheck` and TypeScript checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d66b9348332a5e76788e9e6c061)