### PR TITLE
Fix yield source freshness and wrapper ownership

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2792,8 +2792,8 @@ Set `projection=summary` for the compact workbench contract. It preserves leader
     "status": "published"
   },
   "methodology": {
-    "version": "8.34",
-    "currentVersion": "8.34",
+    "version": "8.35",
+    "currentVersion": "8.35",
     "changelogPath": "/methodology/yield-changelog/"
   },
   "_meta": { "updatedAt": 1710500000, "ageSeconds": 42, "status": "fresh" }
@@ -2956,7 +2956,7 @@ Yield adapter manifest for every yield-bearing asset. The route is public-read, 
 
 ```text
 {
-  "methodologyVersion": "v8.34",
+  "methodologyVersion": "v8.35",
   "updatedAt": 1779210000,
   "entries": [
     {
@@ -2970,7 +2970,7 @@ Yield adapter manifest for every yield-bearing asset. The route is public-read, 
       "project": null,
       "lifecycle": "active",
       "quarantineReason": null,
-      "methodologyVersion": "v8.34",
+      "methodologyVersion": "v8.35",
       "updatedAt": 1779210000
     }
   ]
@@ -3022,8 +3022,8 @@ For tracked savings-wrapper handoffs (`USDe`, `USDS`, `DAI`, `frxUSD`, `crvUSD`,
     "status": "published"
   },
   "methodology": {
-    "version": "8.34",
-    "currentVersion": "8.34",
+    "version": "8.35",
+    "currentVersion": "8.35",
     "changelogPath": "/methodology/yield-changelog/"
   }
 }
@@ -3059,7 +3059,7 @@ For tracked savings-wrapper handoffs (`USDe`, `USDS`, `DAI`, `frxUSD`, `crvUSD`,
   "pysAtPublish": 42.7,
   "pysInputsAtPublish": {
     "schemaVersion": 1,
-    "methodologyVersion": "8.34",
+    "methodologyVersion": "8.35",
     "apy30d": 12.1,
     "safetyScore": 81,
     "varianceScore": 0.18,

--- a/docs/yield-intelligence.md
+++ b/docs/yield-intelligence.md
@@ -8,7 +8,7 @@ Risk-adjusted yield tracking and ranking for yield-bearing stablecoins and curat
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v8.34`
+- **Current methodology version:** `v8.35`
 - **Public changelog page:** `/methodology/yield-changelog/`
 - **Canonical source:** `shared/lib/yield-methodology-version.ts`
 
@@ -75,7 +75,7 @@ interface OnChainRateConfig {
 }
 ```
 
-Currently configured for 23 generic vaults (all use selector `0x07a2d13a` — `convertToAssets(uint256)`):
+Currently configured for 22 generic vaults (all use selector `0x07a2d13a` — `convertToAssets(uint256)`):
 
 | Coin ID                 | Wrapper   | Contract              | Chain     |
 | ----------------------- | --------- | --------------------- | --------- |
@@ -88,7 +88,6 @@ Currently configured for 23 generic vaults (all use selector `0x07a2d13a` — `c
 | `bold-liquity`          | yBOLD     | `0x9F43...a3d8`       | Ethereum  |
 | `usdf-falcon`           | sUSDf     | `0xc8cf...4b0`        | Ethereum  |
 | `susn-noon`             | sUSN      | `0xE24a...B91D`       | Ethereum  |
-| `ustb-superstate`       | USTB      | ERC-4626 (6 decimals) | Ethereum  |
 | `thbill-theo`           | thBILL    | ERC-4626 (6 decimals) | Ethereum  |
 | `susdc-spark`           | spUSDC    | `0x28b3...a43d`       | Ethereum  |
 | `susdt-spark`           | spUSDT    | `0xe2e7...c372`       | Ethereum  |
