### PR TITLE
fix(skills): link Claude subagent references

### DIFF
--- a/.claude/skills/pharos-ci-failure-triage/references
+++ b/.claude/skills/pharos-ci-failure-triage/references
@@ -1,0 +1,1 @@
+../../../.codex/skills/pharos-ci-failure-triage/references

--- a/.claude/skills/pharos-docs-sync-audit/references
+++ b/.claude/skills/pharos-docs-sync-audit/references
@@ -1,0 +1,1 @@
+../../../.codex/skills/pharos-docs-sync-audit/references

--- a/.claude/skills/pharos-release-runner/references
+++ b/.claude/skills/pharos-release-runner/references
@@ -1,0 +1,1 @@
+../../../.codex/skills/pharos-release-runner/references


### PR DESCRIPTION
### Motivation
- Recent exposure of `.codex` skills to Claude created `.claude` symlinks for `SKILL.md` but omitted the companion `references` directories, causing runtime failures when skill bodies asked for `references/subagents.md`.
- The change restores reliable agent-local resolution so Claude Code can load the same subagent templates the Codex skills reference.

### Description
- Add `.claude/skills/pharos-release-runner/references` symlink pointing at `../../../.codex/skills/pharos-release-runner/references` to restore `references/subagents.md` resolution.
- Add `.claude/skills/pharos-ci-failure-triage/references` symlink pointing at `../../../.codex/skills/pharos-ci-failure-triage/references` to restore `references/subagents.md` resolution.
- Add `.claude/skills/pharos-docs-sync-audit/references` symlink pointing at `../../../.codex/skills/pharos-docs-sync-audit/references` to restore `references/subagents.md` resolution.

### Testing
- Ran `npm run -s check:agent-skill-symlinks` and the symlink check passed.
- Verified each Claude-side path with a `node` `fs.statSync` script that confirmed `.claude/skills/*/references/subagents.md` exists and is a file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500d63c1a883329709566cb53ef4ce)