### PR TITLE
fix(worker): restore TronGrid block timestamp filters

### DIFF
--- a/worker/src/cron/blacklist/__tests__/tron-source.test.ts
+++ b/worker/src/cron/blacklist/__tests__/tron-source.test.ts
@@ -197,8 +197,8 @@ describe("fetchTronEventsIncremental cursor safety", () => {
     await fetchTronEventsIncremental(config, null, lastTimestampMs, makeRunBudget(), noopLimiter);
 
     const requested = new URL(String(vi.mocked(fetch).mock.calls[0]?.[0]));
-    expect(requested.searchParams.get("min_timestamp")).toBe(String(lastTimestampMs));
-    expect(Number(requested.searchParams.get("max_timestamp"))).toBeLessThanOrEqual(Date.now() - 15 * 60_000);
+    expect(requested.searchParams.get("min_block_timestamp")).toBe(String(lastTimestampMs));
+    expect(Number(requested.searchParams.get("max_block_timestamp"))).toBeLessThanOrEqual(Date.now() - 15 * 60_000);
     expect(requested.searchParams.get("only_confirmed")).toBe("true");
   });
 

--- a/worker/src/cron/blacklist/tron-source.ts
+++ b/worker/src/cron/blacklist/tron-source.ts
@@ -79,8 +79,8 @@ function buildTronEventsUrl(args: {
   url.searchParams.set("limit", "200");
   url.searchParams.set("order_by", "block_timestamp,asc");
   url.searchParams.set("only_confirmed", "true");
-  if (args.lastTimestampMs > 0) url.searchParams.set("min_timestamp", String(args.lastTimestampMs));
-  url.searchParams.set("max_timestamp", String(args.safeHead));
+  if (args.lastTimestampMs > 0) url.searchParams.set("min_block_timestamp", String(args.lastTimestampMs));
+  url.searchParams.set("max_block_timestamp", String(args.safeHead));
   if (args.fingerprint) url.searchParams.set("fingerprint", args.fingerprint);
   return url.toString();
 }


### PR DESCRIPTION
### Motivation
- Fix a regression where the TronGrid contract events query used `min_timestamp`/`max_timestamp` (unsupported by TronGrid) which could cause unbounded scans, stale blacklist data, or incorrect cursor advancement.

### Description
- Replace the query parameters in `buildTronEventsUrl` to use `min_block_timestamp` and `max_block_timestamp` and update the focused unit test to assert the provider-supported parameter names in `worker/src/cron/blacklist/tron-source.ts` and `worker/src/cron/blacklist/__tests__/tron-source.test.ts`.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/blacklist/__tests__/tron-source.test.ts` and all tests passed.
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc399848332bbc6d2300e5bdcc3)