### PR TITLE
fix(ci): ratchet API reference HTML budget

### DIFF
--- a/scripts/maintenance/report-build-size.mjs
+++ b/scripts/maintenance/report-build-size.mjs
@@ -43,10 +43,11 @@ const DEFAULT_BUDGETS = {
   // narrow post-ratchet ceiling with about 1 KiB of headroom for gzip variance.
   largestCssGzipBytes: 69_632,
   totalStaticMediaBytes: 2_000_000,
-  // API-reference schema and route-contract growth measured 2,724,991 bytes
-  // in the July 2026 export. Retain about 10 KB of headroom while keeping
-  // future docs-heavy App Router payload growth reviewable.
-  largestHtmlBytes: 2_735_000,
+  // API-reference schema and route-contract growth measured 2,737,491 bytes
+  // after adding the identity-aware safety-score-history contract. Retain
+  // about 12 KB of headroom while keeping future docs-heavy App Router payload
+  // growth reviewable.
+  largestHtmlBytes: 2_750_000,
   // Keep the homepage bootstrap/RSC payload from silently growing into the
   // mobile critical path again without constraining long-form docs pages.
   // The homepage table moved directly under the KPI band (1f76d3c36), which


### PR DESCRIPTION
## Summary
- ratchet the largest-HTML build budget for the expanded generated API reference
- record the production measurement and retain a narrow ~12 KB headroom

## Validation
- npm run check:build-size
- git diff --check

## Release context
Follow-up to the Pages build-size failure in deploy run 29397698980. The Worker portion of that release already deployed and passed activation proof; this patch unblocks the Pages publish.