### PR TITLE
fix(worker): guard malformed report-card score entries

### DIFF
--- a/worker/src/lib/__tests__/report-card-cache.test.ts
+++ b/worker/src/lib/__tests__/report-card-cache.test.ts
@@ -293,6 +293,19 @@ describe("loadReportCardCache", () => {
 
     expect(result).toMatchObject({ kind: "error", reason: "completeness-mismatch" });
   });
+
+  it("rejects malformed score entries without throwing for completeness checks", async () => {
+    const payload = JSON.parse(exactCachePayload()) as {
+      scores: Record<string, unknown>;
+    };
+    payload.scores[[...ACTIVE_IDS][0]] = null;
+
+    const result = await loadReportCardCache(makeReportCardDb(JSON.stringify(payload)), {
+      requireCompleteness: true,
+    });
+
+    expect(result).toMatchObject({ kind: "error", reason: "completeness-mismatch" });
+  });
 });
 
 describe("writeReportCardCache", () => {

--- a/worker/src/lib/report-card-cache.ts
+++ b/worker/src/lib/report-card-cache.ts
@@ -91,6 +91,14 @@ function isValidCompleteness(value: unknown): value is ReportCardPublicationComp
     && value.expectedCount === value.scoredCount + value.notRatedCount;
 }
 
+function isValidReportCardScoreEntry(value: unknown): value is ReportCardScoreEntry {
+  return isRecord(value)
+    && typeof value.score === "number"
+    && Number.isFinite(value.score)
+    && typeof value.grade === "string"
+    && value.grade.length > 0;
+}
+
 function isValidReportCardCachePayload(value: unknown): value is ParsedReportCardCachePayload {
   if (!isRecord(value)) return false;
   const parsed = value as {
@@ -170,10 +178,7 @@ function hasExactReportCardCacheCompleteness(payload: ReportCardCachePayload): b
   for (const [id, score] of Object.entries(payload.scores)) {
     if (
       notRatedIdSet.has(id)
-      || typeof score.score !== "number"
-      || !Number.isFinite(score.score)
-      || typeof score.grade !== "string"
-      || score.grade.length === 0
+      || !isValidReportCardScoreEntry(score)
     ) {
       return false;
     }


### PR DESCRIPTION
### Motivation
- Completeness validation for publication-sensitive report-card cache consumers could dereference malformed `scores` entries (e.g. `null`) and throw a `TypeError`, causing availability/robustness failures instead of returning a structured `completeness-mismatch` error.

### Description
- Add `isValidReportCardScoreEntry` to `worker/src/lib/report-card-cache.ts` to validate each cached score is a non-null record with a finite numeric `score` and a non-empty string `grade`.
- Use the new guard inside `hasExactReportCardCacheCompleteness` before reading `score.score`/`score.grade` so malformed entries fail closed.
- Add a regression test in `worker/src/lib/__tests__/report-card-cache.test.ts` that inserts a `null` score entry and verifies `loadReportCardCache(..., { requireCompleteness: true })` returns `completeness-mismatch` instead of throwing.

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/report-card-cache.test.ts`, and all tests passed (`14 passed`).
- Ran `cd worker && npx tsc --noEmit`, and TypeScript check succeeded.
- Ran `git diff --check` to ensure no whitespace/git issues, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc4f2d4833285ef673bbc2d2ad2)