### PR TITLE
fix(yield): preserve opportunityRisk in published sourceRisk

### DIFF
--- a/worker/src/cron/__tests__/yield-publication.test.ts
+++ b/worker/src/cron/__tests__/yield-publication.test.ts
@@ -629,6 +629,57 @@ describe("validateYieldRankingsPayloadForPublish", () => {
     });
   });
 
+  it("publishes opportunity-level risk evidence for selected and alternate sources", () => {
+    const startSec = Math.floor(FIXED_NOW.getTime() / 1000);
+    const benchmark = makeBenchmarkMeta();
+    const selectedOpportunityRisk = {
+      opportunityClass: "lending" as const,
+      underlyingSafetyScore: 82,
+      opportunitySafetyScore: 77,
+      opportunitySafetyPenalty: 5,
+      venueReviewed: true,
+      missingCriticalEvidence: [],
+    };
+    const alternateOpportunityRisk = {
+      opportunityClass: "structured-tranche" as const,
+      underlyingSafetyScore: 74,
+      opportunitySafetyScore: null,
+      opportunitySafetyPenalty: null,
+      venueReviewed: false,
+      missingCriticalEvidence: ["venue-review" as const, "market-size" as const],
+    };
+    const selected = makeEvaluatedSource({
+      sourceKey: "defillama:selected-opportunity",
+      yieldSource: "Selected Opportunity",
+      currentApy: 6,
+      pharosYieldScore: 90,
+      sourceRisk: { opportunityRisk: selectedOpportunityRisk },
+    });
+    const alternate = makeEvaluatedSource({
+      sourceKey: "defillama:alternate-opportunity",
+      yieldSource: "Alternate Opportunity",
+      currentApy: 5,
+      pharosYieldScore: 80,
+      sourceRisk: { opportunityRisk: alternateOpportunityRisk },
+    });
+
+    const payload = buildYieldRankingsPayloadFromEvaluatedSources({
+      evaluatedSources: [selected, alternate],
+      bestSourceKeyByCoin: new Map([[selected.id, selected.sourceKey]]),
+      rankingProvenanceByKey: new Map(),
+      riskFreeRate: benchmark.rate,
+      riskFreeRateMeta: benchmark,
+      riskFreeRateRegistry: { USD: benchmark, EUR: null, CHF: null },
+      dlPoolsMeta: makeYieldSourceMeta(),
+      safetySnapshot: makeSafetySnapshotMeta(),
+      medianApy: 4.5,
+      startSec,
+    });
+
+    expect(payload.rankings[0]?.sourceRisk?.opportunityRisk).toEqual(selectedOpportunityRisk);
+    expect(payload.rankings[0]?.altSources[0]?.sourceRisk?.opportunityRisk).toEqual(alternateOpportunityRisk);
+  });
+
   it("publishes golden source-risk rows only under nested public sourceRisk", () => {
     const startSec = Math.floor(FIXED_NOW.getTime() / 1000);
     const benchmark = makeBenchmarkMeta();

--- a/worker/src/cron/__tests__/yield-source-risk.test.ts
+++ b/worker/src/cron/__tests__/yield-source-risk.test.ts
@@ -280,6 +280,28 @@ describe("yield source-risk registry", () => {
     expect(derivePysSourceRiskPenalty({ dependencyConcentrationSeverity: "low" })).toBe(1);
   });
 
+  it("preserves opportunity-level risk evidence for published source-risk payloads", () => {
+    const opportunityRisk = {
+      opportunityClass: "lending" as const,
+      underlyingSafetyScore: 82,
+      opportunitySafetyScore: 77,
+      opportunitySafetyPenalty: 5,
+      venueReviewed: true,
+      missingCriticalEvidence: [],
+    };
+
+    const sourceRisk = buildYieldSourceRisk({
+      source: makeSource({
+        yieldType: "lending-opportunity",
+        sourceRisk: { opportunityRisk },
+      }),
+      provenance: { sourceAgeSeconds: 300 },
+      isBest: true,
+    });
+
+    expect(sourceRisk.opportunityRisk).toEqual(opportunityRisk);
+  });
+
   it("normalizes sourceRiskScore from the resolved sourceRiskPenalty", () => {
     const neutralSource = buildYieldSourceRisk({
       source: makeSource({ sourceRiskPenalty: 1 }),

--- a/worker/src/cron/yield-sync/source-risk.ts
+++ b/worker/src/cron/yield-sync/source-risk.ts
@@ -56,6 +56,7 @@ function optionalSourceRiskFields(existing: YieldSourceRisk): Partial<YieldSourc
     ...(existing.trancheSafetyScore !== undefined ? { trancheSafetyScore: existing.trancheSafetyScore } : {}),
     ...(existing.trancheSafetyPenalty !== undefined ? { trancheSafetyPenalty: existing.trancheSafetyPenalty } : {}),
     ...(existing.underlyingSafetyScore !== undefined ? { underlyingSafetyScore: existing.underlyingSafetyScore } : {}),
+    ...(existing.opportunityRisk !== undefined ? { opportunityRisk: existing.opportunityRisk } : {}),
     ...(existing.marketCoverageRatio !== undefined ? { marketCoverageRatio: existing.marketCoverageRatio } : {}),
     ...(existing.marketMinCoverageRatio !== undefined ? { marketMinCoverageRatio: existing.marketMinCoverageRatio } : {}),
     ...(existing.marketUtilizationRatio !== undefined ? { marketUtilizationRatio: existing.marketUtilizationRatio } : {}),


### PR DESCRIPTION
### Motivation
- The evaluation step attaches `sourceRisk.opportunityRisk` for external opportunities, but the public payload builder reconstructed `sourceRisk` through a whitelist and omitted `opportunityRisk`, causing the published rankings and alternate rows to drop the new contract expected by the UI and API schema.
- Preserve the opportunity-level evidence in published payloads so the UI and consumers receive the same contract used during scoring and nulling.

### Description
- Add `opportunityRisk` to the optional source-risk field whitelist in `worker/src/cron/yield-sync/source-risk.ts` so `buildYieldSourceRisk()` retains the field when rebuilding published payloads.
- Add a unit test to `worker/src/cron/__tests__/yield-source-risk.test.ts` that asserts `buildYieldSourceRisk()` preserves `opportunityRisk` from the evaluated source.
- Add a publication-path regression test to `worker/src/cron/__tests__/yield-publication.test.ts` that asserts both selected ranking rows and alternate sources expose `sourceRisk.opportunityRisk` in the produced rankings payload.

### Testing
- Ran `npx vitest run worker/src/cron/__tests__/yield-source-risk.test.ts worker/src/cron/__tests__/yield-publication.test.ts --reporter=dot` and the targeted suites passed (all tests in those files green).
- Ran `cd worker && npx tsc --noEmit` to verify type checks and it completed without errors.
- Noted that `npm test -- --runInBand` is unsupported here because Vitest does not accept the Jest-style `--runInBand` option; this is a test-invocation mismatch rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f56b556c8332b702626a2b0cf61c)