### PR TITLE
fix(worker): gate reserve fault injection admin route

### DIFF
--- a/worker/src/api/__tests__/router-contract.test.ts
+++ b/worker/src/api/__tests__/router-contract.test.ts
@@ -225,6 +225,22 @@ describe("router contract: strict frontend paths are routable", () => {
     }
   });
 
+  it("requires the admin mutation header for reserve recovery fault injection", async () => {
+    const path = "https://stablecoin-api.preview.workers.dev/api/admin/reserve-recovery-fault-injection";
+    const response = await route(makeRouteCtx({
+      url: new URL(path),
+      request: new Request(path, { method: "POST" }),
+      trustedAdmin: true,
+      workerVersion: "preview-v1",
+    }));
+
+    expect(response).not.toBeNull();
+    expect(response!.status).toBe(403);
+    await expect(response!.json()).resolves.toEqual({
+      error: "Missing required X-Pharos-Admin header; refusing mutation.",
+    });
+  });
+
   it("keeps the dynamic discovery dismiss route aligned with shared admin method/auth rules", async () => {
     const postPath = "https://api.pharos.watch/api/discovery-candidates/42/dismiss";
     const postResult = await route(makeRouteCtx({

--- a/worker/src/routes/admin-routes.ts
+++ b/worker/src/routes/admin-routes.ts
@@ -21,7 +21,7 @@ import { handleAdminTelegramBroadcast } from "../api/admin-telegram-broadcast";
 import { handleAlertBrokerCanary } from "../api/admin-alert-broker-canary";
 import { handleStatusProbeHistory } from "../api/status-probe-history";
 import { handleArmReserveRecoveryFaultInjection } from "../api/admin-reserve-recovery-fault-injection";
-import { makeConditionalIdempotentAdminRoute, makeIdempotentAdminRoute } from "../lib/route-wrappers";
+import { makeAdminRoute, makeConditionalIdempotentAdminRoute, makeIdempotentAdminRoute } from "../lib/route-wrappers";
 import { defineStaticRoute, type StaticRouteDefinition, type StaticRouteHandler } from "./shared";
 import type { EndpointKey } from "@shared/lib/api-endpoints";
 
@@ -84,8 +84,12 @@ export const ADMIN_STATIC_ROUTES = [
   defineStaticRoute("reset-cron-lease", handleResetCronLease),
   defineStaticRoute("reset-circuit-breaker", handleResetCircuitBreaker),
   defineStaticRoute("kill-cron-in-flight", handleKillCronInFlight),
-  defineStaticRoute("reserve-recovery-fault-injection", ({ db, request, trustedAdmin, workerVersion }) =>
-    handleArmReserveRecoveryFaultInjection(db, request, trustedAdmin, workerVersion)),
+  defineStaticRoute(
+    "reserve-recovery-fault-injection",
+    makeAdminRoute("reserve-recovery-fault-injection", ({ db, request, trustedAdmin, workerVersion }) =>
+      handleArmReserveRecoveryFaultInjection(db, request, trustedAdmin, workerVersion),
+    ),
+  ),
   defineStaticRoute("bulk-dismiss-discovery-candidates", handleBulkDismissDiscoveryCandidates),
   defineStaticRoute("clear-telegram-pending", handleClearTelegramPending),
   defineConditionalIdempotentAdminRoute(


### PR DESCRIPTION
### Motivation
- The `reserve-recovery-fault-injection` admin endpoint was exposed as a bare static route and could be exercised without the project-wide `X-Pharos-Admin` mutation header, weakening the CSRF defense for mutating admin requests.

### Description
- Wrap `reserve-recovery-fault-injection` with `makeAdminRoute(...)` in `worker/src/routes/admin-routes.ts` so `runAdminRoute` enforces the `X-Pharos-Admin` mutation gate before the handler runs.
- Add a router contract regression test in `worker/src/api/__tests__/router-contract.test.ts` that verifies a trusted preview `POST` without `X-Pharos-Admin` is rejected with `403`.

### Testing
- Ran typecheck with `npm run typecheck:worker` and it completed successfully.
- Ran the focused Vitest suites with `npx vitest run worker/src/api/__tests__/router-contract.test.ts worker/src/api/__tests__/admin-reserve-recovery-fault-injection.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50d5294f68833292be92b06af42ab4)