### PR TITLE
fix(telegram): preserve pending selection initiator

### DIFF
--- a/worker/src/api/__tests__/telegram-webhook-subscriptions-settings.test.ts
+++ b/worker/src/api/__tests__/telegram-webhook-subscriptions-settings.test.ts
@@ -458,6 +458,44 @@ describe("handleTelegramWebhook", () => {
     expect(buttons.some((button) => button.text.startsWith("1.") && button.callback_data === "select:1")).toBe(true);
   });
 
+  it("preserves the pending initiator on chained ambiguous ticker selections", async () => {
+    const firstAmbiguous = resolveTicker("USDF");
+    const nextAmbiguous = resolveTicker("USX");
+    if (firstAmbiguous.status !== "ambiguous" || nextAmbiguous.status !== "ambiguous") {
+      throw new Error("Expected USDF and USX to be ambiguous for chained disambiguation test");
+    }
+
+    const db = fixtureMockD1([
+      {
+        match: "FROM telegram_pending_disambiguation WHERE chat_id = ?",
+        rows: [],
+        first: {
+          action_type: "subscribe",
+          action_payload: JSON.stringify({ alertTypes: ["dews"], presetIds: [] }),
+          alert_types: JSON.stringify(["dews"]),
+          resolved_ids: JSON.stringify([]),
+          ambiguous_ticker: "USDF",
+          candidates: JSON.stringify(firstAmbiguous.matches),
+          remaining_tickers: JSON.stringify(["USX"]),
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+          initiator_user_id: "999",
+        },
+      },
+      { match: "telegram_pending_disambiguation", rows: [] },
+    ]);
+
+    await handleTelegramWebhook(
+      db,
+      makeCallbackRequest("select:1", { chatId: -123, chatType: "supergroup", fromId: 999 }),
+      "test-secret",
+      "bot-token",
+    );
+
+    const followUpInsert = db.getHistory()
+      .find((entry) => entry.sql.includes("INSERT INTO telegram_pending_disambiguation"));
+    expect(followUpInsert?.binds[9]).toBe("999");
+  });
+
   it("handles /set for a unique ticker", async () => {
     const db = fixtureMockD1([
       { match: "telegram_pending_disambiguation", rows: [] },

--- a/worker/src/api/telegram-webhook-disambiguation-selection.ts
+++ b/worker/src/api/telegram-webhook-disambiguation-selection.ts
@@ -15,6 +15,7 @@ export type NormalizedPendingSelection =
       depegWorseningBpsStep?: 100 | 250 | 500 | null;
       initialCoinIds: string[];
       remainingTickers: string[];
+      initiatorUserId: string | null;
       clearPending: boolean;
     }
   | {
@@ -22,6 +23,7 @@ export type NormalizedPendingSelection =
       presetIds: string[];
       initialCoinIds: string[];
       remainingTickers: string[];
+      initiatorUserId: string | null;
       clearPending: boolean;
     }
   | {
@@ -29,6 +31,7 @@ export type NormalizedPendingSelection =
       command: ParsedSetCommand;
       initialCoinIds: string[];
       remainingTickers: string[];
+      initiatorUserId: string | null;
       clearPending: boolean;
     };
 
@@ -74,6 +77,7 @@ function normalizePendingDisambiguationSelection(
       depegWorseningBpsStep: pending.depegWorseningBpsStep,
       initialCoinIds,
       remainingTickers,
+      initiatorUserId: pending.initiatorUserId,
       clearPending: true,
     };
   }
@@ -83,6 +87,7 @@ function normalizePendingDisambiguationSelection(
       presetIds: [...pending.presetIds],
       initialCoinIds,
       remainingTickers,
+      initiatorUserId: pending.initiatorUserId,
       clearPending: true,
     };
   }
@@ -91,6 +96,7 @@ function normalizePendingDisambiguationSelection(
     command: pending.command,
     initialCoinIds,
     remainingTickers,
+    initiatorUserId: pending.initiatorUserId,
     clearPending: true,
   };
 }
@@ -125,6 +131,10 @@ function parseStoredCoinIds(value: unknown): string[] | null {
     return null;
   }
   return [...value];
