### PR TITLE
Fix Pages release build attribution baseline

### DIFF
--- a/scripts/lib/build-attribution-baseline.json
+++ b/scripts/lib/build-attribution-baseline.json
@@ -3,42 +3,42 @@
   "groups": [
     {
       "key": "(unclassified)",
-      "totalBytes": 2595620,
+      "totalBytes": 2567135,
       "chunkCount": 131
     },
     {
       "key": "stablecoin-client-registry",
-      "totalBytes": 571737,
+      "totalBytes": 691174,
       "chunkCount": 1
     },
     {
       "key": "recharts+recharts-component",
-      "totalBytes": 501423,
+      "totalBytes": 501433,
       "chunkCount": 1
     },
     {
       "key": "next-framework",
-      "totalBytes": 378677,
+      "totalBytes": 378733,
       "chunkCount": 3
     },
     {
       "key": "depeg-event-related-data",
-      "totalBytes": 229806,
+      "totalBytes": 230212,
       "chunkCount": 1
     },
     {
       "key": "error-boundary",
-      "totalBytes": 123013,
-      "chunkCount": 4
+      "totalBytes": 100853,
+      "chunkCount": 3
     },
     {
       "key": "zod",
-      "totalBytes": 71593,
+      "totalBytes": 71592,
       "chunkCount": 1
     },
     {
       "key": "react-tweet",
-      "totalBytes": 29516,
+      "totalBytes": 29520,
       "chunkCount": 1
     }
   ]


### PR DESCRIPTION
## Summary

- refresh the checked-in build attribution baseline for the intentional stablecoin client registry growth in release #499
- preserve the existing absolute build-size budgets, which passed in the failed production Pages job

## Failure addressed

Deploy run `29354266766` stopped at `npm run check:build-attribution` because `stablecoin-client-registry` grew from 558 KiB to 675 KiB. Worker deployment and activation succeeded; Pages was not published.

## Validation

- `npm run check:build-attribution`
