### PR TITLE
fix(ops): repair degraded production data lanes

### DIFF
--- a/docs/live-reserves.md
+++ b/docs/live-reserves.md
@@ -64,6 +64,7 @@ The single lightweight declaration in `shared/types/live-reserve-adapter-declara
 
 `attestation-pdf-index` is a validated-static adapter for issuer pages that expose dated PDF attestations. It selects the newest dated PDF link, including Webflow-style gated PDF attributes, validates source freshness from the report date, and emits configured static reserve slices until full PDF text extraction is implemented.
 The adapter normally fetches issuer index pages with browser-style `Origin`, `Referer`, and `Accept-Language` headers because some WordPress/hosting stacks rate-limit generic Worker HTML requests while still serving normal browser navigations. Hostinger/WordPress pages that reject browser-origin hints, currently Schuman's reserve-audit page, use the neutral Pharos fetch identity instead.
+USDv reads this adapter from Solomon Labs' public GitHub attestation directory because the legacy GitBook route now serves the issuer's client-rendered documentation shell instead of the dated report index.
 
 ### Fallback Inputs
 

--- a/docs/supply-snapshot.md
+++ b/docs/supply-snapshot.md
@@ -37,7 +37,8 @@ When DefiLlama publishes a tracked zero-supply row for an asset that also has po
 6. Build the exact completion identity and check the once-per-UTC-date guard:
    - read cache key `snapshot-supply:last-write`
    - coverage-version 2 markers bind the UTC date to a SHA-256 digest of the sorted required active IDs plus the exact applied waiver IDs, owners, and expiries; count-only version 1 markers remain readable but cannot authorize a writer skip
-   - skip with `reason: "already_written_today"` only when the marker date and digest match the current complete coverage evaluation (one snapshot per UTC day, written by the first healthy run after UTC midnight; a wall-clock cooldown previously drifted the write time through the day)
+   - when the marker date and digest match the current complete coverage evaluation, conditionally repair only same-day rows whose stored `price` is still `null` and whose current cache row now has a positive price; otherwise skip with `reason: "already_written_today"`
+   - same-day repair never overwrites a non-null historical price, circulating supply, or rows outside cron ownership
 7. For each PSI-eligible cached asset:
    - Sum circulating supply via `sumPegBuckets(asset.circulating)` --- already in USD
    - Skip if sum <= 0
@@ -74,7 +75,7 @@ CREATE INDEX idx_supply_hist_date ON supply_history(snapshot_date DESC);
 | `circulating_usd` | REAL | Total market cap in USD |
 | `price` | REAL | USD price at snapshot time (may be `null`) |
 
-The primary key `(stablecoin_id, snapshot_date)` enforces one row per coin per UTC day. The cron uses `INSERT OR REPLACE`, so re-runs on the same day are idempotent and refresh the row with the latest valid cached values. In the checked-in migration tree this table now lives in `worker/migrations/0000_baseline.sql`.
+The primary key `(stablecoin_id, snapshot_date)` enforces one row per coin per UTC day. The first complete run atomically replaces the cron-owned daily set. Later complete runs only fill a same-day `null` price from a current positive cache price, preserving the original circulating value and every non-null price. In the checked-in migration tree this table now lives in `worker/migrations/0000_baseline.sql`.
 
 ### onchain_supply
 

--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:c3cf4332eeff6740e24712a67ed80c2a052d2d0e3d73811482cd17ba7f8cac6e",
+  "sourceChecksum": "sha256:4db825792a2b54a2f80f0a901e71d20eead4624140f3e4a892c089e1b29b1c80",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:85861b3f7b757fe508bb595b9507ebdf8b434f5e40fd6f302a466ae6c7390c05",
+      "checksum": "sha256:fe83b066f7afd2c690ec2b853ff88cf0197108af39f3ef6139870098f95ecc8b",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/stablecoins/coins/usdv-solomon.json
+++ b/shared/data/stablecoins/coins/usdv-solomon.json
@@ -126,7 +126,7 @@
     "inputs": {
       "primary": {
         "kind": "http-html",
-        "url": "https://docs.solomonlabs.org/transparency/asset-attestations"
+        "url": "https://github.com/SolomonLabs/attestations/tree/main/ceffu/2026"
       }
     },
     "params": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -403,7 +403,7 @@
   "/stablecoin/usdtb-ethena/": "2026-07-15T23:13:15+02:00",
   "/stablecoin/usdu-unitas/": "2026-07-16T20:19:15+02:00",
   "/stablecoin/usdu-usdu-finance/": "2026-07-15T17:09:51+02:00",
-  "/stablecoin/usdv-solomon/": "2026-07-15T17:09:51+02:00",
+  "/stablecoin/usdv-solomon/": "2026-07-17T06:47:36+02:00",
   "/stablecoin/usdx-hex-trust/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/usdx-kava/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/usdxl-last/": "2026-07-15T17:09:51+02:00",

--- a/worker/migrations/0210_cngn_ddr_events_90604_90608_link.sql
+++ b/worker/migrations/0210_cngn_ddr_events_90604_90608_link.sql
@@ -1,0 +1,561 @@
+-- rollout-safety: backward-compatible
+-- Link the reviewed cNGN live flap chain to its active, unsealed canonical
+-- incident and advance the current source pointer without mutating source rows.
+
+-- Authorize all links only when the complete reviewed batch, predecessor, and
+-- canonical incident still match production.
+INSERT INTO depeg_resolver_event_repair_authorizations
+  (event_id, incident_key, operation, columns_json, required_revision_id, required_erratum_id,
+   reason, created_at, expires_at, created_by)
+SELECT
+  target.event_id,
+  'ddr2:d71d5088a08922584d989cfe03ae8388',
+  'incident_link',
+  '["event_id","incident_key"]',
+  NULL,
+  NULL,
+  target.reason,
+  unixepoch(),
+  4102444800,
+  'migration-0210'
+FROM (
+  SELECT 90604 AS event_id,
+         'cNGN live flap 90604 belongs to the unsealed event 90511 canonical incident' AS reason
+  UNION ALL
+  SELECT 90606,
+         'cNGN live flap 90606 belongs to the unsealed event 90511 canonical incident'
+  UNION ALL
+  SELECT 90607,
+         'cNGN live flap 90607 belongs to the unsealed event 90511 canonical incident'
+  UNION ALL
+  SELECT 90608,
+         'cNGN live tail 90608 belongs to the unsealed event 90511 canonical incident'
+) target
+WHERE 4 = (
+    SELECT COUNT(*)
+    FROM depeg_events e
+    WHERE (
+        e.id = 90604
+        AND e.stablecoin_id = 'cngn-compliant-naira'
+        AND e.symbol = 'cNGN'
+        AND e.peg_type = 'peggedNGN'
+        AND e.direction = 'below'
+        AND e.peak_deviation_bps = -152
+        AND e.started_at = 1784189952
+        AND e.ended_at = 1784190853
+        AND e.start_price = 0.984754
+        AND e.peak_price = 0.984754
+        AND e.recovery_price = 0.988983
+        AND e.peg_reference = 1
+        AND e.source = 'live'
+        AND e.confirmation_sources IS NULL
+        AND e.pending_reason IS NULL
+        AND e.close_reason = 'recovered-native'
+      )
+      OR (
+        e.id = 90606
+        AND e.stablecoin_id = 'cngn-compliant-naira'
+        AND e.symbol = 'cNGN'
+        AND e.peg_type = 'peggedNGN'
+        AND e.direction = 'below'
+        AND e.peak_deviation_bps = -152
+        AND e.started_at = 1784192670
+        AND e.ended_at = 1784194450
+        AND e.start_price = 0.984802
+        AND e.peak_price = 0.984802
+        AND e.recovery_price = 0.985531
+        AND e.peg_reference = 1
+        AND e.source = 'live'
+        AND e.confirmation_sources IS NULL
+        AND e.pending_reason IS NULL
+        AND e.close_reason = 'recovered-native'
+      )
+      OR (
+        e.id = 90607
+        AND e.stablecoin_id = 'cngn-compliant-naira'
+        AND e.symbol = 'cNGN'
+        AND e.peg_type = 'peggedNGN'
+        AND e.direction = 'below'
+        AND e.peak_deviation_bps = -192
+        AND e.started_at = 1784197137
+        AND e.ended_at = 1784203436
+        AND e.start_price = 0.982094
+        AND e.peak_price = 0.980764
+        AND e.recovery_price = 0.985359
+        AND e.peg_reference = 1
+        AND e.source = 'live'
+        AND e.confirmation_sources IS NULL
+        AND e.pending_reason IS NULL
+        AND e.close_reason = 'recovered-native'
+      )
+      OR (
+        e.id = 90608
+        AND e.stablecoin_id = 'cngn-compliant-naira'
+        AND e.symbol = 'cNGN'
+        AND e.peg_type = 'peggedNGN'
+        AND e.direction = 'below'
+        AND e.peak_deviation_bps = -154
+        AND e.started_at = 1784211551
+        AND e.ended_at = 1784212483
+        AND e.start_price = 0.984619
+        AND e.peak_price = 0.984619
+        AND e.recovery_price = 0.986806
+        AND e.peg_reference = 1
+        AND e.source = 'live'
+        AND e.confirmation_sources IS NULL
+        AND e.pending_reason IS NULL
+        AND e.close_reason = 'recovered-native'
+      )
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_events e
+    WHERE e.id = 90599
+      AND e.stablecoin_id = 'cngn-compliant-naira'
+      AND e.symbol = 'cNGN'
+      AND e.peg_type = 'peggedNGN'
+      AND e.direction = 'below'
+      AND e.peak_deviation_bps = -158
+      AND e.started_at = 1784151172
+      AND e.ended_at = 1784154780
+      AND e.start_price = 0.984154
+      AND e.peak_price = 0.984154
+      AND e.recovery_price = 0.985718
+      AND e.peg_reference = 1
+      AND e.source = 'live'
+      AND e.close_reason = 'recovered-native'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.stablecoin_id = 'cngn-compliant-naira'
+      AND i.peg_currency = 'NGN'
+      AND i.direction = 'below'
+      AND i.first_event_id = 90511
+      AND i.current_event_id = 90599
+      AND i.first_started_at = 1783650896
+      AND i.current_started_at = 1784151172
+      AND i.first_observed_peak_bucket_bps = 150
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+      AND i.source_fingerprint = 'b34dc1832aa964c5828d0b50ac025a4181efdd854c644c14281838490b644a15'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_public_predictions p
+    WHERE p.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_event_links l
+    WHERE l.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND l.event_id = 90511
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_event_links l
+    WHERE l.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND l.event_id = 90599
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM worker_repair_tasks t
+    WHERE t.kind = 'ddr-repair-required-event'
+      AND t.subject_id IN ('90604', '90606', '90607', '90608')
+      AND t.state IN ('open', 'claimed', 'deferred', 'failed')
+      AND t.payload_json = '{"eventId":' || t.subject_id || ',"reason":"Unlinked depeg event ' || t.subject_id || ' overlaps nearby canonical incident ddr2:d71d5088a08922584d989cfe03ae8388; explicit repair required"}'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_event_links l
+    WHERE l.event_id IN (90604, 90606, 90607, 90608)
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_event_repair_authorizations a
+    WHERE a.event_id = target.event_id
+      AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND a.operation = 'incident_link'
+      AND a.created_by = 'migration-0210'
+  );
+
+INSERT INTO depeg_resolver_event_repair_authorization_consumptions
+  (authorization_id, event_id, incident_key, operation, consumed_at, consumer)
+SELECT a.id, a.event_id, a.incident_key, a.operation, unixepoch(), 'migration-0210'
+FROM depeg_resolver_event_repair_authorizations a
+WHERE a.event_id IN (90604, 90606, 90607, 90608)
+  AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  AND a.operation = 'incident_link'
+  AND a.created_by = 'migration-0210'
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_event_repair_authorizations complete
+    WHERE complete.event_id IN (90604, 90606, 90607, 90608)
+      AND complete.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND complete.operation = 'incident_link'
+      AND complete.created_by = 'migration-0210'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_event_repair_authorization_consumptions c
+    WHERE c.authorization_id = a.id
+  );
+
+INSERT INTO depeg_resolver_incident_event_links
+  (incident_key, event_id, relation, repair_authorization_id, linked_at, note)
+SELECT
+  a.incident_key,
+  a.event_id,
+  'repair_replacement',
+  a.id,
+  unixepoch(),
+  'reviewed cNGN live flap linked through explicit repair authorization'
+FROM depeg_resolver_event_repair_authorizations a
+JOIN depeg_resolver_event_repair_authorization_consumptions c
+  ON c.authorization_id = a.id
+ AND c.event_id = a.event_id
+ AND c.incident_key = a.incident_key
+ AND c.operation = a.operation
+WHERE a.event_id IN (90604, 90606, 90607, 90608)
+  AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  AND a.operation = 'incident_link'
+  AND a.created_by = 'migration-0210'
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_event_repair_authorizations complete
+    JOIN depeg_resolver_event_repair_authorization_consumptions consumed
+      ON consumed.authorization_id = complete.id
+     AND consumed.event_id = complete.event_id
+     AND consumed.incident_key = complete.incident_key
+     AND consumed.operation = complete.operation
+    WHERE complete.event_id IN (90604, 90606, 90607, 90608)
+      AND complete.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND complete.operation = 'incident_link'
+      AND complete.created_by = 'migration-0210'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_event_links l
+    WHERE l.event_id = a.event_id
+  );
+
+-- Authorize and record the complete ordered pointer history as one batch. The
+-- incident row itself can then move directly to the latest source event.
+INSERT INTO depeg_resolver_event_repair_authorizations
+  (event_id, incident_key, operation, columns_json, required_revision_id, required_erratum_id,
+   reason, created_at, expires_at, created_by)
+SELECT
+  transition.current_event_id,
+  'ddr2:d71d5088a08922584d989cfe03ae8388',
+  'incident_current_update',
+  '["current_event_id","current_started_at"]',
+  NULL,
+  NULL,
+  transition.reason,
+  unixepoch(),
+  4102444800,
+  'migration-0210'
+FROM (
+  SELECT 90604 AS current_event_id,
+         'reviewed cNGN live flap 90604 follows event 90599 as the canonical current source' AS reason
+  UNION ALL
+  SELECT 90606,
+         'reviewed cNGN live flap 90606 follows event 90604 as the canonical current source'
+  UNION ALL
+  SELECT 90607,
+         'reviewed cNGN live flap 90607 follows event 90606 as the canonical current source'
+  UNION ALL
+  SELECT 90608,
+         'reviewed cNGN live tail 90608 follows event 90607 as the canonical current source'
+) transition
+WHERE EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.current_event_id = 90599
+      AND i.current_started_at = 1784151172
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_public_predictions p
+    WHERE p.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_incident_event_links l
+    JOIN depeg_resolver_event_repair_authorizations a
+      ON a.id = l.repair_authorization_id
+     AND a.operation = 'incident_link'
+     AND a.created_by = 'migration-0210'
+    JOIN depeg_resolver_event_repair_authorization_consumptions c
+      ON c.authorization_id = a.id
+     AND c.event_id = l.event_id
+     AND c.incident_key = l.incident_key
+     AND c.operation = a.operation
+    WHERE l.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND l.event_id IN (90604, 90606, 90607, 90608)
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_event_repair_authorizations a
+    WHERE a.event_id = transition.current_event_id
+      AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND a.operation = 'incident_current_update'
+      AND a.created_by = 'migration-0210'
+  );
+
+INSERT INTO depeg_resolver_event_repair_authorization_consumptions
+  (authorization_id, event_id, incident_key, operation, consumed_at, consumer)
+SELECT a.id, a.event_id, a.incident_key, a.operation, unixepoch(), 'migration-0210'
+FROM depeg_resolver_event_repair_authorizations a
+WHERE a.event_id IN (90604, 90606, 90607, 90608)
+  AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  AND a.operation = 'incident_current_update'
+  AND a.created_by = 'migration-0210'
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_event_repair_authorizations complete
+    WHERE complete.event_id IN (90604, 90606, 90607, 90608)
+      AND complete.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND complete.operation = 'incident_current_update'
+      AND complete.created_by = 'migration-0210'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_event_repair_authorization_consumptions c
+    WHERE c.authorization_id = a.id
+  );
+
+INSERT INTO depeg_resolver_incident_revisions
+  (incident_key, previous_event_id, current_event_id, reason, repair_authorization_id,
+   erratum_id, created_at, created_by)
+SELECT
+  'ddr2:d71d5088a08922584d989cfe03ae8388',
+  transition.previous_event_id,
+  transition.current_event_id,
+  transition.reason,
+  a.id,
+  NULL,
+  unixepoch(),
+  'migration-0210'
+FROM (
+  SELECT 90599 AS previous_event_id, 90604 AS current_event_id,
+         'reviewed cNGN live flap 90604 adopted after event 90599' AS reason
+  UNION ALL
+  SELECT 90604, 90606,
+         'reviewed cNGN live flap 90606 adopted after event 90604'
+  UNION ALL
+  SELECT 90606, 90607,
+         'reviewed cNGN live flap 90607 adopted after event 90606'
+  UNION ALL
+  SELECT 90607, 90608,
+         'reviewed cNGN live tail 90608 adopted after event 90607'
+) transition
+JOIN depeg_resolver_event_repair_authorizations a
+  ON a.event_id = transition.current_event_id
+ AND a.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+ AND a.operation = 'incident_current_update'
+ AND a.created_by = 'migration-0210'
+JOIN depeg_resolver_event_repair_authorization_consumptions c
+  ON c.authorization_id = a.id
+ AND c.event_id = a.event_id
+ AND c.incident_key = a.incident_key
+ AND c.operation = a.operation
+WHERE EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.current_event_id = 90599
+      AND i.current_started_at = 1784151172
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_public_predictions p
+    WHERE p.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_event_repair_authorizations complete
+    JOIN depeg_resolver_event_repair_authorization_consumptions consumed
+      ON consumed.authorization_id = complete.id
+     AND consumed.event_id = complete.event_id
+     AND consumed.incident_key = complete.incident_key
+     AND consumed.operation = complete.operation
+    WHERE complete.event_id IN (90604, 90606, 90607, 90608)
+      AND complete.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND complete.operation = 'incident_current_update'
+      AND complete.created_by = 'migration-0210'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incident_revisions r
+    WHERE r.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND r.previous_event_id = transition.previous_event_id
+      AND r.current_event_id = transition.current_event_id
+      AND r.created_by = 'migration-0210'
+  );
+
+UPDATE depeg_resolver_incidents
+SET current_event_id = 90608,
+    current_started_at = 1784211551,
+    updated_at = unixepoch()
+WHERE incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  AND current_event_id = 90599
+  AND current_started_at = 1784151172
+  AND incident_state = 'active'
+  AND superseded_by_incident_key IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_public_predictions p
+    WHERE p.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_incident_revisions r
+    JOIN depeg_resolver_event_repair_authorizations a
+      ON a.id = r.repair_authorization_id
+     AND a.operation = 'incident_current_update'
+     AND a.created_by = 'migration-0210'
+    JOIN depeg_resolver_event_repair_authorization_consumptions c
+      ON c.authorization_id = a.id
+     AND c.event_id = a.event_id
+     AND c.incident_key = a.incident_key
+     AND c.operation = a.operation
+    WHERE r.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND r.created_by = 'migration-0210'
+      AND (
+        (r.previous_event_id = 90599 AND r.current_event_id = 90604)
+        OR (r.previous_event_id = 90604 AND r.current_event_id = 90606)
+        OR (r.previous_event_id = 90606 AND r.current_event_id = 90607)
+        OR (r.previous_event_id = 90607 AND r.current_event_id = 90608)
+      )
+  );
+
+UPDATE worker_repair_tasks
+SET state = 'closed',
+    locked_by = NULL,
+    locked_until = NULL,
+    last_error = NULL,
+    updated_at = unixepoch(),
+    closed_at = unixepoch()
+WHERE kind = 'ddr-repair-required-event'
+  AND subject_id IN ('90604', '90606', '90607', '90608')
+  AND state IN ('open', 'claimed', 'deferred', 'failed')
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_incident_event_links l
+    JOIN depeg_resolver_event_repair_authorizations a
+      ON a.id = l.repair_authorization_id
+     AND a.operation = 'incident_link'
+     AND a.created_by = 'migration-0210'
+    JOIN depeg_resolver_event_repair_authorization_consumptions c
+      ON c.authorization_id = a.id
+     AND c.event_id = l.event_id
+     AND c.incident_key = l.incident_key
+     AND c.operation = a.operation
+    WHERE l.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND l.event_id IN (90604, 90606, 90607, 90608)
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.current_event_id = 90608
+      AND i.current_started_at = 1784211551
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM depeg_resolver_public_predictions p
+    WHERE p.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+  );
+
+-- Force both projections to regenerate from the repaired canonical lineage.
+UPDATE cache
+SET value = '{"generation":-1,"methodologyVersion":"invalidated-cngn-ddr-repair-0210","payload":{}}',
+    updated_at = unixepoch()
+WHERE key IN ('depeg-resolver:snapshot', 'depeg-resolver-review:snapshot')
+  AND 4 = (
+    SELECT COUNT(DISTINCT t.subject_id)
+    FROM worker_repair_tasks t
+    WHERE t.kind = 'ddr-repair-required-event'
+      AND t.subject_id IN ('90604', '90606', '90607', '90608')
+      AND t.state = 'closed'
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_incident_revisions r
+    WHERE r.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND r.created_by = 'migration-0210'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.current_event_id = 90608
+      AND i.current_started_at = 1784211551
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+  );
+
+DELETE FROM cache
+WHERE key = 'ddr:repair-debt:v1'
+  AND json_valid(value)
+  AND json_type(value, '$.events') = 'array'
+  AND json_array_length(value, '$.events') = 4
+  AND json_type(value, '$.count') = 'integer'
+  AND json_extract(value, '$.count') = 4
+  AND json_extract(value, '$.eventsTruncated') = 0
+  AND 4 = (
+    SELECT COUNT(DISTINCT CAST(json_extract(event.value, '$.eventId') AS INTEGER))
+    FROM json_each(cache.value, '$.events') event
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(cache.value, '$.events') event
+    WHERE json_type(event.value, '$.eventId') IS NOT 'integer'
+       OR CAST(json_extract(event.value, '$.eventId') AS INTEGER) NOT IN (90604, 90606, 90607, 90608)
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM worker_repair_tasks t
+    WHERE t.kind = 'ddr-repair-required-event'
+      AND t.state IN ('open', 'claimed', 'deferred', 'failed')
+  )
+  AND 4 = (
+    SELECT COUNT(DISTINCT t.subject_id)
+    FROM worker_repair_tasks t
+    WHERE t.kind = 'ddr-repair-required-event'
+      AND t.subject_id IN ('90604', '90606', '90607', '90608')
+      AND t.state = 'closed'
+  )
+  AND 4 = (
+    SELECT COUNT(*)
+    FROM depeg_resolver_incident_event_links l
+    JOIN depeg_resolver_event_repair_authorizations a
+      ON a.id = l.repair_authorization_id
+     AND a.operation = 'incident_link'
+     AND a.created_by = 'migration-0210'
+    JOIN depeg_resolver_event_repair_authorization_consumptions c
+      ON c.authorization_id = a.id
+     AND c.event_id = l.event_id
+     AND c.incident_key = l.incident_key
+     AND c.operation = a.operation
+    WHERE l.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND l.event_id IN (90604, 90606, 90607, 90608)
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM depeg_resolver_incidents i
+    WHERE i.incident_key = 'ddr2:d71d5088a08922584d989cfe03ae8388'
+      AND i.current_event_id = 90608
+      AND i.current_started_at = 1784211551
+      AND i.incident_state = 'active'
+      AND i.superseded_by_incident_key IS NULL
+  );

--- a/worker/migrations/MANIFEST.md
+++ b/worker/migrations/MANIFEST.md
@@ -153,6 +153,7 @@ Applied sequentially after the baseline (fresh setup) or after the previous indi
 | 0207     | `0207_telegram_execution_unknown_backlog_archive.sql`     | Guard, archive, and remove the exact reviewed Telegram execution-unknown backlog, then rebuild its ten authoritative job counters                       |
 | 0208     | `0208_eurq_ddr_events_90589_90595_link.sql`               | Link four reviewed EURQ live flaps to the active unsealed incident, advance ordered lineage, and close their durable DDR repair tasks                    |
 | 0209     | `0209_cngn_ddr_event_90599_link.sql`                      | Link reviewed cNGN reopen 90599 to the active unsealed incident, advance lineage from event 90584, and close its durable DDR repair task                  |
+| 0210     | `0210_cngn_ddr_events_90604_90608_link.sql`               | Link four reviewed cNGN live flaps to the active unsealed incident, advance ordered lineage, and close their durable DDR repair tasks                    |
 
 ## Retired Individual Migrations
 
@@ -245,6 +246,7 @@ Current owner rulings for append-only operational/product tables that are intent
 - `0207_telegram_execution_unknown_backlog_archive.sql`: do not requeue or reinterpret the archived effects during rollback. Keep the deterministic dead-letter evidence and authoritative `execution_unknown` target truth; restoring live queue rows could duplicate Telegram delivery and requires a separate operator-reviewed reconciliation.
 - `0208_eurq_ddr_events_90589_90595_link.sql`: roll back DDR publication behavior by restoring the prior Worker. Keep the append-only repair authorizations, consumptions, links, and ordered revisions as reviewed provenance; do not recreate the closed tasks or detach events 90589, 90591, 90594, and 90595 without a separate corrective migration.
 - `0209_cngn_ddr_event_90599_link.sql`: roll back DDR publication behavior by restoring the prior Worker. Keep the append-only repair authorizations, consumptions, link, and revision as reviewed provenance; do not recreate the closed task or detach event 90599 without a separate corrective migration.
+- `0210_cngn_ddr_events_90604_90608_link.sql`: roll back DDR publication behavior by restoring the prior Worker. Keep the append-only repair authorizations, consumptions, links, and ordered revisions as reviewed provenance; do not recreate the closed tasks or detach events 90604, 90606, 90607, and 90608 without a separate corrective migration.
 
 ## Rollback Procedure
 

--- a/worker/src/api/__tests__/admin-telegram-adoption-report.test.ts
+++ b/worker/src/api/__tests__/admin-telegram-adoption-report.test.ts
@@ -1,10 +1,14 @@
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSqliteD1 } from "../../test-helpers/sqlite-d1";
 import { handleAdminTelegramAdoptionReport } from "../admin-telegram-adoption-report";
 
 describe("admin Telegram adoption report", () => {
+  afterEach(() => vi.useRealTimers());
+
   it("returns only suppressed aggregate data behind admin auth", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
     const sqlite = new DatabaseSync(":memory:");
     sqlite.exec(`
       CREATE TABLE telegram_adoption_daily (

--- a/worker/src/cron/__tests__/snapshot-supply.test.ts
+++ b/worker/src/cron/__tests__/snapshot-supply.test.ts
@@ -517,6 +517,64 @@ describe("snapshotSupply", () => {
     }
   });
 
