### PR TITLE
Fix detail cache generation claim timing

### DIFF
--- a/worker/src/api/__tests__/stablecoin-detail.test.ts
+++ b/worker/src/api/__tests__/stablecoin-detail.test.ts
@@ -441,6 +441,19 @@ describe("handleStablecoinDetail", () => {
     expect(detailWrite?.sql).toContain("generation = ?");
   });
 
+  it("does not claim a detail cache generation before a fresh body is ready", async () => {
+    const db = mockD1([{ match: "cache", rows: [] }]);
+
+    fetchSpy.mockResolvedValueOnce(new Response("upstream unavailable", { status: 503 }));
+
+    const ctx = makeCtx();
+    const res = await handleStablecoinDetail(db, "usdt-tether", ctx);
+
+    expect(res.status).toBe(502);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(db.getHistory().some((entry) => entry.sql.includes("RETURNING generation"))).toBe(false);
+  });
+
   it("passes the CoinGecko API key through the commodity detail path", async () => {
     const db = mockD1([{ match: "cache", rows: [] }]);
 

--- a/worker/src/api/stablecoin-detail/shared.ts
+++ b/worker/src/api/stablecoin-detail/shared.ts
@@ -4,12 +4,7 @@ import { DAY_SECONDS } from "@shared/lib/time-constants";
 import { CACHE_PROFILES, DETAIL_WRITE_FAILURE_KEY_PREFIX } from "../../lib/constants";
 import { binarySearchNearest } from "../../lib/binary-search";
 import { errorResponse } from "../../lib/api-utils";
-import {
-  claimDetailCacheGeneration,
-  publishDetailCacheGeneration,
-  type DetailCacheGenerationClaim,
-} from "../../lib/detail-cache-generation";
-import { toErrorMessage } from "../../lib/error-utils";
+import { claimDetailCacheGeneration, publishDetailCacheGeneration } from "../../lib/detail-cache-generation";
 import { logWorkerEvent } from "../../lib/structured-log";
 
 export const CACHE_TTL_SECONDS = PER_COIN_CACHE_TTL_SECONDS;
@@ -123,14 +118,6 @@ export function createDetailResponseHelpers(config: {
   execCtx: ExecutionContext;
 }): DetailResponseHelpers {
   const cacheKey = `detail:${config.stablecoinId}`;
-  const requestStartedAtMs = Date.now();
-  const generationClaim = claimDetailCacheGeneration(config.db, config.stablecoinId, {
-    claimedAtMs: requestStartedAtMs,
-  }).then(
-    (claim) => ({ claim, error: null as string | null }),
-    (error) => ({ claim: null as DetailCacheGenerationClaim | null, error: toErrorMessage(error) }),
-  );
-
   // Failed/oversized cache writes used to vanish into sampled console logs,
   // leaving flagship coins on a synchronous-refetch-per-request path for
   // weeks. A small marker row makes the failure visible to the staleness
@@ -159,11 +146,8 @@ export function createDetailResponseHelpers(config: {
           return;
         }
         try {
-          const claimed = await generationClaim;
-          if (!claimed.claim) {
-            throw new Error(claimed.error ?? "detail cache generation claim failed");
-          }
-          const write = await publishDetailCacheGeneration(config.db, cacheKey, body, claimed.claim);
+          const claim = await claimDetailCacheGeneration(config.db, config.stablecoinId);
+          const write = await publishDetailCacheGeneration(config.db, cacheKey, body, claim);
           if (!write.written) {
             logWorkerEvent({
               scope: "api",


### PR DESCRIPTION
### Motivation
- Prevent a timing vulnerability where refreshes claimed cache publication generations before a successful upstream response, allowing newer (possibly failing) refreshes to block older successful writers and cause cache starvation.
- Preserve existing publication fencing semantics while ensuring only a refresh that has a ready, size-checked body reserves a generation owner.

### Description
- Remove the eager `generationClaim` created when `createDetailResponseHelpers` is constructed and instead call `claimDetailCacheGeneration` only when a cacheable body is ready inside the background `queueCacheWrite` task.
- Keep the existing `publishDetailCacheGeneration` fencing logic intact so writes still validate owner/generation at publish time.
- Add a regression test asserting that an upstream failure does not call `ctx.waitUntil` and does not perform a generation claim before a cacheable body exists (`worker/src/api/__tests__/stablecoin-detail.test.ts`).

### Testing
- Ran unit tests: `npx vitest run worker/src/api/__tests__/stablecoin-detail.test.ts worker/src/lib/__tests__/detail-cache-generation.test.ts`, both files passed (all tests succeeded).
- Ran worker typecheck: `npm run typecheck:worker`, which completed without errors.
- Existing detail-cache generation fencing test (`worker/src/lib/__tests__/detail-cache-generation.test.ts`) still passes and validates publish-time owner checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc4ed9483329275babddfe853fd)