### PR TITLE
fix(worker): keep QuoterV2 measurements score-ineligible

### DIFF
--- a/worker/src/cron/measured-execution/__tests__/registry.test.ts
+++ b/worker/src/cron/measured-execution/__tests__/registry.test.ts
@@ -7,18 +7,11 @@ import {
 } from "../registry";
 
 describe("measured execution deployment registry", () => {
-  it("activates exactly the 2026-07-17 owner-ratified QuoterV2 cohort", () => {
-    expect(DEX_MEASURED_EXECUTION_SCORE_ELIGIBLE_DEPLOYMENT_KEYS).toEqual([
-      "uniswap-v3-quoter-v2:ethereum",
-      "uniswap-v3-quoter-v2:polygon",
-      "uniswap-v3-quoter-v2:arbitrum",
-      "pancakeswap-v3-quoter-v2:base",
-      "pancakeswap-v3-quoter-v2:bsc",
-      "pancakeswap-v3-quoter-v2:ethereum",
-    ]);
-    expect(isDexMeasuredExecutionDeploymentScoreEligible("uniswap-v3-quoter-v2", "ethereum")).toBe(true);
-    expect(isDexMeasuredExecutionDeploymentScoreEligible("uniswap-v3-quoter-v2", "Ethereum")).toBe(true);
-    expect(isDexMeasuredExecutionDeploymentScoreEligible("pancakeswap-v3-quoter-v2", "bsc")).toBe(true);
+  it("keeps QuoterV2 deployments shadow-only until RPC evidence is authenticated", () => {
+    expect(DEX_MEASURED_EXECUTION_SCORE_ELIGIBLE_DEPLOYMENT_KEYS).toEqual([]);
+    expect(isDexMeasuredExecutionDeploymentScoreEligible("uniswap-v3-quoter-v2", "ethereum")).toBe(false);
+    expect(isDexMeasuredExecutionDeploymentScoreEligible("uniswap-v3-quoter-v2", "Ethereum")).toBe(false);
+    expect(isDexMeasuredExecutionDeploymentScoreEligible("pancakeswap-v3-quoter-v2", "bsc")).toBe(false);
   });
 
   it("keeps unratified deployments shadow-only fail-closed", () => {

--- a/worker/src/cron/measured-execution/registry.ts
+++ b/worker/src/cron/measured-execution/registry.ts
@@ -95,20 +95,12 @@ export const DEX_MEASURED_EXECUTION_DEPLOYMENTS: readonly DexMeasuredExecutionDe
 ] as const;
 
 /**
- * Activation is cohort-scoped. The 2026-07-17 owner-ratified cohort is backed
- * by the fork-equivalence, cross-check, drift, and shadow evidence packet at
- * agents/safety-score-v9/results/cl-activation-evidence-2026-07-17/packet.md
- * (120/120 exact provider reproductions; failures confined to producer
- * startup generations). Keys not listed here remain shadow-only fail-closed.
+ * QuoterV2 measurements remain shadow-only until their RPC evidence is
+ * independently authenticated at runtime. An empty cohort keeps the
+ * activation-pending gate in place and prevents untrusted quote data from
+ * affecting score-eligible exit-route observations.
  */
-export const DEX_MEASURED_EXECUTION_SCORE_ELIGIBLE_DEPLOYMENT_KEYS: readonly string[] = [
-  "uniswap-v3-quoter-v2:ethereum",
-  "uniswap-v3-quoter-v2:polygon",
-  "uniswap-v3-quoter-v2:arbitrum",
-  "pancakeswap-v3-quoter-v2:base",
-  "pancakeswap-v3-quoter-v2:bsc",
-  "pancakeswap-v3-quoter-v2:ethereum",
-];
+export const DEX_MEASURED_EXECUTION_SCORE_ELIGIBLE_DEPLOYMENT_KEYS: readonly string[] = [];
 
 function deploymentKey(adapterProfileId: string, chain: string): string {
   return `${adapterProfileId.trim().toLowerCase()}:${chain.trim().toLowerCase()}`;


### PR DESCRIPTION
### Motivation
- Prevent forged or compromised single-RPC responses from becoming score-eligible evidence after a recent cohort activation by retaining the fail-closed shadow mode for QuoterV2 until RPC evidence is independently authenticated.

### Description
- Return the QuoterV2 cohort to fail-closed by setting `DEX_MEASURED_EXECUTION_SCORE_ELIGIBLE_DEPLOYMENT_KEYS` to an empty array in `worker/src/cron/measured-execution/registry.ts`.
- Update the registry contract test in `worker/src/cron/measured-execution/__tests__/registry.test.ts` to assert QuoterV2 deployments remain score-ineligible and preserve case-normalized chain handling.
- Commit message and test adjustments ensure the activation-pending `executionCapabilityGate` remains applied until runtime RPC evidence authentication is implemented.

### Testing
- Ran the focused Vitest suite: `npm test -- --run worker/src/cron/measured-execution/__tests__/registry.test.ts worker/src/cron/measured-execution/__tests__/join.test.ts`, and all tests passed.
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, which succeeded. 
- Ran schedule and connection checks `npm run check:cron-sync` and `npm run check:cron-connections`, both of which reported success and budget parity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ab056d29c8332b3538c96a14535ce)