### PR TITLE
fix(pricing): restrict retained pool evidence to direct APIs

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts
@@ -330,6 +330,27 @@ describe("buildDexPriceObservationsFromRetainedPools", () => {
 
     expect(result.has("usp-pareto-credit")).toBe(false);
   });
+
+  it("does not join exact evidence from non-direct sources", () => {
+    const pool = makePool({ poolId: "ethereum:0xretained", tvlUsd: 52_000, price: undefined });
+    const result = buildDexPriceObservationsFromRetainedPools(
+      new Map([["usp-pareto-credit", [pool]]]),
+      new Map([
+        [
+          "usp-pareto-credit",
+          [
+            makeObs({
+              poolKey: "ethereum:0xretained",
+              identityConfidence: "exact",
+              sourceFamily: "dexscreener",
+            }),
+          ],
+        ],
+      ]),
+    );
+
+    expect(result.has("usp-pareto-credit")).toBe(false);
+  });
 });
 
 describe("filterRetainedPools", () => {

--- a/worker/src/cron/dex-liquidity/scoring-helpers.ts
+++ b/worker/src/cron/dex-liquidity/scoring-helpers.ts
@@ -513,6 +513,7 @@ export function buildDexPriceObservationsFromRetainedPools(
     for (const evidence of exactPriceEvidenceByStablecoin?.get(stablecoinId) ?? []) {
       if (
         evidence.identityConfidence !== "exact" ||
+        evidence.sourceFamily !== "direct_api" ||
         !evidence.poolKey ||
         !Number.isFinite(evidence.price) ||
         evidence.price <= 0 ||


### PR DESCRIPTION
### Motivation
- Prevent non-direct staged or fallback provider price observations from being joined into final retained DEX pricing for unpriced retained pools.
- This closes a potential integrity bypass where exact pool-address observations from untrusted families (e.g. DexScreener/staged) could publish prices via the retained-pool join despite not being direct-API quotes.

### Description
- Add a source-family guard in `buildDexPriceObservationsFromRetainedPools` so evidence is accepted only when `evidence.sourceFamily === "direct_api"`, preserving existing `identityConfidence === "exact"`, pool-key, positive price, and `$50K` TVL checks (file: `worker/src/cron/dex-liquidity/scoring-helpers.ts`).
- Add a regression unit test that verifies an otherwise exact DexScreener observation cannot price an unpriced retained pool (file: `worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts`).

### Testing
- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/scoring-helpers.test.ts`, and the suite passed (all tests in that file passed).
- Ran TypeScript worker typecheck with `npm run typecheck:worker`, which completed successfully.
- Ran cron validation checks `npm run check:cron-sync` and `npm run check:cron-connections`, which passed and reported adequate connection headroom.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d513bb508332ae5fdab0421b014e)