### PR TITLE
fix(telegram): retire repeatedly unreachable chats

### DIFF
--- a/docs/telegram-alerts.md
+++ b/docs/telegram-alerts.md
@@ -616,7 +616,7 @@ Delivery semantics are explicit:
 - `permanent_failure`
 
 Fresh retryable failures are enqueued into `telegram_pending_alerts` instead of being dropped.
-`403` responses from the pending-queue dispatcher follow a two-strike rule: the first 403 stamps `consecutive_block_first_at` on `telegram_subscribers` and increments `consecutive_block_count` but leaves alert flags untouched; a second 403 within 24 hours of the first strike disables the subscriber's global flags and all per-coin alert booleans. When the second strike disables a chat, any other live pending rows for that chat are dead-lettered with `blocked_disabled` and deleted so a known-blocked bot is not retried until the pending-row TTL. Any successful send resets both counters. A first strike older than 24 hours is treated as fresh.
+Blocked or definitively unreachable responses (`403` or Telegram `chat not found`) follow a two-strike rule: the first response stamps `consecutive_block_first_at` on `telegram_subscribers` and increments `consecutive_block_count` but leaves alert flags untouched; a second response within 24 hours of the first strike disables the subscriber's global flags and all per-coin alert booleans. When the second strike disables a chat, any other live pending rows for that chat are dead-lettered with `blocked_disabled` and deleted so the bot does not retry a known-undeliverable chat until the pending-row TTL. Any successful send resets both counters. A first strike older than 24 hours is treated as fresh.
 
 ### Pending Delivery Queue
 

