### PR TITLE
Fix Telegram load guard coverage for scenario model

### DIFF
--- a/.github/workflows/telegram-load.yml
+++ b/.github/workflows/telegram-load.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/telegram-load.yml"
       - "scripts/ci/check-telegram-load.ts"
+      - "scripts/lib/telegram-load-scenarios.ts"
       - "scripts/lib/telegram-load-guard.mjs"
       - "scripts/maintenance/test-merge-gate.mjs"
       - "scripts/__tests__/check-telegram-load.test.ts"

--- a/scripts/__tests__/telegram-load-guard.test.ts
+++ b/scripts/__tests__/telegram-load-guard.test.ts
@@ -74,6 +74,11 @@ describe("Telegram load guard dependency registry", () => {
       }
     }
 
+    expect(hasTelegramLoadGuardImpact(["scripts/lib/telegram-load-scenarios.ts"])).toBe(true);
+    expect(commandTexts(buildCommandPlan(["scripts/lib/telegram-load-scenarios.ts"]))).toContain(
+      TELEGRAM_LOAD_ADVISORY_COMMAND,
+    );
+
     expect(hasTelegramLoadGuardImpact(["worker/src/api/unrelated.ts"])).toBe(false);
   });
 });

--- a/scripts/lib/telegram-load-guard.mjs
+++ b/scripts/lib/telegram-load-guard.mjs
@@ -14,6 +14,7 @@ export const TELEGRAM_LOAD_GUARD_DEPENDENCY_GROUPS = [
     paths: [
       ".github/workflows/telegram-load.yml",
       "scripts/ci/check-telegram-load.ts",
+      "scripts/lib/telegram-load-scenarios.ts",
       "scripts/lib/telegram-load-guard.mjs",
       "scripts/maintenance/test-merge-gate.mjs",
       "scripts/__tests__/check-telegram-load.test.ts",


### PR DESCRIPTION
### Motivation
- A refactor moved the Telegram load simulation model into `scripts/lib/telegram-load-scenarios.ts`, but the GitHub Actions path filter and the local merge-gate dependency registry omitted that file, creating a CI/coverage gap where model-only edits would not trigger the Telegram Load Guard workflow or advisory.

### Description
- Add `scripts/lib/telegram-load-scenarios.ts` to the workflow pull-request `paths` in `.github/workflows/telegram-load.yml` so scenario-model-only changes will trigger the dedicated workflow.
- Add `scripts/lib/telegram-load-scenarios.ts` to the `guard-contract` dependency `paths` in `scripts/lib/telegram-load-guard.mjs` so `hasTelegramLoadGuardImpact()` recognizes the extracted model as guard-relevant.
- Add a regression assertion to `scripts/__tests__/telegram-load-guard.test.ts` that verifies `scripts/lib/telegram-load-scenarios.ts` produces a local merge-gate advisory.

### Testing
- Ran the focused unit test with `npx vitest run scripts/__tests__/telegram-load-guard.test.ts` and all tests passed.
- Executed the load check with `npm run check:telegram-load` which completed successfully and produced the expected simulation output.
- Verified the local registry programmatically with `node --input-type=module -e 'import {hasTelegramLoadGuardImpact,isTelegramLoadGuardDependency,TELEGRAM_LOAD_GUARD_PATHS} from "./scripts/lib/telegram-load-guard.mjs"; const p="scripts/lib/telegram-load-scenarios.ts"; console.log({inRegistry: TELEGRAM_LOAD_GUARD_PATHS.includes(p), dep:isTelegramLoadGuardDependency(p), impact:hasTelegramLoadGuardImpact([p])});'` which returned `true` for registry membership, dependency match, and impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f56aa5cc8332978268d3c575e486)