### PR TITLE
Fix the V9 fresh-capture defects: venue-family normalization, reserve-drift tolerance, D14/D15

### DIFF
--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -10,7 +10,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/data/safety-score-v9/methodology-policy-candidate-v1.json",
-      "sha256": "82d676b91f1a7e9dd54614658a6bb630500e46002389049619c326df5896b162"
+      "sha256": "7add9b6076b9e024d50853c02ab9943f7d5d03345ab9bc8309deb649eef401c3"
     },
     {
       "path": "shared/lib/chains/index.ts",
@@ -118,7 +118,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/safety-score-v9/evaluate-set.ts",
-      "sha256": "92c18229bfd19808d4dd8d00fcf40eed0e932b223372be4d6cece11f42b82e52"
+      "sha256": "eeeb3760ee380d33b7a606b11c5f4ef0e78ee513726570186434f132a98a3771"
     },
     {
       "path": "shared/lib/safety-score-v9/evidence.ts",
@@ -254,7 +254,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "worker/src/lib/safety-score-v9-extension.ts",
-      "sha256": "e0e9eca5a5d010534b9ee6c9c2f3f35efc5daef2f164f1d51ce09008bf597acb"
+      "sha256": "22c35ed9062ce4b8b96f5b60a6529a2cf6cdb2a4f9d7d8a171654c6706e3c14a"
     },
     {
       "path": "worker/src/lib/safety-score-v9-fact-set-boundary.ts",
@@ -265,7 +265,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "232d2a97f1a3a073587b51e3f3744667f4b6e7ca53319150578cf7827d6e8e5a"
     }
   ],
-  "digest": "da992cd61ae7d84eb3f515ac43d71be0c8762cb4270ca108dc73a238bdfa0202"
+  "digest": "93b5677d730ec161e7efc1d69df6e4421d39797fc1c1905dc45b71d07104339b"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/safety-score-v9/methodology-policy-candidate-v1.json
+++ b/shared/data/safety-score-v9/methodology-policy-candidate-v1.json
@@ -243,6 +243,7 @@
       "matureVenues": [
         "balancer",
         "curve",
+        "pancakeswap",
         "raydium",
         "uniswap"
       ]

--- a/shared/lib/__tests__/safety-score-v9-policy.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-policy.test.ts
@@ -26,7 +26,7 @@ describe("Safety Score v9 methodology policy", () => {
     expect(V9_CANDIDATE_POLICY_V1.policy.lifecycle).toBe("candidate");
     expect(V9_CANDIDATE_POLICY_V1.policy.releaseVersion).toBeNull();
     expect(V9_CANDIDATE_POLICY_V1.semanticDigest).toBe(
-      "c660ddf0559624b6d186384b6fe43f6a2d8e1ee6129aa392fe3d15a15c809306",
+      "d77890e759e4494aba42634c442fee39eca3527ef1b111746bd3aaec922a5912",
     );
     const cdpPolicy = V9_CANDIDATE_POLICY_V1.policy.semantic.backing.structural.cdp;
     expect(cdpPolicy.instantaneousCollateralShock).toBe(0.5);

--- a/shared/lib/__tests__/safety-score-v9-r2-d1-mature-domains.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-r2-d1-mature-domains.test.ts
@@ -120,6 +120,27 @@ describe("R2/D1 threshold boundary semantics — active (PR #530 behavior must s
     }
   });
 
