### PR TITLE
Tighten ops route exclusion contract test

### DIFF
--- a/functions/__tests__/ops-asset-host-gates.test.ts
+++ b/functions/__tests__/ops-asset-host-gates.test.ts
@@ -11,12 +11,10 @@ const SURFACES = [
 describe("ops asset host gates", () => {
   it("keeps both static route families behind Pages Functions", () => {
     expect(routes.include).toContain("/*");
-    expect(routes.exclude).not.toEqual(expect.arrayContaining([
-      "/admin",
-      "/admin/*",
-      "/admin-api",
-      "/admin-api/*",
-    ]));
+
+    for (const pattern of ["/admin", "/admin/*", "/admin-api", "/admin-api/*"] as const) {
+      expect(routes.exclude).not.toContain(pattern);
+    }
   });
 
   for (const surface of SURFACES) {


### PR DESCRIPTION
### Motivation
- Prevent a test-regression where a grouped negative `arrayContaining` matcher would only fail if all admin and admin-api patterns were present, which could allow a partial `_routes.json` exclusion to bypass the host-gate contract.

### Description
- Replace the grouped `expect(routes.exclude).not.toEqual(expect.arrayContaining([...]))` assertion with per-pattern `expect(routes.exclude).not.toContain(pattern)` checks in `functions/__tests__/ops-asset-host-gates.test.ts` so each `/admin` and `/admin-api` exclusion is validated independently.

### Testing
- Ran `npx vitest run functions/__tests__/ops-asset-host-gates.test.ts --reporter=dot` and the test suite passed (1 file, 7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a518fc530688332ab7c73cad17e8b5c)