### PR TITLE
fix(worker): ignore TOML comments in Wrangler route guard

### DIFF
--- a/scripts/__tests__/check-worker-wrangler-config.test.ts
+++ b/scripts/__tests__/check-worker-wrangler-config.test.ts
@@ -60,4 +60,29 @@ routes = [{ pattern = "api.pharos.watch", custom_domain = true }]
     expect(report.issues).toContain("Route preview.pharos.watch must set custom_domain = true.");
     expect(report.issues.some((issue) => issue.startsWith("Root custom domains must be exactly"))).toBe(true);
   });
+
+  it("rejects route entries that only appear in TOML comments", () => {
+    const report = evaluateWorkerWranglerConfig(`
+routes = [
+  # { pattern = "api.pharos.watch", custom_domain = true },
+  # { pattern = "site-api.pharos.watch", custom_domain = true },
+  # { pattern = "ops-api.pharos.watch", custom_domain = true }
+]
+
+[[rules]]
+type = "Data"
+globs = ["**/*.ttf"]
+fallthrough = true
+
+[[rules]]
+type = "CompiledWasm"
+globs = ["**/*.wasm"]
+fallthrough = true
+`);
+
+    expect(report.failed).toBe(true);
+    expect(report.issues).toContain(
+      "Root custom domains must be exactly api.pharos.watch, ops-api.pharos.watch, site-api.pharos.watch; found none.",
+    );
+  });
 });

--- a/scripts/ci/check-worker-wrangler-config.ts
+++ b/scripts/ci/check-worker-wrangler-config.ts
@@ -16,6 +16,32 @@ export interface WorkerWranglerConfigReport {
   issues: string[];
 }
 
+function stripTomlComment(line: string): string {
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (character === "\"") {
+      inString = !inString;
+      continue;
+    }
+    if (!inString && character === "#") {
+      return line.slice(0, index);
+    }
+  }
+
+  return line;
+}
+
 function countBracketDelta(value: string): number {
   let delta = 0;
   let inString = false;
@@ -47,7 +73,8 @@ function parseAssignments(toml: string): TomlAssignment[] {
   let section = "root";
 
   for (let index = 0; index < lines.length; index += 1) {
-    const trimmed = lines[index].trim();
+    const uncommented = stripTomlComment(lines[index]);
+    const trimmed = uncommented.trim();
     const arrayTable = trimmed.startsWith("[[");
     const tableStart = arrayTable ? 2 : trimmed.startsWith("[") ? 1 : 0;
     const tableTerminator = arrayTable ? "]]" : "]";
@@ -63,11 +90,13 @@ function parseAssignments(toml: string): TomlAssignment[] {
 
     const [, key] = assignmentMatch;
     let value = assignmentMatch[2];
+    value = stripTomlComment(value).trim();
     let bracketDepth = countBracketDelta(value);
     while (bracketDepth > 0 && index + 1 < lines.length) {
       index += 1;
-      value += `\n${lines[index].trim()}`;
-      bracketDepth += countBracketDelta(lines[index]);
+      const nextLine = stripTomlComment(lines[index]);
+      value += `\n${nextLine.trim()}`;
+      bracketDepth += countBracketDelta(nextLine);
     }
     assignments.push({ key, section, value });
   }


### PR DESCRIPTION
### Motivation
- The Wrangler config checker was accumulating multiline TOML assignment text verbatim and then extracting route inline tables with a raw regex, which allowed commented-out route objects to be treated as real routes and weakened the CI guardrail.

### Description
- Add `stripTomlComment()` to remove TOML `#` comments while respecting quoted strings and use it when scanning lines and accumulating multiline assignment values so comments cannot contribute route objects.
- Trim and count brackets on uncommented text during multiline value accumulation so bracket depth logic ignores commented content.
- Add a regression test that supplies a `routes = [ ... ]` array containing only commented route objects and asserts the checker rejects the configuration.
- Changes applied to `scripts/ci/check-worker-wrangler-config.ts` and `scripts/__tests__/check-worker-wrangler-config.test.ts`.

### Testing
- Ran the unit tests with `npm run test -- scripts/__tests__/check-worker-wrangler-config.test.ts` and the test suite passed.
- Executed the guard script with `npm run check:worker-config` and it reported the expected pass/fail results for the covered scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc5030c83329e1080bb211c1da2)