### PR TITLE
fix(admin-api): preserve catalog audit rows on wrapper failures

### DIFF
--- a/worker/src/lib/__tests__/catalog-action-audit.test.ts
+++ b/worker/src/lib/__tests__/catalog-action-audit.test.ts
@@ -186,6 +186,47 @@ describe("catalog action canonical audit", () => {
     expect(JSON.parse(rows(sqlite)[0]?.details_json ?? "null")).toMatchObject({ mode: "live" });
   });
 
+  it("does not let a pre-idempotency failure replace the original intent outcome", async () => {
+    const sqlite = new DatabaseSync(":memory:");
+    sqlite.exec(AUDIT_SCHEMA);
+    const db = createSqliteD1(sqlite);
+    const definition = endpoint("backfill-depegs");
+    const intentKey = "operator-known-idempotency-key";
+
+    await auditCatalogActionResponse({
+      db,
+      endpoint: definition,
+      request: request("/api/backfill-depegs?stablecoin=usdt-tether&dry-run=false", intentKey),
+      response: Response.json({ ok: true }, { status: 200, headers: { "X-Idempotent-Replay": "false" } }),
+    });
+    await auditCatalogActionResponse({
+      db,
+      endpoint: definition,
+      request: request("/api/backfill-depegs?stablecoin=attacker-target&dry-run=false", intentKey, {
+        headers: {
+          "X-Pharos-Admin": "",
+          "Cf-Access-Authenticated-User-Email": "attacker@pharos.watch",
+        },
+      }),
+      response: Response.json(
+        { error: "Missing required X-Pharos-Admin header; refusing mutation." },
+        { status: 403 },
+      ),
+    });
+
+    const auditRows = rows(sqlite);
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]).toMatchObject({
+      target: "usdt-tether",
+      result: "ok",
+      http_status: 200,
+    });
+    expect(JSON.parse(auditRows[0]?.details_json ?? "null")).toMatchObject({
+      outcome: "succeeded",
+      idempotentReplay: false,
+    });
+  });
+
   it("lets the original success replace an earlier replay-unknown placeholder", async () => {
     const sqlite = new DatabaseSync(":memory:");
     sqlite.exec(AUDIT_SCHEMA);

--- a/worker/src/lib/catalog-action-audit.ts
+++ b/worker/src/lib/catalog-action-audit.ts
@@ -95,7 +95,9 @@ export async function auditCatalogActionResponse({
   const { target, label: scopeLabel } = getSafeTarget(endpoint.statusPageAction.scope, url);
   const outcome = getOutcome(endpoint, response);
   const executionCertainty = getExecutionCertainty(response, outcome);
-  const idempotentReplay = response.headers.get("X-Idempotent-Replay") === "true";
+  const idempotencyReplayHeader = response.headers.get("X-Idempotent-Replay");
+  const idempotentReplay = idempotencyReplayHeader === "true";
+  const intentWriteMode = idempotencyReplayHeader === "false" ? "authoritative" : "insert-if-missing";
 
   const persisted = await logAdminAction(
     db,
@@ -105,7 +107,7 @@ export async function auditCatalogActionResponse({
       result: outcome === "failed" || outcome === "unknown" ? "error" : "ok",
       httpStatus: response.status,
       intentKey,
-      intentWriteMode: idempotentReplay ? "insert-if-missing" : "authoritative",
+      intentWriteMode,
       details: {
         path: endpoint.path,
         method: request.method.toUpperCase(),


### PR DESCRIPTION
### Motivation
- The router-level canonical audit previously performed authoritative upserts for any response carrying an Idempotency-Key, which allowed pre-idempotency wrapper failures (e.g., a 403 returned by `runAdminRoute` when `X-Pharos-Admin` is missing) to overwrite an existing audit row for the same intent key.
- The intent is to ensure the idempotency layer remains the source of truth for whether a response is the original execution or a replay, and to avoid attacker-controlled wrapper failures replacing prior successful audit records.

### Description
- Change audit write mode selection in `worker/src/lib/catalog-action-audit.ts` to derive `intentWriteMode` from the raw `X-Idempotent-Replay` header string so that only an explicit idempotency-layer-marked original (`"X-Idempotent-Replay": "false"`) is treated as `authoritative`, and all other cases use `insert-if-missing`.
- Add a regression test in `worker/src/lib/__tests__/catalog-action-audit.test.ts` that verifies a pre-idempotency 403 (missing `X-Pharos-Admin`) using a reused Idempotency-Key cannot overwrite an earlier successful audit row.
- Keep existing replay-backfill behavior intact (replays that carry `X-Idempotent-Replay: true` still use `insert-if-missing` and `X-Idempotency-Conflict: request-mismatch` remains excluded).

### Testing
- Ran the focused test suites: `npx vitest run worker/src/lib/__tests__/catalog-action-audit.test.ts worker/src/lib/__tests__/admin-action-audit.test.ts --reporter=verbose`, and all tests passed.
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f5695a6c8332abf8fdb4c14a8368)