### PR TITLE
fix(safety): persist intra-day V9 shadow refreshes

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-store.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-store.test.ts
@@ -662,6 +662,61 @@ describe("Safety Score v9 shadow state persistence", () => {
     expect(sqlite.prepare("SELECT COUNT(*) AS count FROM safety_score_v9_artifacts").get()).toEqual({ count: 5 });
   });
 
+  it("atomically re-selects a newer intra-day success and records later failures", async () => {
+    const { sqlite, db } = createTestDatabase();
+    const original = await successfulState();
+    await persistSafetyScoreV9ShadowState(db, original);
+
+    const refreshedCandidate = {
+      ...candidate(),
+      candidateId: "candidate-v9-store-refreshed",
+      policyVersion: "candidate-v9-store-refreshed",
+      publicationGenerationId: "v9-shadow:refreshed-generation",
+      resultDigest: digest("8"),
+    };
+    const refreshed = await successfulState(false, refreshedCandidate);
+    refreshed.daily = buildSafetyScoreV9ShadowDailySuccess({
+      utcDay: original.daily.utcDay,
+      selectedAtSec: SCHEDULED_FOR_SEC + 3 * 60 * 60,
+      updatedAtSec: SCHEDULED_FOR_SEC + 3 * 60 * 60 + 1,
+      previous: original.daily,
+      envelope: refreshed.envelope,
+      diff: refreshed.diff,
+    });
+
+    await expect(persistSafetyScoreV9ShadowState(db, refreshed)).resolves.toBeUndefined();
+    await expect(loadSafetyScoreV9ShadowHistory(db)).resolves.toEqual([refreshed.daily]);
+    await expect(loadLatestSafetyScoreV9ShadowEnvelope(db)).resolves.toEqual(refreshed.envelope);
+    await expect(loadLatestSafetyScoreV9DiffReport(db)).resolves.toEqual(refreshed.diff);
+
+    const failure = buildSafetyScoreV9ShadowDailyFailure({
+      utcDay: refreshed.daily.utcDay,
+      updatedAtSec: refreshed.daily.updatedAtSec + 1,
+      previous: refreshed.daily,
+      failure: {
+        atSec: refreshed.daily.updatedAtSec + 1,
+        stage: "shadow-write",
+        code: "write-failed",
+        message: "write failed",
+      },
+    });
+    await expect(persistSafetyScoreV9ShadowState(db, { daily: failure })).resolves.toBeUndefined();
+    expect(
+      sqlite
+        .prepare(
+          `SELECT successful_attempt_count, failed_attempt_count, selected_run_at_sec,
+                  latest_error_code
+           FROM safety_score_v9_shadow_daily`,
+        )
+        .get(),
+    ).toEqual({
+      successful_attempt_count: 2,
+      failed_attempt_count: 1,
+      selected_run_at_sec: refreshed.daily.selectedRun?.selectedAtSec,
+      latest_error_code: "write-failed",
+    });
+  });
+
   it("rolls back selected artifacts, daily state, and envelope when the atomic latest write fails", async () => {
     const { sqlite, db } = createTestDatabase();
     const state = await successfulState(true);
@@ -692,6 +747,45 @@ describe("Safety Score v9 shadow state persistence", () => {
       resultDigest: digest("8"),
     };
     const winner = await successfulState(false, winnerCandidate);
+    const originalBatch = db.batch.bind(db);
+    vi.spyOn(db, "batch").mockImplementation(async (statements) => {
+      await persistSafetyScoreV9ShadowState(raceDb, winner);
+      return originalBatch(statements);
+    });
+
+    await expect(persistSafetyScoreV9ShadowState(db, loser)).rejects.toThrow();
+
+    await expect(loadSafetyScoreV9ShadowHistory(raceDb)).resolves.toEqual([winner.daily]);
+    await expect(loadLatestSafetyScoreV9ShadowEnvelope(raceDb)).resolves.toEqual(winner.envelope);
+    await expect(loadLatestSafetyScoreV9DiffReport(raceDb)).resolves.toEqual(winner.diff);
+  });
+
+  it("keeps the winning intra-day refresh when a stale refresh passed preflight", async () => {
+    const { sqlite, db } = createTestDatabase();
+    const raceDb = createSqliteD1(sqlite);
+    const original = await successfulState();
+    await persistSafetyScoreV9ShadowState(raceDb, original);
+
+    const buildRefresh = async (label: string, selectedAtSec: number) => {
+      const refreshed = await successfulState(false, {
+        ...candidate(),
+        candidateId: `candidate-v9-race-${label}`,
+        policyVersion: `candidate-v9-race-${label}`,
+        publicationGenerationId: `v9-shadow:race-${label}`,
+        resultDigest: digest(label === "winner" ? "8" : "9"),
+      });
+      refreshed.daily = buildSafetyScoreV9ShadowDailySuccess({
+        utcDay: original.daily.utcDay,
+        selectedAtSec,
+        updatedAtSec: selectedAtSec + 1,
+        previous: original.daily,
+        envelope: refreshed.envelope,
+        diff: refreshed.diff,
+      });
+      return refreshed;
+    };
+    const loser = await buildRefresh("loser", SCHEDULED_FOR_SEC + 3 * 60 * 60);
+    const winner = await buildRefresh("winner", SCHEDULED_FOR_SEC + 3 * 60 * 60 + 1);
     const originalBatch = db.batch.bind(db);
     vi.spyOn(db, "batch").mockImplementation(async (statements) => {
       await persistSafetyScoreV9ShadowState(raceDb, winner);

--- a/worker/src/lib/safety-score-v9-store.ts
+++ b/worker/src/lib/safety-score-v9-store.ts
@@ -824,6 +824,9 @@ export async function persistSafetyScoreV9ShadowState(
     if (existing?.selectedRun === null || existing === null) {
       throw new Error("A newly selected Safety Score v9 daily run must persist its latest envelope and diff");
     }
+    if (stableJsonStringifyV1(existing.selectedRun) !== stableJsonStringifyV1(daily.selectedRun)) {
+      throw new Error("A re-selected Safety Score v9 daily run must persist its latest envelope and diff");
+    }
   }
   if (localBundle === null) {
     for (const artifact of artifacts) {
@@ -854,14 +857,22 @@ export async function persistSafetyScoreV9ShadowState(
   if (existingDaily) {
     const oldAttempts = existingDaily.attemptCounts.successful + existingDaily.attemptCounts.failed;
     const newAttempts = daily.attemptCounts.successful + daily.attemptCounts.failed;
-    if (newAttempts < oldAttempts || daily.updatedAtSec < existingDaily.updatedAtSec) {
-      throw new SafetyScoreV9StoreConflictError(`Stale Safety Score v9 daily update for ${daily.utcDay}`);
-    }
-    if (
-      existingDaily.selectedRun !== null &&
-      stableJsonStringifyV1(existingDaily.selectedRun) !== stableJsonStringifyV1(daily.selectedRun)
-    ) {
-      throw new SafetyScoreV9StoreConflictError(`Selected Safety Score v9 daily run conflict for ${daily.utcDay}`);
+    const existingDailyJson = stableJsonStringifyV1(existingDaily);
+    if (existingDailyJson !== dailyJson) {
+      if (newAttempts <= oldAttempts || daily.updatedAtSec < existingDaily.updatedAtSec) {
+        throw new SafetyScoreV9StoreConflictError(`Stale Safety Score v9 daily update for ${daily.utcDay}`);
+      }
+      if (existingDaily.selectedRun !== null) {
+        const selected = daily.selectedRun;
+        if (
+          selected === null ||
+          selected.selectedAtSec < existingDaily.selectedRun.selectedAtSec ||
+          (selected.selectedAtSec === existingDaily.selectedRun.selectedAtSec &&
+            stableJsonStringifyV1(selected) !== stableJsonStringifyV1(existingDaily.selectedRun))
+        ) {
+          throw new SafetyScoreV9StoreConflictError(`Selected Safety Score v9 daily run conflict for ${daily.utcDay}`);
+        }
+      }
     }
   }
 
@@ -916,20 +927,52 @@ export async function persistSafetyScoreV9ShadowState(
            latest_error_code = excluded.latest_error_code,
            latest_error_message = excluded.latest_error_message,
            daily_json = CASE
-             WHEN (safety_score_v9_shadow_daily.successful_attempt_count + safety_score_v9_shadow_daily.failed_attempt_count
-                     < excluded.successful_attempt_count + excluded.failed_attempt_count
-                   OR safety_score_v9_shadow_daily.daily_json = excluded.daily_json)
-                  AND safety_score_v9_shadow_daily.updated_at_sec <= excluded.updated_at_sec
-                  AND (safety_score_v9_shadow_daily.selected_run_at_sec IS NULL
-                       OR safety_score_v9_shadow_daily.daily_json = excluded.daily_json)
+             WHEN safety_score_v9_shadow_daily.daily_json = excluded.daily_json
+                  OR (
+                    safety_score_v9_shadow_daily.successful_attempt_count
+                      + safety_score_v9_shadow_daily.failed_attempt_count
+                      < excluded.successful_attempt_count + excluded.failed_attempt_count
+                    AND safety_score_v9_shadow_daily.updated_at_sec <= excluded.updated_at_sec
+                    AND (
+                      safety_score_v9_shadow_daily.selected_run_at_sec IS NULL
+                      OR (
+                        excluded.selected_run_at_sec IS NOT NULL
+                        AND (
+                          safety_score_v9_shadow_daily.selected_run_at_sec < excluded.selected_run_at_sec
+                          OR (
+                            safety_score_v9_shadow_daily.selected_run_at_sec = excluded.selected_run_at_sec
+                            AND json_extract(safety_score_v9_shadow_daily.daily_json, '$.selectedRun')
+                              = json_extract(excluded.daily_json, '$.selectedRun')
+                          )
+                        )
+                      )
+                    )
+                  )
                THEN excluded.daily_json
              ELSE NULL
            END,
            updated_at_sec = CASE
-             WHEN (safety_score_v9_shadow_daily.successful_attempt_count + safety_score_v9_shadow_daily.failed_attempt_count
-                     < excluded.successful_attempt_count + excluded.failed_attempt_count
-                   OR safety_score_v9_shadow_daily.daily_json = excluded.daily_json)
-                  AND safety_score_v9_shadow_daily.updated_at_sec <= excluded.updated_at_sec
+             WHEN safety_score_v9_shadow_daily.daily_json = excluded.daily_json
+                  OR (
+                    safety_score_v9_shadow_daily.successful_attempt_count
+                      + safety_score_v9_shadow_daily.failed_attempt_count
+                      < excluded.successful_attempt_count + excluded.failed_attempt_count
+                    AND safety_score_v9_shadow_daily.updated_at_sec <= excluded.updated_at_sec
+                    AND (
+                      safety_score_v9_shadow_daily.selected_run_at_sec IS NULL
+                      OR (
+                        excluded.selected_run_at_sec IS NOT NULL
+                        AND (
+                          safety_score_v9_shadow_daily.selected_run_at_sec < excluded.selected_run_at_sec
+                          OR (
+                            safety_score_v9_shadow_daily.selected_run_at_sec = excluded.selected_run_at_sec
+                            AND json_extract(safety_score_v9_shadow_daily.daily_json, '$.selectedRun')
+                              = json_extract(excluded.daily_json, '$.selectedRun')
+                          )
+                        )
+                      )
+                    )
+                  )
                THEN excluded.updated_at_sec
              ELSE -1
            END`,


### PR DESCRIPTION
## Summary
- allow the intended three-hour Safety Score v9 shadow reselection to replace the same UTC day's compact D1 row
- preserve stale-writer protection with attempt, timestamp, selected-run, and atomic cache guards
- cover successful refreshes, later failure recording, and competing refresh writers

## Production evidence
The deployed refresh runner recomputes successfully but every post-deploy write fails with:
`Selected Safety Score v9 daily run conflict for 2026-07-14`

That leaves the selected 00:34Z row at 0 rated / 361 NR even though the current candidate is being evaluated every quarter hour.

## Validation
- `npx vitest run worker/src/lib/__tests__/safety-score-v9-store.test.ts worker/src/lib/__tests__/safety-score-v9-shadow-runner.test.ts worker/src/lib/__tests__/safety-score-v9-shadow.test.ts worker/src/api/__tests__/admin-safety-score-v9.test.ts`
- `npm run typecheck:worker`
- `npm run typecheck:tests`
- `npx eslint worker/src/lib/safety-score-v9-store.ts worker/src/lib/__tests__/safety-score-v9-store.test.ts`
- `git diff --check`