+  it("resolves versioned measured-execution protocol keys to their venue family", () => {
+    // 2026-07-18 regression: CL activation registers "uniswap-v3" /
+    // "pancakeswap-v3"; maturity is a family property (D14 later ruled
+    // pancakeswap mature as well). An unruled versioned venue stays
+    // fail-closed at unknown share.
+    for (const key of ["uniswap-v3", "pancakeswap-v3"]) {
+      const domain: V9FailureDomainRef = { kind: "dex-protocol", key };
+      for (const { share } of CHAIN_BOUNDARIES) {
+        expect(
+          commonModeSignalSeverity(domain, contextForVenue(key, share), STAGE_B_MATERIALITY),
+          `${key} share=${share}`,
+        ).toBe("low");
+      }
+    }
+    const unruled: V9FailureDomainRef = { kind: "dex-protocol", key: "futuredex-v2" };
+    expect(commonModeSignalSeverity(unruled, contextForVenue("futuredex-v2", null), STAGE_B_MATERIALITY)).toBe("high");
+    expect(commonModeSignalSeverity(unruled, contextForVenue("futuredex-v2", 0.07), STAGE_B_MATERIALITY)).toBe(
+      "moderate",
+    );
+  });
+
   it("keeps the previously mature chains/venues diagnostic under the extended fixture", () => {
     for (const chainId of CANDIDATE_MATERIALITY.matureChains) {
       const domain: V9FailureDomainRef = { kind: "chain", key: chainId };

--- a/shared/lib/safety-score-v9/evaluate-set.ts
+++ b/shared/lib/safety-score-v9/evaluate-set.ts
@@ -589,6 +589,10 @@ function buildCommonModeContext(
  * is diagnostic, 5%-<10% is moderate, and >=10% or unknown is high. Serial
  * control domains do not enter this proportional path and remain fail-closed.
  */
+function venueFamilyKey(key: string): string {
+  return key.toLowerCase().replace(/-v\d+$/u, "");
+}
+
 function proportionalCommonModeSeverity(
   share: number | null,
   mature: boolean,
@@ -622,7 +626,11 @@ export function commonModeSignalSeverity(
     case "dex-protocol":
       return proportionalCommonModeSeverity(
         context.dexExposureByDomain.get(domainKey(failureDomain))?.upper ?? null,
-        materiality.matureVenues.includes(failureDomain.key.toLowerCase()),
+        // Measured-execution routes carry versioned protocol keys
+        // ("uniswap-v3", "pancakeswap-v3"); venue maturity is a property of
+        // the venue family, so membership is tested on the version-stripped
+        // family key.
+        materiality.matureVenues.includes(venueFamilyKey(failureDomain.key)),
         materiality,
       );
     case "bridge-route": {
@@ -702,7 +710,12 @@ function commonModeSignalsByAsset(
     }
     const key = domainKey(group.failureDomain);
     const mintControlSeverity = (() => {
-      if (group.failureDomain.kind !== "mint-control") return null;
+      // D2 (mint-control) extended by D15 (2026-07-18) to upgrade-control:
+      // an issuer's own controller shared across its own products is the
+      // issuer itself, not an external dependency. Cross-issuer and
+      // unresolved-identity groups still fail closed in
+      // resolveV9MintControlGroupSeverity.
+      if (group.failureDomain.kind !== "mint-control" && group.failureDomain.kind !== "upgrade-control") return null;
       const members = assetIds.map((assetId) => {
         const assetMembers = effectiveMembers.filter((member) => member.assetId === assetId);
         return {

--- a/worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts
@@ -83,9 +83,11 @@ describe("buildReviewedReserveClassifications", () => {
 
   it("leaves mismatched, ambiguous, and unreviewed live rows source-native", () => {
     const live = [{ name: "Cash", pct: 15, risk: "very-low" as const }];
+    // 22 vs 15 sits beyond the 5pp drift tolerance, so the weight mismatch
+    // is gross rather than normal rebalancing and the join must fail.
     const structuredCash: ReserveSlice = {
       name: "Cash",
-      pct: 16,
+      pct: 22,
       risk: "very-low",
       assetClass: "bank-deposit",
       issuerOrObligor: "Reserve bank",
@@ -173,6 +175,45 @@ describe("buildReviewedReserveClassifications", () => {
       riskFactors: ["custody", "liquidity", "market"],
       liquidityHorizon: "seven-days",
     });
+  });
+
+  it("keeps reviewed classifications joined across normal live composition drift", () => {
+    // 2026-07-18 regression: Circle's T-bill share moved 2.0pp in two days,
+    // which severed every USDC classification under the old 0.5pp bound and
+    // collapsed backing. Identity is the bijective name match; weight drift
+    // within 5pp must not destroy the slice's class.
+    const reviewed = reviewedMeta([
+      {
+        name: "<3-Month U.S. Treasuries",
+        pct: 73.7,
+        risk: "very-low",
+        assetClass: "treasury-bill",
+        issuerOrObligor: "United States Treasury",
+      },
+      {
+        name: "Other Bank Deposits",
+        pct: 14.8,
+        risk: "very-low",
+        assetClass: "bank-deposit",
+        issuerOrObligor: "Other regulated financial institutions",
+      },
+    ]);
+    const drifted = buildReviewedReserveClassifications(
+      [
+        { name: "<3-Month U.S. Treasuries", pct: 71.7, risk: "very-low" },
+        { name: "Other Bank Deposits", pct: 15.9, risk: "very-low" },
+      ],
+      reviewed,
+      CLOCK_SEC,
+    );
+    expect(drifted.every((row) => !row.classificationKey.startsWith("source-native:"))).toBe(true);
+
+    const grosslyDifferent = buildReviewedReserveClassifications(
+      [{ name: "<3-Month U.S. Treasuries", pct: 62, risk: "very-low" }],
+      reviewed,
+      CLOCK_SEC,
+    );
+    expect(grosslyDifferent.every((row) => row.classificationKey.startsWith("source-native:"))).toBe(true);
   });
 
   it("rejects the current USDC repartition and USD1 aggregate basket as non-identical", () => {

--- a/worker/src/lib/safety-score-v9-extension.ts
+++ b/worker/src/lib/safety-score-v9-extension.ts
@@ -108,7 +108,14 @@ type ControlOverlay = NonNullable<
 >["controls"][number];
 type ReserveClassification = ReturnType<typeof buildSafetyScoreV9ReserveClassifications>[number];
 
-const RESERVE_WEIGHT_MATCH_TOLERANCE_PCT = 0.5;
+// Identity tolerance for joining a live reserve slice to its reviewed
+// classification. Name equality (with the surrounding 1:1 bijection guards)
+// carries slice identity; the weight check only rejects gross mismatches.
+// Live compositions drift daily (2026-07-18: USDC T-bills moved 2.0pp in two
+// days, severing every fiat classification under the prior 0.5), so the
+// bound must tolerate normal rebalancing. Weights used for scoring always
+// come from the live row, never the reviewed one.
+const RESERVE_WEIGHT_MATCH_TOLERANCE_PCT = 5;
 const DEPLOYMENT_MATERIAL_SHARE_THRESHOLD =
   V9_CANDIDATE_POLICY_V1.policy.semantic.materiality.deploymentMaterialSharePct / 100;
 


### PR DESCRIPTION
## Summary

The first post-deploy shadow envelope (2026-07-18) exposed three defects at the two seams that had never run end-to-end; this PR resolves the two systemic ones and records two owner rulings made with them.

- **Venue-family normalization**: measured-execution routes register versioned protocol keys (`uniswap-v3`/`pancakeswap-v3`) that missed `matureVenues`, putting a spurious fail-closed `critical-dependency:high@64` on 36 coins and collapsing the top of the shadow distribution (BOLD 84→64). Maturity now resolves on the version-stripped family key.
- **D14 (owner-ratified)**: pancakeswap joins matureVenues.
- **D15 (owner-ratified)**: the D2 same-issuer diagnostic treatment extends from mint-control to upgrade-control groups; cross-issuer and unresolved identities keep failing closed.
- **Reserve-drift tolerance**: the reviewed-classification join required live/reviewed weights within 0.5pp, so two days of normal issuer rebalancing severed 36 coins' classifications (USDC backing 86→63). The name-bijection identity stands; the weight bound moves to 5pp with a gross-mismatch regression.

Verified by replaying the captured 2026-07-18 production envelope with the fixed tree: BOLD 84/A and LUSD 77/B+ restored, PYUSD 73/B and USDT 70/B uncapped on honest facts, adverse projections byte-stable (USDD 39, U 32, USDai 39, MIM 0, EURS 21 = attributed fresh-input peg drift). Shared suite 1,588 green, worker 2,670 green, both typechecks, manifest regenerated once (semantic digest → d77890e7).

Residuals tracked for follow-up (not in this PR): USDC bridge-route curation for legacy wrapped supply (BSC 2.16% + dust), USDG issuer-identity join, ZCHF CCIP reviewed-tier wiring, TUSD stale external PoR feed (self-healing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)