--- a/worker/src/cron/__tests__/dispatch-telegram-alerts-backoff-transitions.test.ts
+++ b/worker/src/cron/__tests__/dispatch-telegram-alerts-backoff-transitions.test.ts
@@ -72,7 +72,7 @@ describe("dispatchTelegramAlerts", () => {
   beforeEach(resetDispatchTelegramAlertsTest);
   afterEach(cleanupDispatchTelegramAlertsTest);
 
-  it("records a fresh-send first strike without deactivating the subscriber", async () => {
+  it("records a fresh-send chat_not_found first strike without deactivating the subscriber", async () => {
     const harness = createDispatchHarness();
     sources(harness, { dews: { "usdc-circle": "CALM" } });
     harness.seed({
@@ -85,8 +85,8 @@ describe("dispatchTelegramAlerts", () => {
       blocked: true,
       retryable: false,
       permanentFailure: true,
-      statusCode: 403,
-      errorClass: "blocked",
+      statusCode: 400,
+      errorClass: "chat_not_found",
       delivery: "blocked",
       retryAfterSec: null,
     });
@@ -103,7 +103,7 @@ describe("dispatchTelegramAlerts", () => {
     ).toEqual({ alert_dews: 1 });
   });
 
-  it("deactivates a fresh-send blocked subscriber only on the second strike", async () => {
+  it("deactivates a fresh-send chat_not_found subscriber only on the second strike", async () => {
     const now = Math.floor(Date.now() / 1000);
     const harness = createDispatchHarness();
     sources(harness, { dews: { "usdc-circle": "CALM" } });
@@ -117,8 +117,8 @@ describe("dispatchTelegramAlerts", () => {
       blocked: true,
       retryable: false,
       permanentFailure: true,
-      statusCode: 403,
-      errorClass: "blocked",
+      statusCode: 400,
+      errorClass: "chat_not_found",
       delivery: "blocked",
       retryAfterSec: null,
     });
@@ -135,6 +135,23 @@ describe("dispatchTelegramAlerts", () => {
     expect(
       harness.sqlite.prepare("SELECT alert_dews FROM telegram_subscriptions WHERE chat_id = '99999'").get(),
     ).toEqual({ alert_dews: 0 });
+
+    const attemptedAtDisable = mockSendToChat.mock.calls.length;
+    vi.advanceTimersByTime(121_000);
+    harness.seed({
+      dews: [{ stablecoinId: "usdc-circle", score: 92, band: "DANGER", computedAt: now + 121 }],
+    });
+
+    const nextMetadata = JSON.parse((await dispatchTelegramAlerts(harness.db, "bot-token")).metadata);
+    expect(nextMetadata).toMatchObject({
+      eventsDetected: { dews: 1 },
+      subscribersNotified: 0,
+      messagesSent: 0,
+    });
+    expect(mockSendToChat).toHaveBeenCalledTimes(attemptedAtDisable);
+    expect(
+      harness.sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_pending_alerts WHERE chat_id = '99999'").get(),
+    ).toEqual({ count: 0 });
   });
 
   it("drains pending queue on an eventless dispatch", async () => {

--- a/worker/src/cron/__tests__/telegram-pending-queue.test.ts
+++ b/worker/src/cron/__tests__/telegram-pending-queue.test.ts
@@ -1884,10 +1884,10 @@ describe("drainPendingQueue", () => {
     }
   });
 
-  it("records a first-strike 403 without zeroing alert flags and deletes the pending message", async () => {
+  it("records a first-strike chat_not_found without zeroing alert flags and deletes the pending message", async () => {
     mockSendToChat.mockResolvedValue({
       ok: false, blocked: true, retryable: false, permanentFailure: true,
-      statusCode: 403, errorClass: "blocked", delivery: "blocked", retryAfterSec: null,
+      statusCode: 400, errorClass: "chat_not_found", delivery: "blocked", retryAfterSec: null,
     });
 
     const db = mockD1([
@@ -1924,11 +1924,11 @@ describe("drainPendingQueue", () => {
     expect(flagCascade).toBeUndefined();
   });
 
-  it("disables the subscriber on a second 403 within the 24h window", async () => {
+  it("disables the subscriber on a second chat_not_found within the 24h window", async () => {
     const now = Math.floor(Date.now() / 1000);
     mockSendToChat.mockResolvedValue({
       ok: false, blocked: true, retryable: false, permanentFailure: true,
-      statusCode: 403, errorClass: "blocked", delivery: "blocked", retryAfterSec: null,
+      statusCode: 400, errorClass: "chat_not_found", delivery: "blocked", retryAfterSec: null,
     });
 
     const db = mockD1([
@@ -1975,7 +1975,7 @@ describe("drainPendingQueue", () => {
     expect(subscriptionsCascade!.sql).toContain("alert_reserve=0");
   });
 
-  it("dead-letters and deletes sibling pending rows when a second 403 disables the chat", async () => {
+  it("dead-letters and deletes sibling pending rows when a second chat_not_found disables the chat", async () => {
     const { sqlite, db } = setupTelegramPendingSqlite();
     try {
       const now = Math.floor(Date.now() / 1000);
@@ -2007,7 +2007,7 @@ describe("drainPendingQueue", () => {
 
       mockSendToChat.mockResolvedValue({
         ok: false, blocked: true, retryable: false, permanentFailure: true,
-        statusCode: 403, errorClass: "blocked", delivery: "blocked", retryAfterSec: null,
+        statusCode: 400, errorClass: "chat_not_found", delivery: "blocked", retryAfterSec: null,
       });
 
       const result = await drainPendingQueue(db, "bot-token", 1);

--- a/worker/src/cron/telegram-pending/lifecycle.ts
+++ b/worker/src/cron/telegram-pending/lifecycle.ts
@@ -3,8 +3,9 @@ import { logTelegramEvent } from "../../lib/telegram-log";
 import { buildInClause, chunkArray, executeAtomicBatch } from "../../lib/db";
 
 /**
- * Two-strike gate for 403 responses. Increments the per-subscriber consecutive
- * block counter and reports whether the aggressive cascade should run.
+ * Two-strike gate for blocked or definitively unreachable chats. Increments
+ * the per-subscriber block counter and reports whether the disable cascade
+ * should run.
  *
  * Rules:
  * - First strike: record `consecutive_block_first_at = nowSec`, count = 1, return false.

--- a/worker/src/lib/__tests__/telegram.test.ts
+++ b/worker/src/lib/__tests__/telegram.test.ts
@@ -210,27 +210,39 @@ describe("sendToChat", () => {
   });
 
   it.each([
-    [{ description: "Bad Request: chat not found" }, 400, "chat_not_found"],
-    [{ description: "Bad Request: can't parse entities: unsupported start tag" }, 400, "formatting_error"],
-    [{ description: "Bad Request: message is too long" }, 400, "payload_too_large"],
-  ] as const)("classifies Telegram JSON failures as %s", async (body, status, errorClass) => {
+    [
+      { description: "Bad Request: chat not found" },
+      400,
+      { errorClass: "chat_not_found", blocked: true, delivery: "blocked" },
+    ],
+    [
+      { description: "Bad Request: can't parse entities: unsupported start tag" },
+      400,
+      { errorClass: "formatting_error", blocked: false, delivery: "permanent_failure" },
+    ],
+    [
+      { description: "Bad Request: message is too long" },
+      400,
+      { errorClass: "payload_too_large", blocked: false, delivery: "permanent_failure" },
+    ],
+  ] as const)("classifies Telegram JSON failures as %s", async (body, status, expected) => {
     fetchSpy.mockResolvedValueOnce(
       new Response(JSON.stringify({ ok: false, error_code: status, ...body }), { status }),
     );
     await expect(sendToChat("12345", "test", "bot-token")).resolves.toMatchObject({
       ok: false,
-      errorClass,
       permanentFailure: true,
+      ...expected,
     });
   });
 
-  it("returns the migration target without retrying the old chat", async () => {
+  it("prioritizes a migration target over the chat_not_found lifecycle", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           ok: false,
           error_code: 400,
-          description: "Bad Request: group chat was upgraded to a supergroup chat",
+          description: "Bad Request: chat not found",
           parameters: { migrate_to_chat_id: -1001234567890 },
         }),
         { status: 400 },
@@ -242,6 +254,8 @@ describe("sendToChat", () => {
       errorClass: "chat_migrated",
       migrateToChatId: "-1001234567890",
       permanentFailure: true,
+      blocked: false,
+      delivery: "permanent_failure",
     });
   });
 

--- a/worker/src/lib/telegram-transport-errors.ts
+++ b/worker/src/lib/telegram-transport-errors.ts
@@ -131,7 +131,9 @@ export function classifyTelegramResponseFailure(
   if (statusCode >= 500) return failure("server_error", { retryable: true, permanentFailure: false });
   if (statusCode === 413 || isPayloadTooLargeDescription(description)) return failure("payload_too_large");
   if (isFormattingDescription(description)) return failure("formatting_error");
-  if (isChatNotFoundDescription(description)) return failure("chat_not_found");
+  if (isChatNotFoundDescription(description)) {
+    return failure("chat_not_found", { blocked: true, delivery: "blocked" });
+  }
   if (statusCode === 403 || isBlockedLifecycleDescription(description)) {
     return failure("blocked", { blocked: true, delivery: "blocked" });
   }


### PR DESCRIPTION
## Summary
- preserve the exact `chat_not_found` transport class while marking the chat lifecycle-blocked
- route fresh and pending delivery through the existing once-per-run, two-strike/24-hour disable cascade
- keep migration targets, transient failures, ambiguous outcomes, formatting errors, payload errors, and generic 400s on their existing paths
- document blocked-or-unreachable cleanup and prove that disabled chats receive no later fanout

## Production evidence
- one group/channel remained eligible after 99 distinct `chat_not_found` dead letters and had no successful delivery or reply
- a second private chat has only one failure, so the existing two-strike policy avoids immediate unsubscribe on an isolated response
- current pending, due, and execution-unknown backlog remains zero; this fix prevents future repeated target creation

## Validation
- 57 Telegram test files / 716 tests passed
- Worker and test typechecks passed
- scoped typed ESLint passed
- documentation source paths, links, and sync passed
- independent review found no issues and confirmed retained 403 coverage, migration precedence, strike resets, and pending cleanup