### PR TITLE
Allow GET inspection on admin-telegram-delivery-control endpoint

### DIFF
--- a/shared/lib/api-endpoints/validation.ts
+++ b/shared/lib/api-endpoints/validation.ts
@@ -17,6 +17,7 @@ const POST_ONLY_METHODS = ["POST"] as const satisfies readonly EndpointMethod[];
 const GET_AND_POST_METHODS = ["GET", "POST"] as const satisfies readonly EndpointMethod[];
 const AUDIT_DEPEG_HISTORY_PATH = API_PATHS.auditDepegHistoryBase();
 const BACKFILL_DEWS_PATH = API_PATHS.backfillDews();
+const ADMIN_TELEGRAM_DELIVERY_CONTROL_PATH = API_PATHS.adminTelegramDeliveryControl();
 const ADMIN_DYNAMIC_PATH_ROOTS = [
   "/api/api-key-requests-admin",
   "/api/api-keys",
@@ -155,6 +156,9 @@ export function isMutatingAdminGetAllowed(url: URL): boolean {
   }
   if (url.pathname === BACKFILL_DEWS_PATH) {
     return !url.searchParams.has("repair") || url.searchParams.get("dry-run") === "true";
+  }
+  if (url.pathname === ADMIN_TELEGRAM_DELIVERY_CONTROL_PATH) {
+    return true;
   }
   return false;
 }

--- a/worker/src/api/__tests__/router-contract.test.ts
+++ b/worker/src/api/__tests__/router-contract.test.ts
@@ -210,6 +210,9 @@ describe("router contract: strict frontend paths are routable", () => {
         }));
         expect(forbiddenRepairGet).not.toBeNull();
         expect(forbiddenRepairGet!.status).toBe(405);
+      } else if (path === "/api/admin-telegram-delivery-control") {
+        expect(getResult!.status).not.toBe(405);
+        expect(getResult!.status).toBe(401);
       } else {
         expect(getResult!.status).toBe(405);
       }


### PR DESCRIPTION
### Motivation

- The admin Telegram delivery-control endpoint was registered as a mutating dual-mode route (`GET` + `POST` with `mutatingAdmin: true`) but the shared mutating-admin GET allowlist did not include its path, causing GET/HEAD inspection requests to be downgraded to POST-only and return `405` before auth/handler ran.

### Description

- Add the delivery-control path to the mutating-admin GET allowance by introducing `ADMIN_TELEGRAM_DELIVERY_CONTROL_PATH` and returning `true` for it in `isMutatingAdminGetAllowed()` in `shared/lib/api-endpoints/validation.ts` so `GET`/`HEAD` reach the auth/handler path.
- Update router contract coverage in `worker/src/api/__tests__/router-contract.test.ts` to assert `GET /api/admin-telegram-delivery-control` is not converted to `POST`-only and still fails closed (returns `401`) when no admin credential is present.
- The change is intentionally minimal and limited to the shared method policy and corresponding test to restore the documented read-only inspection behavior while preserving `POST` as the mutation lane.

### Testing

- Ran focused unit suites: `npx vitest run worker/src/api/__tests__/router-contract.test.ts worker/src/api/__tests__/admin-auth-contract.test.ts` and they passed (all tests in those files succeeded).
- Ran TypeScript worker build check: `cd worker && npx tsc --noEmit` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f56b39d88332890f95e0c2cd6fbf)