+  it("repairs null prices in an already-complete same-day snapshot without rewriting other fields", async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const sqlite = new DatabaseSync(":memory:");
+    try {
+      sqlite.exec(`
+        CREATE TABLE cache (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL);
+        CREATE TABLE supply_history (
+          stablecoin_id TEXT NOT NULL,
+          snapshot_date INTEGER NOT NULL,
+          circulating_usd REAL NOT NULL,
+          price REAL,
+          PRIMARY KEY (stablecoin_id, snapshot_date)
+        );
+      `);
+      const nowSec = Math.floor(Date.now() / 1000);
+      const snapshotDate = Date.UTC(2025, 5, 15) / 1000;
+      sqlite.prepare("INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)").run(
+        "stablecoins",
+        JSON.stringify({ peggedAssets: [
+          { id: "usdt-tether", symbol: "USDT", price: 1.001, circulating: { peggedUSD: 100 } },
+          { id: "usdc-circle", symbol: "USDC", price: 0.999, circulating: { peggedUSD: 50 } },
+        ] }),
+        nowSec - 60,
+      );
+      sqlite.prepare("INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)").run(
+        "snapshot-supply:last-write",
+        completionMarker({ snapshotDate }),
+        nowSec - 60,
+      );
+      sqlite.prepare(
+        "INSERT INTO supply_history (stablecoin_id, snapshot_date, circulating_usd, price) VALUES (?, ?, ?, ?)",
+      ).run("usdt-tether", snapshotDate, 90, null);
+      sqlite.prepare(
+        "INSERT INTO supply_history (stablecoin_id, snapshot_date, circulating_usd, price) VALUES (?, ?, ?, ?)",
+      ).run("usdc-circle", snapshotDate, 45, 0.998);
+
+      const result = await snapshotSupply(createSqliteD1(sqlite), undefined, {
+        nowSec,
+        requiredActiveIds: DEFAULT_REQUIRED_IDS,
+        snapshotEligibleIds: DEFAULT_REQUIRED_IDS,
+      });
+
+      expect(result.itemCount).toBe(1);
+      expect(JSON.parse(String(result.metadata))).toMatchObject({
+        reason: "repaired_missing_prices_today",
+        repairedPriceRows: 1,
+      });
+      expect(sqlite.prepare(
+        "SELECT stablecoin_id, circulating_usd, price FROM supply_history ORDER BY stablecoin_id",
+      ).all()).toEqual([
+        { stablecoin_id: "usdc-circle", circulating_usd: 45, price: 0.998 },
+        { stablecoin_id: "usdt-tether", circulating_usd: 90, price: 1.001 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("invalidates completion when an applied waiver owner or expiry changes", async () => {
     const freshUpdatedAt = Math.floor(Date.now() / 1000) - 60;
     const snapshotDate = Date.UTC(2025, 5, 15) / 1000;

--- a/worker/src/cron/reserve-adapters/__tests__/attestation-pdf-index.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/attestation-pdf-index.test.ts
@@ -32,6 +32,20 @@ describe("adaptAttestationPdfIndex", () => {
     vi.unstubAllGlobals();
   });
 
+  it("parses Solomon's GitHub attestation index", () => {
+    const result = adaptAttestationPdfIndex(`
+      <a href="/SolomonLabs/attestations/blob/main/ceffu/2026/2026-03-01.pdf">2026-03-01.pdf</a>
+      <a href="/SolomonLabs/attestations/blob/main/ceffu/2026/2026-04-01.pdf">2026-04-01.pdf</a>
+    `, CONFIGURED_PARAMS, {
+      indexUrl: "https://github.com/SolomonLabs/attestations/tree/main/ceffu/2026",
+    });
+
+    expect(result.metadata).toMatchObject({
+      reportDate: "2026-04-01",
+      reportPdfUrl: "https://github.com/SolomonLabs/attestations/blob/main/ceffu/2026/2026-04-01.pdf",
+    });
+  });
+
   it("selects the newest dated PDF link and emits configured reserve slices", () => {
     const html = `
       <a href="/reports/2026-01-31-attestation.pdf">January 2026 attestation</a>

--- a/worker/src/cron/snapshot-supply.ts
+++ b/worker/src/cron/snapshot-supply.ts
@@ -1,5 +1,6 @@
 import {
   D1_MAX_BOUND_PARAMETERS,
+  batchExecute,
   chunkArray,
   executeAtomicBatch,
   prepareMultiRowInsertStatements,
@@ -72,6 +73,27 @@ function buildAlreadyWrittenBeforeFreshnessGateResult(params: {
       freshnessGateLabel: params.freshnessGateLabel,
     }),
   };
+}
+
+async function repairSameDayMissingPrices(
+  db: D1Database,
+  snapshotDate: number,
+  snapshotRows: readonly (readonly [string, number, number, number | null])[],
+  signal?: AbortSignal,
+): Promise<number> {
+  const missing = await db.prepare(
+    "SELECT stablecoin_id FROM supply_history WHERE snapshot_date = ? AND price IS NULL",
+  ).bind(snapshotDate).all<{ stablecoin_id: string }>();
+  throwIfAborted(signal);
+
+  const missingIds = new Set((missing.results ?? []).map((row) => row.stablecoin_id));
+  const repairs = snapshotRows
+    .filter(([stablecoinId, , , price]) => missingIds.has(stablecoinId) && price != null)
+    .map(([stablecoinId, , , price]) => db.prepare(
+      "UPDATE supply_history SET price = ? WHERE stablecoin_id = ? AND snapshot_date = ? AND price IS NULL",
+    ).bind(price, stablecoinId, snapshotDate));
+
+  return batchExecute(db, repairs, { signal });
 }
 
 export async function snapshotSupply(
@@ -182,7 +204,25 @@ export async function snapshotSupply(
     && lastWrite?.snapshotDate === snapshotDate
     && lastWrite.exactCoverageVerified
   ) {
-    return { itemCount: 0, metadata: JSON.stringify({ reason: "already_written_today", snapshotDate }) };
+    try {
+      const repairedPriceRows = await repairSameDayMissingPrices(db, snapshotDate, snapshotRows, signal);
+      return {
+        itemCount: repairedPriceRows,
+        metadata: JSON.stringify({
+          reason: repairedPriceRows > 0 ? "repaired_missing_prices_today" : "already_written_today",
+          snapshotDate,
+          repairedPriceRows,
+        }),
+      };
+    } catch (err) {
+      rethrowIfAborted(err, signal);
+      recordCronFailure("snapshot-supply", err, { metadata: { stage: "sameDayPriceRepair" } });
+      return {
+        status: "degraded",
+        itemCount: 0,
+        metadata: JSON.stringify({ reason: "same_day_price_repair_failed", error: String(err).slice(0, 200) }),
+      };
+    }
   }
   if (!publicationCoverage.complete) {
     const cacheCoverage = evaluateStablecoinPublicationCoverage(

--- a/worker/src/lib/__tests__/cngn-ddr-events-90604-90608-repair-migration.test.ts
+++ b/worker/src/lib/__tests__/cngn-ddr-events-90604-90608-repair-migration.test.ts
@@ -1,0 +1,258 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+const MIGRATIONS_DIR = join(process.cwd(), "worker/migrations");
+const PREVIOUS_MIGRATION = "0209_cngn_ddr_event_90599_link.sql";
+const TARGET_MIGRATION = "0210_cngn_ddr_events_90604_90608_link.sql";
+const INCIDENT_KEY = "ddr2:d71d5088a08922584d989cfe03ae8388";
+
+function applyMigration(db: DatabaseSync, file: string): void {
+  // Test-only replay of repo-controlled migration files.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  db.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
+}
+
+function applyThrough(db: DatabaseSync, throughFile: string): void {
+  for (const file of readdirSync(MIGRATIONS_DIR)
+    .filter((entry) => entry.endsWith(".sql"))
+    .sort()) {
+    applyMigration(db, file);
+    if (file === throughFile) return;
+  }
+  throw new Error(`missing migration ${throughFile}`);
+}
+
+function seedReviewedCngnState(db: DatabaseSync): void {
+  applyThrough(db, PREVIOUS_MIGRATION);
+
+  db.exec(`
+    INSERT INTO depeg_events
+      (id, stablecoin_id, symbol, peg_type, direction, peak_deviation_bps,
+       started_at, ended_at, start_price, peak_price, recovery_price, peg_reference,
+       source, confirmation_sources, pending_reason, close_reason)
+    VALUES
+      (90599, 'cngn-compliant-naira', 'cNGN', 'peggedNGN', 'below', -158,
+       1784151172, 1784154780, 0.984154, 0.984154, 0.985718, 1,
+       'live', NULL, NULL, 'recovered-native'),
+      (90604, 'cngn-compliant-naira', 'cNGN', 'peggedNGN', 'below', -152,
+       1784189952, 1784190853, 0.984754, 0.984754, 0.988983, 1,
+       'live', NULL, NULL, 'recovered-native'),
+      (90606, 'cngn-compliant-naira', 'cNGN', 'peggedNGN', 'below', -152,
+       1784192670, 1784194450, 0.984802, 0.984802, 0.985531, 1,
+       'live', NULL, NULL, 'recovered-native'),
+      (90607, 'cngn-compliant-naira', 'cNGN', 'peggedNGN', 'below', -192,
+       1784197137, 1784203436, 0.982094, 0.980764, 0.985359, 1,
+       'live', NULL, NULL, 'recovered-native'),
+      (90608, 'cngn-compliant-naira', 'cNGN', 'peggedNGN', 'below', -154,
+       1784211551, 1784212483, 0.984619, 0.984619, 0.986806, 1,
+       'live', NULL, NULL, 'recovered-native');
+
+    INSERT INTO depeg_resolver_incident_event_links
+      (incident_key, event_id, relation, repair_authorization_id, linked_at, note)
+    VALUES
+      ('${INCIDENT_KEY}', 90511, 'observed', NULL,
+       1783650915, 'initial canonical incident link'),
+      ('${INCIDENT_KEY}', 90599, 'repair_replacement', NULL,
+       1784153527, 'reviewed predecessor event adopted as current incident source');
+
+    INSERT INTO depeg_resolver_incidents
+      (incident_key, stablecoin_id, peg_currency, direction, first_event_id, current_event_id,
+       first_started_at, current_started_at, first_observed_peak_bucket_bps, incident_state,
+       superseded_by_incident_key, source_fingerprint, created_at, updated_at)
+    VALUES
+      ('${INCIDENT_KEY}', 'cngn-compliant-naira', 'NGN', 'below', 90511, 90599,
+       1783650896, 1784151172, 150, 'active', NULL,
+       'b34dc1832aa964c5828d0b50ac025a4181efdd854c644c14281838490b644a15',
+       1783650915, 1784153527);
+
+    INSERT INTO worker_repair_tasks
+      (task_id, kind, subject_id, priority, state, attempt_count, payload_json, created_at, updated_at)
+    VALUES
+      ('repair:ddr-repair-required-event:90604', 'ddr-repair-required-event', '90604',
+       50, 'open', 0, '{"eventId":90604,"reason":"Unlinked depeg event 90604 overlaps nearby canonical incident ddr2:d71d5088a08922584d989cfe03ae8388; explicit repair required"}', 1784189990, 1784262798),
+      ('repair:ddr-repair-required-event:90606', 'ddr-repair-required-event', '90606',
+       50, 'open', 0, '{"eventId":90606,"reason":"Unlinked depeg event 90606 overlaps nearby canonical incident ddr2:d71d5088a08922584d989cfe03ae8388; explicit repair required"}', 1784192716, 1784262798),
+      ('repair:ddr-repair-required-event:90607', 'ddr-repair-required-event', '90607',
+       50, 'open', 0, '{"eventId":90607,"reason":"Unlinked depeg event 90607 overlaps nearby canonical incident ddr2:d71d5088a08922584d989cfe03ae8388; explicit repair required"}', 1784197203, 1784262798),
+      ('repair:ddr-repair-required-event:90608', 'ddr-repair-required-event', '90608',
+       50, 'open', 0, '{"eventId":90608,"reason":"Unlinked depeg event 90608 overlaps nearby canonical incident ddr2:d71d5088a08922584d989cfe03ae8388; explicit repair required"}', 1784211595, 1784262798);
+
+    INSERT INTO cache (key, value, updated_at)
+    VALUES
+      ('depeg-resolver:snapshot',
+       '{"generation":2,"methodologyVersion":"3.04","payload":{}}', 1784142261),
+      ('depeg-resolver-review:snapshot',
+       '{"generation":2,"methodologyVersion":"3.04","payload":{}}', 1784142261),
+      ('ddr:repair-debt:v1',
+       '{"checkedAt":1784142257,"count":4,"events":[{"eventId":90604},{"eventId":90606},{"eventId":90607},{"eventId":90608}],"eventsTruncated":false}',
+       1784142261);
+  `);
+}
+
+function migrationLedgerCounts(db: DatabaseSync): unknown {
+  return db
+    .prepare(
+      `SELECT
+         (SELECT COUNT(*) FROM depeg_resolver_event_repair_authorizations
+          WHERE created_by = 'migration-0210') AS authorizations,
+         (SELECT COUNT(*)
+          FROM depeg_resolver_event_repair_authorization_consumptions c
+          JOIN depeg_resolver_event_repair_authorizations a ON a.id = c.authorization_id
+          WHERE a.created_by = 'migration-0210') AS consumptions,
+         (SELECT COUNT(*) FROM depeg_resolver_incident_event_links
+          WHERE event_id IN (90604, 90606, 90607, 90608)) AS links,
+         (SELECT COUNT(*) FROM depeg_resolver_incident_revisions
+          WHERE created_by = 'migration-0210') AS revisions`,
+    )
+    .get();
+}
+
+describe("0210 cNGN DDR repair migration", () => {
+  it("links the reviewed chain, advances ordered lineage, and replays idempotently", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      seedReviewedCngnState(db);
+      applyMigration(db, TARGET_MIGRATION);
+
+      expect(
+        db
+          .prepare(
+            `SELECT event_id, incident_key, relation, repair_authorization_id IS NOT NULL AS authorized
+             FROM depeg_resolver_incident_event_links
+             WHERE event_id IN (90604, 90606, 90607, 90608)
+             ORDER BY event_id`,
+          )
+          .all(),
+      ).toEqual(
+        [90604, 90606, 90607, 90608].map((eventId) => ({
+          event_id: eventId,
+          incident_key: INCIDENT_KEY,
+          relation: "repair_replacement",
+          authorized: 1,
+        })),
+      );
+      expect(
+        db
+          .prepare(
+            `SELECT previous_event_id, current_event_id
+             FROM depeg_resolver_incident_revisions
+             WHERE created_by = 'migration-0210'
+             ORDER BY id`,
+          )
+          .all(),
+      ).toEqual([
+        { previous_event_id: 90599, current_event_id: 90604 },
+        { previous_event_id: 90604, current_event_id: 90606 },
+        { previous_event_id: 90606, current_event_id: 90607 },
+        { previous_event_id: 90607, current_event_id: 90608 },
+      ]);
+      expect(
+        db
+          .prepare(
+            `SELECT current_event_id, current_started_at
+             FROM depeg_resolver_incidents
+             WHERE incident_key = ?`,
+          )
+          .get(INCIDENT_KEY),
+      ).toEqual({ current_event_id: 90608, current_started_at: 1784211551 });
+      expect(
+        db
+          .prepare(
+            `SELECT state, COUNT(*) AS count
+             FROM worker_repair_tasks
+             WHERE subject_id IN ('90604', '90606', '90607', '90608')
+             GROUP BY state`,
+          )
+          .all(),
+      ).toEqual([{ state: "closed", count: 4 }]);
+      expect(
+        db
+          .prepare(
+            `SELECT COUNT(*) AS count
+             FROM cache
+             WHERE key IN ('depeg-resolver:snapshot', 'depeg-resolver-review:snapshot')
+               AND json_extract(value, '$.methodologyVersion') = 'invalidated-cngn-ddr-repair-0210'`,
+          )
+          .get(),
+      ).toEqual({ count: 2 });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM cache WHERE key = 'ddr:repair-debt:v1'").get()).toEqual({
+        count: 0,
+      });
+      expect(migrationLedgerCounts(db)).toEqual({
+        authorizations: 8,
+        consumptions: 8,
+        links: 4,
+        revisions: 4,
+      });
+
+      applyMigration(db, TARGET_MIGRATION);
+
+      expect(migrationLedgerCounts(db)).toEqual({
+        authorizations: 8,
+        consumptions: 8,
+        links: 4,
+        revisions: 4,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fails closed when a recovered source-row fingerprint drifts", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      seedReviewedCngnState(db);
+      db.prepare("UPDATE depeg_events SET recovery_price = ? WHERE id = 90606").run(0.985532);
+
+      applyMigration(db, TARGET_MIGRATION);
+
+      expect(migrationLedgerCounts(db)).toEqual({
+        authorizations: 0,
+        consumptions: 0,
+        links: 0,
+        revisions: 0,
+      });
+      expect(
+        db.prepare("SELECT current_event_id FROM depeg_resolver_incidents WHERE incident_key = ?").get(INCIDENT_KEY),
+      ).toEqual({ current_event_id: 90599 });
+      expect(
+        db
+          .prepare(
+            `SELECT state, COUNT(*) AS count
+             FROM worker_repair_tasks
+             WHERE subject_id IN ('90604', '90606', '90607', '90608')
+             GROUP BY state`,
+          )
+          .all(),
+      ).toEqual([{ state: "open", count: 4 }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fails closed when a deterministic repair-task payload drifts", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      seedReviewedCngnState(db);
+      db.prepare("UPDATE worker_repair_tasks SET payload_json = ? WHERE subject_id = '90608'").run(
+        '{"eventId":90608,"reason":"operator review changed"}',
+      );
+
+      applyMigration(db, TARGET_MIGRATION);
+
+      expect(migrationLedgerCounts(db)).toEqual({
+        authorizations: 0,
+        consumptions: 0,
+        links: 0,
+        revisions: 0,
+      });
+      expect(
+        db.prepare("SELECT current_event_id FROM depeg_resolver_incidents WHERE incident_key = ?").get(INCIDENT_KEY),
+      ).toEqual({ current_event_id: 90599 });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/worker/src/lib/__tests__/price-publish-policy.test.ts
+++ b/worker/src/lib/__tests__/price-publish-policy.test.ts
@@ -10,6 +10,26 @@ const USD_CONTEXT: PriceValidationContext = {
 };
 
 describe("validatePrimaryPriceCandidate — severe downside with directional corroboration", () => {
+  it("admits the reviewed AZND exact-pool display route without making the source globally authoritative", () => {
+    const decision = validatePrimaryPriceCandidate({
+      price: 0.38,
+      source: "curve-thin-onchain",
+      confidence: "fallback",
+      agreeSources: ["curve-thin-onchain"],
+      validationContext: { ...USD_CONTEXT, stablecoinId: "aznd-mu-digital" },
+    });
+
+    expect(decision.accepted).toBe(true);
+
+    expect(validatePrimaryPriceCandidate({
+      price: 0.38,
+      source: "curve-thin-onchain",
+      confidence: "fallback",
+      agreeSources: ["curve-thin-onchain"],
+      validationContext: { ...USD_CONTEXT, stablecoinId: "another-stablecoin" },
+    }).reason).toBe("severe_downside_requires_corroboration");
+  });
+
   it("rejects severe downside with single source and no corroboration", () => {
     const decision = validatePrimaryPriceCandidate({
       price: 0.38,

--- a/worker/src/lib/price-publish-policy.ts
+++ b/worker/src/lib/price-publish-policy.ts
@@ -9,6 +9,8 @@ import type { PriceConfidence, PriceObservedAtMode } from "@shared/types/core";
 
 const WEAK_FIXED_PEG_JUMP_WITHHOLD_BPS = 2_000;
 const WEAK_FALLBACK_FIXED_PEG_DEPEG_BPS = 500;
+const AZND_ID = "aznd-mu-digital";
+const AZND_EXACT_POOL_SOURCE = "curve-thin-onchain";
 
 export interface TrustedPriceReference {
   price: number;
@@ -90,6 +92,12 @@ function isFallbackSearchOnlySource(source: string | null | undefined): boolean 
   });
 }
 
+function isReviewedAssetScopedDisplayRoute(input: PublishablePriceInput): boolean {
+  return input.validationContext.stablecoinId === AZND_ID
+    && input.source === AZND_EXACT_POOL_SOURCE
+    && input.confidence === "fallback";
+}
+
 function fixedPegDeviationBps(input: PublishablePriceInput): number | null {
   if (!isFixedPegValidationContext(input.validationContext)) return null;
   const referencePrice = getReferencePriceForContext(input.validationContext, input.validationReferences);
@@ -151,6 +159,10 @@ function hasSevereDownsidePublicationCorroboration(input: PublishablePriceInput)
   }
 
   if (isPricingSourceSoftGuardrailExempt(input.source)) {
+    return true;
+  }
+
+  if (isReviewedAssetScopedDisplayRoute(input)) {
     return true;
   }
 
@@ -228,6 +240,9 @@ export function shouldWithholdTemporalJump(input: PublishablePriceInput): boolea
     (input.confidence === "high" || input.confidence === "single-source") &&
     hasDepegAuthoritativeSource(authoritativeSources);
   if (hasAuthoritativeAgreement || isPricingSourceSoftGuardrailExempt(input.source)) {
+    return false;
+  }
+  if (isReviewedAssetScopedDisplayRoute(input)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- repair same-day `NULL` supply snapshot prices from later healthy cache generations so price-derived yield rows recover without rewriting historical supply or non-null prices
- admit the reviewed AZND exact Curve display route only for AZND, and move USDv live reserves to Solomon's maintained attestation repository
- link cNGN events 90604, 90606, 90607, and 90608 through guarded append-only DDR authorizations and ordered incident revisions

## Production evidence
- `sync-yield-data` was degraded by two price-derived rows whose daily `supply_history.price` was captured as `NULL` at midnight even though current protocol-redeem prices later recovered
- `sync-live-reserves` repeatedly failed USDv because the former GitBook path now returns a client-rendered docs shell; the issuer repository exposes dated reports through 2026-04-01
- AZND's reviewed exact-pool adapter returned a current executable quote but the generic severe-downside gate contradicted the existing v6.193 asset-scoped display policy
- four exact cNGN repair tasks remained open for immutable recovered-native events in the active unsealed incident

## Verification
- 54 focused tests pass
- `npm run typecheck:worker`
- `npm run check:migrations` (139 migrations replayed)
- `npm run check:stablecoin-data`
- focused typed/default ESLint checks
- live USDv adapter probe selected the 2026-04-01 Solomon report

## Known base-branch gate debt
Local merge-gate discovery also reported pre-existing repository-wide ratchet failures in raw console/JSON usage, hotspot enrollment, oracle-risk coverage, dependency coverage, and unused-code checks. This patch does not modify those reported files or baselines; authoritative GitHub PR checks remain the release gate.
