### PR TITLE
Fix no-sidecar stablecoin catalog validation

### DIFF
--- a/scripts/__tests__/stablecoin-catalog-sources.test.ts
+++ b/scripts/__tests__/stablecoin-catalog-sources.test.ts
@@ -282,6 +282,20 @@ describe("stablecoin catalog source helpers", () => {
     );
   });
 
+  it("applies full catalog invariants to base coin files without sidecars", () => {
+    const rootDir = makeTempRoot();
+
+    writeJson(
+      rootDir,
+      "shared/data/stablecoins/coins/base-usd.json",
+      makeCoin("base-usd", { canBeBlacklisted: true }),
+    );
+
+    expect(() => loadPerCoinStablecoinEntries(rootDir)).toThrow(
+      /blacklistabilityReview: explicit canBeBlacklisted overrides require blacklistabilityReview/,
+    );
+  });
+
   it("rejects sidecars that duplicate a field still present in the base coin", () => {
     const rootDir = makeTempRoot();
 

--- a/scripts/lib/stablecoin-catalog-sources.ts
+++ b/scripts/lib/stablecoin-catalog-sources.ts
@@ -215,7 +215,10 @@ function mergeStablecoinSidecars(
   sidecars: StablecoinDomainSidecarEntry[],
 ): StablecoinSourceEntry {
   if (sidecars.length === 0) {
-    return entry;
+    return {
+      ...entry,
+      coin: parseSingleAssetValue(entry.coin, entry.file),
+    };
   }
 
   const patch: Record<string, unknown> = {};


### PR DESCRIPTION
### Motivation
- A recent refactor validated per-coin source files with a raw source schema and returned base entries early when no domain sidecars existed, which allowed base files to bypass full cross-field invariants such as the `canBeBlacklisted` / `blacklistabilityReview` checks.
- The change restores the fail-closed catalog validation behavior so developer-controlled metadata cannot accidentally violate catalog invariants when no sidecars are present.

### Description
- Ensure per-coin entries with zero domain sidecars are validated with the full `StablecoinMetaAssetSchema` by calling `parseSingleAssetValue(entry.coin, entry.file)` before returning the entry in `mergeStablecoinSidecars` (in `scripts/lib/stablecoin-catalog-sources.ts`).
- Add a regression test that asserts a base coin file without sidecars and with `canBeBlacklisted: true` is rejected unless `blacklistabilityReview` is present (in `scripts/__tests__/stablecoin-catalog-sources.test.ts`).
- The change is minimal and preserves the existing merge/path behavior for entries that do have sidecars.

### Testing
- Ran the focused test suite with `npm test -- --run scripts/__tests__/stablecoin-catalog-sources.test.ts`, and all tests passed (21/21).
- Ran the stablecoin data validation check with `npm run check:stablecoin-data`, which reported `Stablecoin data validation: OK` and that the generated aggregate is current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc52c3483328177e76eace016cb)