### PR TITLE
fix(blacklist): verify replay balance provenance

### DIFF
--- a/worker/scripts/__tests__/reconcile-night-watch-blacklist.test.ts
+++ b/worker/scripts/__tests__/reconcile-night-watch-blacklist.test.ts
@@ -23,13 +23,16 @@ function amountNative(event: FrozenManifestEvent): number | null {
   return event.amountRaw == null ? null : Number(BigInt(event.amountRaw)) / 1_000_000;
 }
 
-function balanceProjection(events: readonly FrozenManifestEvent[]): Map<string, number> {
+function balanceProjection(events: readonly FrozenManifestEvent[]): Map<string, { amount: number; source: string }> {
   const latest = new Map<string, FrozenManifestEvent>();
   for (const event of events) latest.set(event.address, event);
-  const balances = new Map<string, number>();
+  const balances = new Map<string, { amount: number; source: string }>();
   for (const event of latest.values()) {
     if (event.eventType === "unblacklist") continue;
-    balances.set(event.address, event.eventType === "destroy" ? amountNative(event)! : 1);
+    balances.set(event.address, {
+      amount: event.eventType === "destroy" ? amountNative(event)! : 1,
+      source: event.eventType === "destroy" ? "destroy_event" : "reconciliation_current_balance",
+    });
   }
   return balances;
 }
@@ -69,10 +72,11 @@ function makeD1(initiallyApplied = false): {
         );
         return [...balances]
           .filter(([address]) => requestedAddresses.has(address.toLowerCase()))
-          .map(([address, amount]) => ({
+          .map(([address, balance]) => ({
             address,
-            amount_native: amount,
-            source: "reconciliation_current_balance",
+            amount_native: balance.amount,
+            amount_usd: balance.amount,
+            source: balance.source,
             config_key: frozenManifest.configKey,
             contract_address: frozenManifest.contractAddress,
           })) as T[];
@@ -307,6 +311,28 @@ describe("Night Watch blacklist reconciliation", () => {
     expect(summary.status).toBe("failed");
     expect(summary.balanceReplayMatchingCount).toBeLessThan(summary.balanceReplayExpectedCount);
     expect(summary.unresolvedManifestGapCount).toBeGreaterThan(0);
+    expect(summary.samples.balanceMismatches).not.toEqual([]);
+  });
+
+  it("requires exact amount USD and source for balance replay parity", async () => {
+    const fixture = makeD1();
+    const originalQuery = fixture.d1.query;
+    fixture.d1.query = (<T>(sql: string): T[] => {
+      const rows = originalQuery<T>(sql);
+      if (sql.includes("FROM blacklist_current_balances") && fixture.executeStatements.mock.calls.length > 0) {
+        const balances = rows as Array<Record<string, unknown>>;
+        if (balances[0]) {
+          balances[0].amount_usd = 999;
+          balances[0].source = "destroy_event";
+        }
+      }
+      return rows;
+    }) as RemoteD1Client["query"];
+
+    const summary = await runNightWatchBlacklistReconciliation(options(true), dependencies(fixture.d1));
+
+    expect(summary.status).toBe("failed");
+    expect(summary.balanceReplayMatchingCount).toBeLessThan(summary.balanceReplayExpectedCount);
     expect(summary.samples.balanceMismatches).not.toEqual([]);
   });
 

--- a/worker/scripts/reconcile-night-watch-blacklist.ts
+++ b/worker/scripts/reconcile-night-watch-blacklist.ts
@@ -107,6 +107,7 @@ type CursorRow = {
 type StoredBalance = {
   address: string;
   amount_native: number | null;
+  amount_usd: number | null;
   source: string;
   config_key: string | null;
   contract_address: string | null;
@@ -608,7 +609,7 @@ function loadStoredBalances(d1: RemoteD1Client, addresses: readonly string[]): S
     const chunk = addresses.slice(index, index + 80).map((address) => address.toLowerCase());
     rows.push(
       ...d1.query<StoredBalance>(
-        `SELECT address, amount_native, source, config_key, contract_address
+        `SELECT address, amount_native, amount_usd, source, config_key, contract_address
        FROM blacklist_current_balances
        WHERE stablecoin = 'USDT' AND chain_id = 'tron'
          AND LOWER(address) IN (${quotedList(chunk)})`,
@@ -636,7 +637,10 @@ function verifyBalances(
     if (
       rows.length !== 1
       || rows[0]!.amount_native == null
+      || rows[0]!.amount_usd == null
       || Math.abs(rows[0]!.amount_native - expectation.amountNative) >= 0.0000005
+      || Math.abs(rows[0]!.amount_usd - expectation.amountNative) >= 0.0000005
+      || rows[0]!.source !== expectation.source
     ) {
       mismatches.push(expectation.address);
     }


### PR DESCRIPTION
### Motivation
- The reconciliation upsert preserves rows when `observed_at`/`last_attempted_at` tie but `amount_usd` or `source` differ, however the verifier only compared `amount_native` and identity which could mark a run as verified while USD amount or provenance remained incorrect.

### Description
- Load `amount_usd` into `StoredBalance` and select it from `blacklist_current_balances` in `loadStoredBalances` so verifier can inspect USD values.  
- Extend `verifyBalances` to require `amount_usd` and `source` to match the expected replay values in addition to `amount_native` and manifest identity.  
- Update the reconciliation test fixture to include `amount_usd` and `source` in mocked current balances and add a regression test that a mismatched USD/source causes replay parity to fail.  
- Files changed: `worker/scripts/reconcile-night-watch-blacklist.ts` and `worker/scripts/__tests__/reconcile-night-watch-blacklist.test.ts`.

### Testing
- Ran the focused test suite with `npm test -- --run worker/scripts/__tests__/reconcile-night-watch-blacklist.test.ts` and all tests passed.  
- Ran TypeScript checks with `cd worker && npx tsc --noEmit` and the build check succeeded.  
- Local SQLite-backed migration/assertion steps used by the tests completed successfully during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc62dfc8332936384ad4d080786)