@@ -103,9 +102,9 @@ Currently configured for 23 generic vaults (all use selector `0x07a2d13a` — `c
 | `savusd-avant`          | savUSD    | `0x06d4...219e`       | Avalanche |
 | `yousd-yield-optimizer` | yoUSD     | `0x0000...8a65`       | Base      |
 
-`scrvusd-curve` is intentionally quarantined from this generic Tier 1 reader because its trailing 7-day `convertToAssets(1e18)` delta understated Curve's current scrvUSD savings APY. It uses the scrvUSD special-case estimator below instead. `reusd-re-protocol` is also quarantined from the generic reader for now because its current `convertToAssets(1e18)` probe does not return a usable value, so it continues to rely on non-deterministic source paths until a protocol-specific deterministic adapter is added.
+`scrvusd-curve` is intentionally quarantined from this generic Tier 1 reader because its trailing 7-day `convertToAssets(1e18)` delta understated Curve's current scrvUSD savings APY. It uses the scrvUSD special-case estimator below instead. `reusd-re-protocol` is also quarantined from the generic reader for now because its current `convertToAssets(1e18)` probe does not return a usable value. `ustb-superstate` is quarantined because the tracked USTB token is not an ERC-4626 vault; restoring deterministic USTB coverage requires a dedicated Superstate NAV-oracle adapter, not another generic `convertToAssets` attempt.
 
-The monthly yield coverage audit re-probes explicit generic `convertToAssets` quarantines when monthly `chainRpcs` are available. `reusd-re-protocol` has an inactive probe config for this audit lane, but it is not part of hourly `ON_CHAIN_RATE_CONFIGS`. Successful nonzero probe rates inside the `<=300%` exchange-rate envelope produce `quarantineReadyToRestore`, `quarantineProbeSummary`, and an operator queue candidate with kind `quarantine-ready-to-restore`; restoration remains manual and requires an operator to move the adapter back into hourly coverage. `scrvusd-curve` remains quarantined from the generic reader because its dedicated current-rate reader is the intended source. After the 2026-07-09 lifecycle review, `reusd-re-protocol` carries `nextReviewAt: 2026-08-09` for the next monthly probe check, and `scrvusd-curve` carries `nextReviewAt: 2026-10-09` while the dedicated reader remains canonical.
+The monthly yield coverage audit re-probes explicit generic `convertToAssets` quarantines when monthly `chainRpcs` are available. `reusd-re-protocol` has an inactive probe config for this audit lane, but it is not part of hourly `ON_CHAIN_RATE_CONFIGS`. Successful nonzero probe rates inside the `<=300%` exchange-rate envelope produce `quarantineReadyToRestore`, `quarantineProbeSummary`, and an operator queue candidate with kind `quarantine-ready-to-restore`; restoration remains manual and requires an operator to move the adapter back into hourly coverage. `scrvusd-curve` remains quarantined because its dedicated current-rate reader is canonical, while USTB is not re-probed because its interface mismatch is structural. Lifecycle review dates remain recorded in the typed registry.
 
 **APY formula:**
 
@@ -173,7 +172,7 @@ This keeps wrapper pools like `fxSAVE` and `msY` eligible even when DeFiLlama ma
 
 **Layer 1 — Static map:** `YIELD_POOL_MAP` maps Pharos ID to a DL pool UUID. Filters for `exposure === "single"`. Finds the native/primary yield source. If a mapped UUID is missing from the DL payload, the sync logs `[yield-sync] Pool UUID ... not found in DL response, falling through` and continues to Layer 2/3 fallback matching.
 
-2026-05-22 source corrections: `usdn-smardex` now uses the exact SMARDEX USDN DeFiLlama single-exposure pool after its `navToken` flag was corrected to false. `a7a5-old-vector` was initially represented as an intentional yield gap, then gained RUB key-rate-derived coverage in v8.291.
+2026-05-22 source corrections: `usdn-smardex` now uses the exact SMARDEX USDN DeFiLlama single-exposure pool after its `navToken` flag was corrected to false. `a7a5-old-vector` was initially represented as an intentional yield gap, then gained RUB key-rate-derived coverage in v8.291. On 2026-07-15, base AZND was corrected to a fixed-peg non-NAV token and its configured yield type was moved to the exact loAZND wrapper path, preventing base-token market prices from being annualized as vault yield.
 
 **Layer 2 — Variant map:** `YIELD_VARIANT_MAP` maps to a wrapper/savings pool symbol and can also pin the wrapper chain, address, and preferred DeFiLlama project. Resolution prefers `(chain, address, project)` when configured, then `(chain, address)`, and only falls back to symbol on an unambiguous chain-scoped match. Filters for `exposure === "single"` only (stablecoin flag intentionally relaxed, since savings wrappers like fxSAVE are not flagged `stablecoin = true` in DeFiLlama).
 
@@ -315,7 +314,7 @@ Uses the structured benchmark cache refreshed daily by `fetch-tbill-rate`. USD d
 | wiTRY    | 0            | Brix TRY yield product, BIST TLREF overnight proxy using `TRY`                       |
 | A7A5     | 100          | Old Vector A7A5, CBR key-rate reserve-yield proxy using `RUB` net of 1.00pp          |
 
-Note: USTB and thBILL were previously rate-derived but have been promoted to Tier 1 `ON_CHAIN_RATE_CONFIGS` (ERC-4626 `convertToAssets`).
+Note: thBILL was previously rate-derived and remains in Tier 1 `ON_CHAIN_RATE_CONFIGS`. USTB's former generic entry is quarantined because the tracked token is not ERC-4626; its current DeFiLlama source remains available while a dedicated Superstate NAV-oracle adapter is deferred.
 VBILL is intentionally not rate-derived in v8.23; its coin metadata documents an on-chain NAVLink-style NAV feed, so it belongs to a future NAV-oracle source lane rather than this benchmark-proxy roster.
 
 Rate-derived runs after Tier 3 in the resolution loop and participates in the `is_best` selection like any other source. For tokens that also have price-derived or DL sources, the highest-APY source wins.
@@ -520,11 +519,11 @@ https://alfred.stlouisfed.org/graph/alfredgraph.csv?id=IUDZOS2
 | `reward-heavy`     | `apyReward / apy > 0.8`                                                                                                                                                                                                                                                                                            | 80%+ from incentives, not base yield                                                |
 | `tvl-outflow`      | TVL dropped > 20% from prev week                                                                                                                                                                                                                                                                                   | Capital leaving the protocol                                                        |
 | `zero-yield`       | `currentApy === 0 AND apy30d > 0.5%`                                                                                                                                                                                                                                                                               | Yield dropped to zero but had recent activity                                       |
-| `data-stale`       | Hourly source families are older than 3 `sync-yield-data` intervals (currently 180 min); supplemental Aave/Compound + protocol-API rows are older than 6 hours; `price-derived` rows are older than 36 hours; `rate-derived` rows are older than 48 hours; ordinary comparison anchors are older than 14 days; price-derived and Midas/Ondo NAV anchors are older than 45 days | Yield data or its APY comparison anchor is older than the source's expected cadence/window |
+| `data-stale`       | Hourly source families are older than 3 `sync-yield-data` intervals (currently 180 min); supplemental Aave/Compound + protocol-API rows are older than 6 hours, except Hashnote USYC and Midas mMEV observations accepted through 72 hours; `price-derived` rows are older than 36 hours; `rate-derived` rows are older than 48 hours; ordinary comparison anchors are older than 14 days; price-derived and Midas/Ondo NAV anchors are older than 45 days | Yield data or its APY comparison anchor is older than the source's expected cadence/window |
 
 All frontend surfaces (leaderboard, detail section, history chart) format warning signals via the shared `formatYieldWarningSignal()` function in `src/lib/yield-constants.ts`, which maps known signal keys to human-readable labels and falls back to hyphen-to-space conversion for unknown signals.
 
-At rankings cache-build time, `sync-yield-data` decorates rows with the read-time-only `data-stale` signal when the resolved source observation or its comparison anchor exceeds the source-aware window. Hourly publication families use the shared three-interval threshold (currently 180 minutes; `STALE_THRESHOLD_MS`), supplemental protocol-API and optional Aave/Compound rows use 6 hours (`SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS`), price-derived source observations use 36 hours (`PRICE_DERIVED_STALE_THRESHOLD_MS`), and rate-derived rows use 48 hours (`RATE_DERIVED_STALE_THRESHOLD_MS`) because the benchmark producer is daily. Ordinary exchange-rate comparison anchors use 14 days (`COMPARISON_ANCHOR_STALE_THRESHOLD_MS`); price-derived plus the Midas mMEV and Ondo USDY NAV-oracle rows use 45 days (`LONG_HORIZON_COMPARISON_ANCHOR_STALE_THRESHOLD_MS`) because those adapters deliberately choose anchors from a 7-45 day window. The signal is included in cached rankings responses but is not written back to `yield_data`.
+At rankings cache-build time, `sync-yield-data` decorates rows with the read-time-only `data-stale` signal when the resolved source observation or its comparison anchor exceeds the source-aware window. Hourly publication families use the shared three-interval threshold (currently 180 minutes; `STALE_THRESHOLD_MS`), supplemental protocol-API and optional Aave/Compound rows use 6 hours (`SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS`), and the exact Hashnote USYC and Midas mMEV NAV source keys use the same 72-hour acceptance window enforced by their adapters (`SLOW_NAV_SOURCE_STALE_THRESHOLD_MS`). Price-derived source observations use 36 hours (`PRICE_DERIVED_STALE_THRESHOLD_MS`), and rate-derived rows use 48 hours (`RATE_DERIVED_STALE_THRESHOLD_MS`) because the benchmark producer is daily. Ordinary exchange-rate comparison anchors use 14 days (`COMPARISON_ANCHOR_STALE_THRESHOLD_MS`); price-derived plus the Midas mMEV and Ondo USDY NAV-oracle rows use 45 days (`LONG_HORIZON_COMPARISON_ANCHOR_STALE_THRESHOLD_MS`) because those adapters deliberately choose anchors from a 7-45 day window. The signal is included in cached rankings responses but is not written back to `yield_data`.
 
 The sync also records comparison-anchor freshness under `sourceCoverage.comparisonAnchorFreshness`. The summary includes the anchored row count, stale anchor count, oldest stale anchor age/source, bounded stale examples with each source's `maxAgeSeconds`, and a truncation flag. Publication metadata additionally records `sourceCoverage.previousPublishedRankingCount` and `sourceCoverage.publishedRankingCountDelta`; severe coverage-regression guards emit the same ranking-count fields at top level before normal source coverage is assembled. `/api/status` exposes both shapes as `yieldHealth.previousRankingCount` and `yieldHealth.rankingCountDelta` so operators can see coverage growth or shrinkage without manually comparing payloads. These summaries are observability-only: stale-anchor warnings still follow the read-time `data-stale` rules above, and the freshness/ranking-delta metadata does not change source arbitration or scoring.
 

--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:05caf4f7430b1d15d8d75ac63bb052fbada12acffbc46c223a7d10e18d6da6b7",
+  "sourceChecksum": "sha256:ef0bbc2b7a9a118aeefa88a8c8ebfd837bc0dd2019bbba73cd414bfe8937a73c",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:2cdbf4a2054e3e74c870c1349126b64e83da0997a8505299f76af6af0520fb19",
+      "checksum": "sha256:33070aa79bb10dcd0b08243f312c8864f192ae2cb1442332723aa2ee3fd370ca",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/methodology-changelogs/yield-methodology/v8.ts
+++ b/shared/data/methodology-changelogs/yield-methodology/v8.ts
@@ -2,6 +2,22 @@ import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions
 
 export const YIELD_METHODOLOGY_V8: readonly MethodologyChangelogEntry[] = [
   {
+    version: "8.35",
+    title: "Source-Cadence and Wrapper Corrections",
+    date: "2026-07-16",
+    effectiveAt: 1784160000,
+    summary:
+      "Yield freshness now follows the accepted cadence of two slow protocol-native NAV sources, AZND yield stays attached to its loAZND wrapper instead of base-token prices, and the incompatible generic USTB reader is quarantined.",
+    impact: [
+      "Hashnote USYC and Midas mMEV observations remain score-eligible through the same 72-hour source-age limit enforced by their adapters; every other protocol-API row keeps the existing six-hour threshold",
+      "Base AZND is no longer treated as a NAV-appreciating token, so supply-history market prices cannot be annualized as holder yield; its exact Monad loAZND wrapper pool remains the configured lending-vault source",
+      "USTB leaves the generic ERC-4626 reader because the tracked token does not implement `convertToAssets`; its valid DeFiLlama source remains available and deterministic replacement requires a dedicated Superstate NAV-oracle adapter",
+      "PYS formula weights, source-risk penalties, comparison-anchor windows, benchmark rules, and source arbitration order are unchanged",
+    ],
+    commits: [],
+    reconstructed: false,
+  },
+  {
     version: "8.34",
     title: "Estimated Scores for Incomplete Evidence",
     date: "2026-07-11",

--- a/shared/data/stablecoins/coins/aznd-mu-digital.json
+++ b/shared/data/stablecoins/coins/aznd-mu-digital.json
@@ -2,14 +2,14 @@
   "id": "aznd-mu-digital",
   "name": "Mu Digital AZND",
   "symbol": "AZND",
-  "oneLiner": "AZND is Mu Digital's KYC-gated, NAV-bearing dollar token backed by a Singapore-regulated Asia credit fund, with a muBOND junior tranche absorbing first losses.",
+  "oneLiner": "AZND is Mu Digital's KYC-gated dollar token; users lock it in the loAZND vault for Asia credit yield, with muBOND absorbing first losses.",
   "flags": {
     "backing": "rwa-backed",
     "pegCurrency": "USD",
     "governance": "centralized",
     "yieldBearing": true,
     "rwa": true,
-    "navToken": true
+    "navToken": false
   },
   "collateral": "The last Accountable snapshot Pharos ingested showed the Asset Pool concentrated in short-term cash and liquid bonds; Mu Digital's published mandate still targets an Asia credit portfolio with illiquid private credit capped at 20%, and the muBOND junior tranche overcollateralizes AZND at ~118%",
   "pegMechanism": "KYC-gated 1:1 mint using USDC, USDT, or AUSD; redemptions processed weekly (~7 calendar days) per Singapore fund liquidity calendar; muBOND junior tranche absorbs NAV losses first; insurance fund provides additional backstop; permissionless secondary swaps via DEX partners on Monad",
@@ -164,8 +164,8 @@
     ]
   },
   "yieldConfig": {
-    "yieldSource": "Mu Digital Asian Dollar credit fund",
-    "yieldType": "nav-appreciation"
+    "yieldSource": "Mu Digital loAZND vault",
+    "yieldType": "lending-vault"
   },
   "chainTier": "ethereum",
   "deploymentModel": "native-multichain",

--- a/shared/lib/methodology-versions/constants.ts
+++ b/shared/lib/methodology-versions/constants.ts
@@ -48,6 +48,6 @@ export const PSI_METHODOLOGY_VERSION = "3.6";
 export const PSI_METHODOLOGY_VERSION_LABEL = methodologyLabel(PSI_METHODOLOGY_VERSION);
 export const PSI_METHODOLOGY_CHANGELOG_PATH = "/methodology/stability-index-changelog/";
 
-export const YIELD_METHODOLOGY_VERSION = "8.34";
+export const YIELD_METHODOLOGY_VERSION = "8.35";
 export const YIELD_METHODOLOGY_VERSION_LABEL = methodologyLabel(YIELD_METHODOLOGY_VERSION);
 export const YIELD_METHODOLOGY_CHANGELOG_PATH = "/methodology/yield-changelog/";

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -1,6 +1,6 @@
 {
   "api-reference": {
-    "dateModified": "2026-07-15T21:01:21+02:00",
+    "dateModified": "2026-07-16T05:09:10+02:00",
     "dateCreated": "2026-02-23T15:28:17+01:00"
   },
   "architecture": {
@@ -64,7 +64,7 @@
     "dateCreated": "2026-03-01T16:21:41+01:00"
   },
   "yield-intelligence": {
-    "dateModified": "2026-07-14T23:53:42+02:00",
+    "dateModified": "2026-07-16T05:09:10+02:00",
     "dateCreated": "2026-03-01T16:21:41+01:00"
   },
   "shadow-stablecoins": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -83,7 +83,7 @@
   "/stablecoin/autousd-auto-finance/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/avusd-avant/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/axcnh-anchorx/": "2026-07-15T17:09:51+02:00",
-  "/stablecoin/aznd-mu-digital/": "2026-07-15T17:09:51+02:00",
+  "/stablecoin/aznd-mu-digital/": "2026-07-16T05:09:10+02:00",
   "/stablecoin/bbqusdc-steakhouse/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/bc3m-backed/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/bd-basedollar/": "2026-07-15T17:09:51+02:00",

--- a/worker/src/cron/__tests__/yield-config-registry.test.ts
+++ b/worker/src/cron/__tests__/yield-config-registry.test.ts
@@ -134,6 +134,26 @@ describe("yield config registry", () => {
     });
   });
 
+  it("keeps AZND on the exact loAZND wrapper path without price-derived fallback", () => {
+    const coin = trackedCoinsById.get("aznd-mu-digital");
+    const manifest = YIELD_ADAPTER_MANIFEST.find((entry) => entry.stablecoinId === "aznd-mu-digital");
+
+    expect(coin?.flags).toMatchObject({ yieldBearing: true, navToken: false });
+    expect(ON_CHAIN_RATE_CONFIGS.some((entry) => entry.stablecoinId === "aznd-mu-digital")).toBe(false);
+    expect(YIELD_VARIANT_MAP["aznd-mu-digital"]).toMatchObject({
+      variantSymbol: "loAZND",
+      variantChain: "monad",
+      variantAddress: "0x9c82eB49B51F7Dc61e22Ff347931CA32aDc6cd90",
+    });
+    expect(manifest?.strategies).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "native-pool" }),
+      expect.objectContaining({ kind: "variant-pool" }),
+    ]));
+    expect(manifest?.strategies).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "price-derived" }),
+    ]));
+  });
+
   it("promotes Wave 1 tracked vaults to deterministic on-chain readers", () => {
     const configsById = new Map(ON_CHAIN_RATE_CONFIGS.map((config) => [config.stablecoinId, config] as const));
     const unsupportedLocalTargets = WAVE_1_DETERMINISTIC_PROMOTION_IDS.filter((stablecoinId) => {
@@ -267,7 +287,7 @@ describe("yield config registry", () => {
       .map((entry) => entry.stablecoinId)
       .sort();
 
-    expect(quarantined).toEqual(["reusd-re-protocol", "scrvusd-curve"]);
+    expect(quarantined).toEqual(["reusd-re-protocol", "scrvusd-curve", "ustb-superstate"]);
   });
 
   it("keeps quarantined deterministic probe configs inactive until manually restored", () => {
@@ -275,6 +295,8 @@ describe("yield config registry", () => {
 
     expect(probeIds).toEqual(["reusd-re-protocol"]);
     expect(onChainIds.has("reusd-re-protocol")).toBe(false);
+    expect(onChainIds.has("ustb-superstate")).toBe(false);
+    expect(probeIds).not.toContain("ustb-superstate");
     expect(QUARANTINED_DETERMINISTIC_PROBE_CONFIGS[0]).toMatchObject({
       stablecoinId: "reusd-re-protocol",
       chain: "ethereum",
@@ -293,6 +315,10 @@ describe("yield config registry", () => {
     expect(YIELD_ADAPTER_LIFECYCLE["reusd-re-protocol"]).toMatchObject({
       lifecycle: "quarantined",
       reason: expect.objectContaining({ nextReviewAt: "2026-08-09" }),
+    });
+    expect(YIELD_ADAPTER_LIFECYCLE["ustb-superstate"]).toMatchObject({
+      lifecycle: "quarantined",
+      reason: expect.objectContaining({ code: "token-not-erc4626", nextReviewAt: "2026-10-15" }),
     });
   });
 

--- a/worker/src/cron/__tests__/yield-helpers.test.ts
+++ b/worker/src/cron/__tests__/yield-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   RATE_DERIVED_STALE_THRESHOLD_MS,
   STALE_THRESHOLD_MS,
   SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS,
+  SLOW_NAV_SOURCE_STALE_THRESHOLD_MS,
   COMPARISON_ANCHOR_STALE_THRESHOLD_MS,
   LONG_HORIZON_COMPARISON_ANCHOR_STALE_THRESHOLD_MS,
   DETERMINISTIC_APY_SANITY_MAX,
@@ -54,6 +55,17 @@ describe("getRankingStaleThresholdMs", () => {
     expect(getRankingStaleThresholdMs("protocol-api", "protocol-api:pendle:ethereum:0xpool")).toBe(
       SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS,
     );
+  });
+
+  it("matches slow protocol-native NAV sources to their adapter freshness window", () => {
+    expect(getRankingStaleThresholdMs("protocol-api", "protocol-api:hashnote-usyc")).toBe(
+      SLOW_NAV_SOURCE_STALE_THRESHOLD_MS,
+    );
+    expect(getRankingStaleThresholdMs("protocol-api", "protocol-api:midas-mmev-nav-oracle")).toBe(
+      SLOW_NAV_SOURCE_STALE_THRESHOLD_MS,
+    );
+    expect(getRankingStaleThresholdMs("defillama", "protocol-api:hashnote-usyc")).toBe(STALE_THRESHOLD_MS);
+    expect(SLOW_NAV_SOURCE_STALE_THRESHOLD_MS).toBe(3 * 24 * 60 * 60 * 1000);
   });
 
   it("uses the supplemental threshold for optional onchain source keys", () => {

--- a/worker/src/cron/__tests__/yield-publication.test.ts
+++ b/worker/src/cron/__tests__/yield-publication.test.ts
@@ -15,6 +15,7 @@ import {
   PRICE_DERIVED_STALE_THRESHOLD_MS,
   STALE_THRESHOLD_MS,
   SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS,
+  SLOW_NAV_SOURCE_STALE_THRESHOLD_MS,
   COMPARISON_ANCHOR_STALE_THRESHOLD_MS,
   LONG_HORIZON_COMPARISON_ANCHOR_STALE_THRESHOLD_MS,
 } from "../yield-helpers";
@@ -277,6 +278,21 @@ describe("buildYieldRankingsPayloadFromEvaluatedSources", () => {
     });
 
     expect(payload.rankings[0]?.warningSignals).toContain("data-stale");
+  });
+
+  it("keeps accepted slow NAV observations fresh through their three-day window", () => {
+    const thresholdSec = SLOW_NAV_SOURCE_STALE_THRESHOLD_MS / 1000;
+    const beforeBoundary = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec, {
+      dataSource: "protocol-api",
+      sourceKey: "protocol-api:hashnote-usyc",
+    });
+    const afterBoundary = buildPayloadWithObservedAt(Math.floor(FIXED_NOW.getTime() / 1000) - thresholdSec - 1, {
+      dataSource: "protocol-api",
+      sourceKey: "protocol-api:hashnote-usyc",
+    });
+
+    expect(beforeBoundary.rankings[0]?.warningSignals).not.toContain("data-stale");
+    expect(afterBoundary.rankings[0]?.warningSignals).toContain("data-stale");
   });
 
   it("does not add data-stale for a fresh comparison anchor", () => {

--- a/worker/src/cron/yield-config-rate-sources.ts
+++ b/worker/src/cron/yield-config-rate-sources.ts
@@ -94,15 +94,6 @@ export const ON_CHAIN_RATE_CONFIGS: OnChainRateConfig[] = [
       "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
   },
   {
-    stablecoinId: "ustb-superstate",
-    chain: "ethereum",
-    contract: "0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e",
-    selector: "0x07a2d13a",
-    decimals: 6,
-    inputAmount:
-      "0x00000000000000000000000000000000000000000000000000000000000f4240",
-  },
-  {
     stablecoinId: "thbill-theo",
     chain: "ethereum",
     contract: "0x5FA487BCa6158c64046B2813623e20755091DA0b",
@@ -258,6 +249,7 @@ export const RATE_DERIVED_CONFIGS: RateDerivedConfig[] = [
  * - scrvusd-curve: uses a dedicated scrvUSD profit-unlock current-rate reader;
  *   generic 7-day convertToAssets deltas understate Curve's current savings APY
  * - reusd-re-protocol: current convertToAssets probe returns empty data
+ * - ustb-superstate: the tracked USTB token is not an ERC-4626 vault
  */
 const QUARANTINED_DETERMINISTIC_ADAPTERS_TYPED: Record<string, YieldAdapterLifecycleReason> = {
   "scrvusd-curve": {
@@ -271,6 +263,12 @@ const QUARANTINED_DETERMINISTIC_ADAPTERS_TYPED: Record<string, YieldAdapterLifec
     since: "2026-03-15",
     nextReviewAt: "2026-08-09",
     note: "2026-07-09 review: keep quarantined pending a successful monthly probe or protocol-specific deterministic reader; generic convertToAssets probe returns empty data",
+  },
+  "ustb-superstate": {
+    code: "token-not-erc4626",
+    since: "2026-07-15",
+    nextReviewAt: "2026-10-15",
+    note: "The tracked USTB token does not implement ERC-4626 convertToAssets; keep the generic reader disabled until a dedicated Superstate NAV-oracle adapter is implemented",
   },
 };
 

--- a/worker/src/cron/yield-config-variants.ts
+++ b/worker/src/cron/yield-config-variants.ts
@@ -10,7 +10,10 @@ export const YIELD_VARIANT_MAP: Record<string, YieldVariant> = {
   // AZND -> loAZND (Mu Digital locked/staking wrapper)
   "aznd-mu-digital": {
     variantSymbol: "loAZND",
+    variantAddress: "0x9c82eB49B51F7Dc61e22Ff347931CA32aDc6cd90",
     variantChain: "monad",
+    yieldSource: "Mu Digital loAZND vault",
+    yieldType: "lending-vault",
   },
   // BOLD -> yBOLD (Yearn vault over Liquity Stability Pool)
   "bold-liquity": {

--- a/worker/src/cron/yield-helpers.ts
+++ b/worker/src/cron/yield-helpers.ts
@@ -24,6 +24,13 @@ export const STALE_THRESHOLD_MS = CRON_INTERVALS["sync-yield-data"] * YIELD_STAL
 const SUPPLEMENTAL_STALE_THRESHOLD_CYCLES = 1.5;
 export const SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS =
   CRON_INTERVALS["sync-yield-supplemental"] * SUPPLEMENTAL_STALE_THRESHOLD_CYCLES * 1000;
+// These protocol-native NAV sources publish less frequently and already reject
+// observations older than three days in their adapters.
+export const SLOW_NAV_SOURCE_STALE_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000;
+const SLOW_NAV_SOURCE_KEYS = new Set([
+  "protocol-api:hashnote-usyc",
+  "protocol-api:midas-mmev-nav-oracle",
+]);
 // Price-derived rows are backed by daily supply-history snapshots, so allow one missed daily write plus buffer.
 export const PRICE_DERIVED_STALE_THRESHOLD_MS = 36 * 60 * 60 * 1000;
 // Rate-derived rows inherit daily benchmark observations rather than the hourly
@@ -176,6 +183,9 @@ export function getRankingStaleThresholdMs(dataSource: string, sourceKey?: strin
   }
   if (dataSource === "rate-derived") {
     return RATE_DERIVED_STALE_THRESHOLD_MS;
+  }
+  if (dataSource === "protocol-api" && sourceKey != null && SLOW_NAV_SOURCE_KEYS.has(sourceKey)) {
+    return SLOW_NAV_SOURCE_STALE_THRESHOLD_MS;
   }
   if (dataSource === "protocol-api" || (dataSource === "onchain" && isSupplementalOnchainSource(sourceKey))) {
     return SUPPLEMENTAL_SOURCE_STALE_THRESHOLD_MS;


### PR DESCRIPTION
## Summary\n- align Hashnote USYC and Midas mMEV source freshness with their adapter-enforced 72-hour acceptance window\n- stop price-derived yield on base AZND and pin the official Monad loAZND wrapper path\n- quarantine USTB's invalid generic ERC-4626 reader without repeating the structurally incompatible probe\n- publish the score-affecting behavior as Yield Methodology v8.35\n\n## Validation\n- 170 focused yield tests\n- worker typecheck\n- cron schedule and connection-budget checks\n- stablecoin catalog and generated-artifact checks\n- full validate:prebuild\n- methodology tests and verified documentation sync/link/source-path checks\n\n## Production context\nThe DEX producer, DEWS, status lane, report-card cache, and Telegram dispatch/watchdog/pulse have already recovered naturally on the prior deployment. This PR removes the remaining yield-source correctness hazards before the next ranking cycle.