### PR TITLE
Restore production Pages payload headroom

### DIFF
--- a/src/app/docs/[slug]/page.test.tsx
+++ b/src/app/docs/[slug]/page.test.tsx
@@ -20,7 +20,7 @@ describe("DocPage", () => {
     expect(html).toContain('href="https://gold-api.com" target="_blank" rel="noopener noreferrer"');
   });
 
-  it("renders markdown tables through the shared table primitives", async () => {
+  it("renders markdown tables with shared table chrome and compact cells", async () => {
     const html = renderToStaticMarkup(await DocPage({ params: Promise.resolve({ slug: "design-tokens" }) }));
 
     expect(html).toContain('data-slot="table-viewport"');
@@ -28,6 +28,7 @@ describe("DocPage", () => {
     expect(html).toContain('data-slot="table-header"');
     expect(html).toContain('data-slot="table-head"');
     expect(html).toContain('data-slot="table-cell"');
+    expect(html).toContain('data-slot="table-cell" class="whitespace-normal px-3 py-2 align-top"');
 
     const labels = Array.from(html.matchAll(/aria-label="(Documentation table:[^"]+)"/g), (match) => match[1]);
     expect(labels.length).toBeGreaterThan(1);

--- a/src/app/docs/[slug]/page.tsx
+++ b/src/app/docs/[slug]/page.tsx
@@ -11,21 +11,16 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import ReactMarkdown from "react-markdown";
 import { FeaturePageShell } from "@/components/feature-page-shell";
-import { TableBody, TableCell, TableFrame, TableHead, TableHeader, TableRow } from "@/components/table";
+import { TableBody, TableFrame, TableHead, TableHeader, TableRow } from "@/components/table";
 import { safeJsonLd } from "@/lib/json-ld";
 import { cn } from "@/lib/utils";
 import { buildPageMetadata } from "@/lib/page-metadata";
 import { SITE_ORIGIN as SITE_URL } from "@shared/lib/runtime-origins";
-import {
-  PUBLIC_DOC_BY_SLUG,
-  preparePublicDocMarkdown,
-  resolvePublicDocHref,
-} from "@shared/lib/public-docs";
+import { PUBLIC_DOC_BY_SLUG, preparePublicDocMarkdown, resolvePublicDocHref } from "@shared/lib/public-docs";
 import docsMetadata from "@/generated/docs-metadata.json";
 
 const DOCS_DIR = path.join(process.cwd(), "docs");
-type MarkdownComponentProps<T extends keyof React.JSX.IntrinsicElements> =
-  React.ComponentProps<T> & { node?: unknown };
+type MarkdownComponentProps<T extends keyof React.JSX.IntrinsicElements> = React.ComponentProps<T> & { node?: unknown };
 interface MarkdownAstNode {
   tagName?: string;
   value?: string;
@@ -47,9 +42,7 @@ function buildDocMetadataTitle(doc: { slug: string; title: string; group: string
 function getMarkdownNodeText(node: MarkdownAstNode | undefined): string {
   if (!node) return "";
   if (typeof node.value === "string") return node.value;
-  return (node.children ?? [])
-    .map((child) => getMarkdownNodeText(child))
-    .join(" ");
+  return (node.children ?? []).map((child) => getMarkdownNodeText(child)).join(" ");
 }
 
 function findFirstMarkdownNodeByTag(node: MarkdownAstNode | undefined, tagName: string): MarkdownAstNode | undefined {
@@ -73,9 +66,7 @@ function getMarkdownTableLabel(node: unknown): string {
   const headerText = headers.join(", ");
   const line = tableNode?.position?.start?.line;
   const lineText = typeof line === "number" ? ` (line ${line})` : "";
-  return headerText
-    ? `Documentation table: ${headerText}${lineText}`
-    : `Documentation table${lineText}`;
+  return headerText ? `Documentation table: ${headerText}${lineText}` : `Documentation table${lineText}`;
 }
 
 const mdxComponents = {
@@ -123,7 +114,7 @@ const mdxComponents = {
     />
   ),
   td: ({ node: _node, className, ...props }: MarkdownComponentProps<"td">) => (
-    <TableCell className={cn("whitespace-normal px-3 py-2 align-top", className)} {...props} />
+    <td {...props} data-slot="table-cell" className={cn("whitespace-normal px-3 py-2 align-top", className)} />
   ),
 };
 
@@ -131,11 +122,7 @@ export function generateStaticParams() {
   return Array.from(PUBLIC_DOC_BY_SLUG.keys()).map((slug) => ({ slug }));
 }
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}): Promise<Metadata> {
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params;
   const doc = PUBLIC_DOC_BY_SLUG.get(slug);
   if (!doc) return { title: "Doc Not Found" };
@@ -147,19 +134,15 @@ export async function generateMetadata({
   });
 }
 
-export default async function DocPage({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function DocPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const doc = PUBLIC_DOC_BY_SLUG.get(slug);
   if (!doc) notFound();
 
-  const source = preparePublicDocMarkdown(
-    fs.readFileSync(path.join(DOCS_DIR, doc.source), "utf-8"),
-    { source: doc.source, stripTitle: true },
-  );
+  const source = preparePublicDocMarkdown(fs.readFileSync(path.join(DOCS_DIR, doc.source), "utf-8"), {
+    source: doc.source,
+    stripTitle: true,
+  });
   const meta = (docsMetadata as Record<string, { dateModified: string; dateCreated: string }>)[slug];
 
   return (


### PR DESCRIPTION
## Summary

- render Markdown documentation body cells as native `td` elements with the same effective compact classes
- preserve the shared table frame, headers, rows, density selector, and `data-slot="table-cell"` contract
- avoid serializing checkbox-only shared-cell selectors into every documentation cell

## Failure context

Deploy run 29656741037 built successfully but stopped before Pages publication because the production API-reference Flight helper was 1,402,029 bytes against a 1,401,000-byte budget. The production environment adds 1,954 bytes of root telemetry references; release-data refresh was not causal.

## Validation

- exact production environment and live release-data refresh reproduced 1,402,029 bytes
- patched production-equivalent build: 1,187,329 bytes
- restored TXT/RSC headroom: about 214 KiB without removing API documentation or raising the budget
- focused docs/API tests: 8 passed
- file-scoped ESLint and diff checks passed
- deploy classifier: pages deploy required, Worker deploy not required

The Worker remains explicitly rolled back to version 8cafca52 while its separate runtime-memory issue is investigated; this Pages-only release cannot reactivate the failed Worker version.