### PR TITLE
Fix stalled Telegram half-open probe recovery

### DIFF
--- a/worker/src/cron/telegram-pending/drain.ts
+++ b/worker/src/cron/telegram-pending/drain.ts
@@ -885,6 +885,7 @@ export async function drainPendingQueue(
     : limit;
   const pending = await claimDuePendingRows(db, nowSec, claimLimit, claimOwner, maxPriority);
   if (pending.length === 0) {
+    await recordTelegramBotWideTransportOutcomes(db, nextTransportPermit, [], nowSec);
     return emptyDrainResult();
   }
 
@@ -1075,7 +1076,6 @@ export async function drainPendingQueue(
         const attemptedOutcomes = results
           .filter((result) => result.attempted !== false)
           .map((result) => ({ chatId: result.chatId, result }));
-        if (attemptedOutcomes.length === 0) return;
         await recordTelegramBotWideTransportOutcomes(
           db,
           transportPermit,

--- a/worker/src/lib/__tests__/telegram-transport-control.test.ts
+++ b/worker/src/lib/__tests__/telegram-transport-control.test.ts
@@ -91,6 +91,30 @@ describe("Telegram transport outage control", () => {
     });
   });
 
+  it("lets fresh handoff seed a replacement probe after a half-open lease expires", async () => {
+    const { sqlite, db } = setupLatestSchema();
+    sqlite.prepare(
+      `UPDATE telegram_transport_circuit
+          SET state = 'half_open',
+              generation = 3,
+              next_probe_at = ?,
+              probe_owner = 'stale-owner',
+              probe_generation = 3,
+              probe_expires_at = ?,
+              probe_limit = 4,
+              probe_attempted = 0,
+              updated_at = ?
+        WHERE singleton_id = 1`,
+    ).run(NOW - 60, NOW - 1, NOW - 30);
+
+    await expect(readTelegramFreshHandoffAllowance(db, NOW, 90)).resolves.toMatchObject({
+      allowed: true,
+      maxTargets: 4,
+      reason: "probe_seed",
+      deferUntil: null,
+    });
+  });
+
   it("opens immediately on auth failure and denies the untouched tail", async () => {
     const { db } = setupLatestSchema();
     const permit = await closedPermit(db);
@@ -203,6 +227,37 @@ describe("Telegram transport outage control", () => {
       { chatId: "chat-2", result: result("blocked", { statusCode: 403, retryable: false, permanentFailure: true }) },
     ], NOW + 11);
     expect(closed).toMatchObject({ state: "closed", probeAttempted: 0, lastSuccessAt: NOW + 11 });
+  });
+
+  it("releases a half-open probe permit when no send is attempted", async () => {
+    const { sqlite, db } = setupLatestSchema();
+    const permit = await closedPermit(db);
+    await recordTelegramTransportOutcomes(db, permit, [
+      { chatId: "chat-a", result: result("auth_error", { statusCode: 401 }) },
+    ], NOW);
+    sqlite.prepare("UPDATE telegram_transport_circuit SET next_probe_at = ? WHERE singleton_id = 1").run(NOW + 10);
+
+    const probe = await claimTelegramTransportPermit(db, {
+      mode: "pending",
+      owner: "probe-without-send",
+      nowSec: NOW + 10,
+      requestedDistinctChats: 4,
+    });
+    expect(probe).toMatchObject({ allowed: true, reason: "half_open_probe" });
+
+    const released = await recordTelegramTransportOutcomes(db, probe, [], NOW + 11);
+    expect(released).toMatchObject({
+      state: "open",
+      nextProbeAt: NOW + 11,
+      probeOwner: null,
+      probeGeneration: null,
+      probeAttempted: 0,
+    });
+    await expect(readTelegramFreshHandoffAllowance(db, NOW + 11, 90)).resolves.toMatchObject({
+      allowed: true,
+      maxTargets: 4,
+      reason: "probe_seed",
+    });
   });
 
   it("treats a lone local 429 half-open result as inconclusive", async () => {

--- a/worker/src/lib/telegram-transport-control.ts
+++ b/worker/src/lib/telegram-transport-control.ts
@@ -208,7 +208,12 @@ export async function readTelegramFreshHandoffAllowance(
   if (circuit.state === "closed") {
     return { allowed: true, maxTargets: requested, reason: "closed", deferUntil: null };
   }
-  if (circuit.state === "open" && (circuit.nextProbeAt == null || circuit.nextProbeAt <= nowSec)) {
+  const halfOpenLeaseExpired = circuit.state === "half_open"
+    && (circuit.probeExpiresAt == null || circuit.probeExpiresAt <= nowSec);
+  if (
+    (circuit.state === "open" && (circuit.nextProbeAt == null || circuit.nextProbeAt <= nowSec))
+    || halfOpenLeaseExpired
+  ) {
     return {
       allowed: requested > 0,
       maxTargets: Math.min(4, requested),
@@ -222,6 +227,33 @@ export async function readTelegramFreshHandoffAllowance(
     reason: circuit.state === "half_open" ? "half_open" : "outage_open",
     deferUntil: circuit.probeExpiresAt ?? circuit.nextProbeAt,
   };
+}
+
+async function releaseHalfOpenProbeWithoutAttempt(
+  db: D1Database,
+  permit: TelegramTransportPermit,
+  nowSec: number,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE telegram_transport_circuit
+          SET state = 'open',
+              generation = generation + 1,
+              next_probe_at = ?,
+              probe_owner = NULL,
+              probe_generation = NULL,
+              probe_expires_at = NULL,
+              probe_limit = NULL,
+              probe_attempted = 0,
+              updated_at = ?
+        WHERE singleton_id = 1
+          AND state = 'half_open'
+          AND generation = ?
+          AND probe_owner = ?
+          AND probe_generation = ?`,
+    )
+    .bind(nowSec, nowSec, permit.circuitGeneration, permit.probeOwner, permit.probeGeneration)
+    .run();
 }
 
 export function telegramTransportPermitSkip(
@@ -703,7 +735,13 @@ export async function recordTelegramTransportOutcomes(
   outcomes: readonly TelegramTransportOutcome[],
   nowSec: number,
 ): Promise<TelegramTransportCircuitSnapshot> {
-  if (!permit.allowed || outcomes.length === 0) return await readTelegramTransportCircuit(db);
+  if (!permit.allowed) return await readTelegramTransportCircuit(db);
+  if (outcomes.length === 0) {
+    if (permit.reason === "half_open_probe") {
+      await releaseHalfOpenProbeWithoutAttempt(db, permit, nowSec);
+    }
+    return await readTelegramTransportCircuit(db);
+  }
   if (permit.reason === "half_open_probe") {
     await completeHalfOpenProbe(db, permit, outcomes, nowSec);
   } else {


### PR DESCRIPTION
### Motivation

- Prevent an availability bug where an expired `half_open` probe lease can leave the Telegram transport circuit stalled and block fresh fanout indefinitely. 
- Ensure that claiming a probe permit without any actual send attempts does not leave the circuit half-open with no recorded outcome. 

### Description

- Allow fresh handoff to seed replacement probes when a `half_open` lease has expired by treating an expired `half_open` as probe-eligible in `readTelegramFreshHandoffAllowance`. 
- Add `releaseHalfOpenProbeWithoutAttempt()` and update `recordTelegramTransportOutcomes()` so a claimed `half_open` permit with zero outcomes reopens the circuit and makes a probe immediately due again. 
- Make the pending-drain path record an empty transport outcome when a transport permit is claimed but there are no pending rows, and record zero-attempt outcomes for fully skipped batches so the circuit can be resolved. 
- Add regression tests for expired `half_open` fresh-handoff seeding and for releasing a half-open probe permit when no send is attempted. 

### Testing

- Ran the focused Vitest suites: `npx vitest run worker/src/lib/__tests__/telegram-transport-control.test.ts worker/src/cron/__tests__/telegram-pending-queue.test.ts --reporter=dot`, and the updated tests passed. 
- Ran TypeScript type check with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f56ac35083329f8410e6c37723a2)