+}
+
+function parseStoredInitiatorUserId(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
 }
 
 /**
@@ -164,6 +174,7 @@ export function parseStoredCommandSelectionIntent(
       depegWorseningBpsStep: payload.depegWorseningBpsStep,
       initialCoinIds: coinIds,
       remainingTickers: [],
+      initiatorUserId: parseStoredInitiatorUserId(payload.initiatorUserId),
       clearPending: payload.clearPending,
     };
   }
@@ -180,6 +191,7 @@ export function parseStoredCommandSelectionIntent(
       presetIds: [...payload.presetIds] as string[],
       initialCoinIds: coinIds,
       remainingTickers: [],
+      initiatorUserId: parseStoredInitiatorUserId(payload.initiatorUserId),
       clearPending: payload.clearPending,
     };
   }
@@ -192,6 +204,7 @@ export function parseStoredCommandSelectionIntent(
       command: { ticker: firstCoin.symbol, ...payload.setting } as ParsedSetCommand,
       initialCoinIds: coinIds,
       remainingTickers: [],
+      initiatorUserId: parseStoredInitiatorUserId(payload.initiatorUserId),
       clearPending: payload.clearPending,
     };
   }
@@ -219,7 +232,7 @@ export async function executeNormalizedPendingSelection(
     db,
     chatId,
     username,
-    initiatorUserId: null,
+    initiatorUserId: normalized.initiatorUserId,
     ...operation,
   };
   if (normalized.actionType === "subscribe") {

--- a/worker/src/api/webhook-commands/action-runner.ts
+++ b/worker/src/api/webhook-commands/action-runner.ts
@@ -183,6 +183,7 @@ const completionHandlers: CompletionHandlerMap = {
       presetIds,
       alertTypes: [...alertTypes].sort(),
       depegWorseningBpsStep: payload.depegWorseningBpsStep ?? null,
+      initiatorUserId: context.initiatorUserId,
       clearPending: options.clearPending,
     });
     if (!context.wasMutationApplied) {
@@ -236,6 +237,7 @@ const completionHandlers: CompletionHandlerMap = {
     const operation = await prepareActionMutation(context, "command:unsubscribe", {
       coinIds: coins.map((coin) => coin.id),
       presetIds,
+      initiatorUserId: context.initiatorUserId,
       clearPending: options.clearPending,
     });
     if (!context.wasMutationApplied) {
@@ -274,6 +276,7 @@ const completionHandlers: CompletionHandlerMap = {
     const operation = await prepareActionMutation(context, "command:set", {
       coinIds: coins.map((coin) => coin.id),
       setting: normalizedSetting,
+      initiatorUserId: context.initiatorUserId,
       clearPending: options.clearPending,
     });
     if (!context.wasMutationApplied) {
@@ -453,6 +456,7 @@ export function makeActionRunner(
           ambiguousTicker: resolution.ticker,
           candidateIds: resolution.candidates.map((coin) => coin.id),
           remainingTickers: resolution.remainingTickers,
+          initiatorUserId: context.initiatorUserId,
           expiresAt,
           clearPending: Boolean(clearPendingOnTerminal),
         };


### PR DESCRIPTION
### Motivation

- A normalized pending-selection path dropped the originating Telegram user id, which caused follow-up ambiguous pending rows to be stored with a null initiator and therefore treated as public in group chats.
- This allowed non-initiating group members to complete or cancel admin-initiated multi-step mutating flows, weakening owner-gated authorization for chained disambiguation prompts.

### Description

- Add `initiatorUserId` to the `NormalizedPendingSelection` union and include it when normalizing a loaded pending disambiguation row so the original initiator is preserved.
- Parse `initiatorUserId` from stored command intents and include it in replayed/resumed normalized selection objects so replay keeps the owner information.
- Propagate `initiatorUserId` into the action runner and into the normalized `disambiguation-prompt` intent/persistence so follow-up pending rows are persisted with the original initiator.
- Add a webhook regression test that simulates a group flow where resolving one ambiguous ticker leaves another pending and asserts the follow-up pending insert retains the original initiator id.

### Testing

- Ran the focused webhook regression suite with `npx vitest run worker/src/api/__tests__/telegram-webhook-subscriptions-settings.test.ts --reporter=verbose`, which completed successfully (Test Files 1 passed, Tests 53 passed).
- Type-checked worker code with `cd worker && npx tsc --noEmit`, which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f56c85688332af0b02bb039f5e7e)