### PR TITLE
fix(worker): fence stale slot reconciliation

### DIFF
--- a/worker/src/lib/__tests__/producer-history.test.ts
+++ b/worker/src/lib/__tests__/producer-history.test.ts
@@ -3,19 +3,16 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { createSqliteD1 } from "../../test-helpers/sqlite-d1";
-import {
-  loadProducerHeads,
-  pruneProducerHistory,
-  recordProducerOutcome,
-  utcCalendarMonth,
-} from "../producer-history";
+import { loadProducerHeads, pruneProducerHistory, recordProducerOutcome, utcCalendarMonth } from "../producer-history";
 import { recordBudgetSurfaceTelemetry } from "../budget-surface-telemetry";
 
 const MIGRATIONS_DIR = join(process.cwd(), "worker/migrations");
 
 function createMigratedDb(): { sqlite: DatabaseSync; db: D1Database } {
   const sqlite = new DatabaseSync(":memory:");
-  for (const file of readdirSync(MIGRATIONS_DIR).filter((entry) => entry.endsWith(".sql")).sort()) {
+  for (const file of readdirSync(MIGRATIONS_DIR)
+    .filter((entry) => entry.endsWith(".sql"))
+    .sort()) {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- repo-owned migration fixture
     sqlite.exec(readFileSync(join(MIGRATIONS_DIR, file), "utf8"));
   }
@@ -43,14 +40,16 @@ describe("producer history", () => {
       itemCount: 364,
       productivity: {
         productive: true,
-        publications: [{
-          surface: "stablecoins",
-          generationId: "stablecoins:100",
-          publishedAt: 108,
-          publishedRows: 364,
-          expectedRows: 364,
-          artifactCacheKey: "stablecoins",
-        }],
+        publications: [
+          {
+            surface: "stablecoins",
+            generationId: "stablecoins:100",
+            publishedAt: 108,
+            publishedRows: 364,
+            expectedRows: 364,
+            artifactCacheKey: "stablecoins",
+          },
+        ],
       },
     });
     await recordProducerOutcome(db, {
@@ -86,11 +85,13 @@ describe("producer history", () => {
       invocationCount: 2,
       productiveCount: 1,
     });
-    const publication = sqlite.prepare(
-      `SELECT state, producer_job, producer_path, invocation_id, worker_version
+    const publication = sqlite
+      .prepare(
+        `SELECT state, producer_job, producer_path, invocation_id, worker_version
          FROM surface_publication_generations
         WHERE surface = 'stablecoins' AND generation_id = 'stablecoins:100'`,
-    ).get() as Record<string, unknown>;
+      )
+      .get() as Record<string, unknown>;
     expect(publication).toMatchObject({
       state: "published",
       producer_job: "sync-stablecoins",
@@ -193,11 +194,13 @@ describe("producer history", () => {
       producer,
     });
 
-    const history = sqlite.prepare(
-      `SELECT outcome, productive, error
+    const history = sqlite
+      .prepare(
+        `SELECT outcome, productive, error
          FROM worker_producer_history
         WHERE idempotency_key = ?`,
-    ).all("budget-surface:budget-invocation-1:digest-trigger-poll");
+      )
+      .all("budget-surface:budget-invocation-1:digest-trigger-poll");
     expect(history).toEqual([{ outcome: "ok", productive: 1, error: null }]);
     expect(await loadProducerHeads(db)).toEqual([
       expect.objectContaining({
@@ -207,11 +210,70 @@ describe("producer history", () => {
         productiveCount: 1,
       }),
     ]);
-    const cache = sqlite.prepare("SELECT value FROM cache WHERE key = ?")
+    const cache = sqlite
+      .prepare("SELECT value FROM cache WHERE key = ?")
       .get("cron:budget-surface:digest-trigger-poll") as { value: string };
     const payload = JSON.parse(cache.value) as Record<string, unknown>;
     expect(payload).toMatchObject({ outcome: "ok", processedCount: 1 });
     expect(payload).not.toHaveProperty("error");
+    sqlite.close();
+  });
+
+  it("lets a late real completion replace reconciliation-owned synthetic history", async () => {
+    const { sqlite, db } = createMigratedDb();
+    const identity = {
+      scheduleKey: "halfHourlyOffset",
+      job: "sync-dex-liquidity",
+      producerPath: "halfHourlyOffset",
+      producerKind: "scheduled-job",
+      invocationId: "shared-invocation",
+      workerVersion: "version-d",
+      slotStartedAt: 1_772_000_000,
+      invokedAt: 1_772_000_000,
+    } as const;
+
+    await recordProducerOutcome(db, {
+      ...identity,
+      idempotencyKey: "synthetic-abandoned",
+      completedAt: 1_772_000_100,
+      outcome: "abandoned",
+      itemCount: null,
+      error: "scheduled slot heartbeat stale",
+      productivity: { productive: false, reason: "platform-abandoned" },
+    });
+    await recordProducerOutcome(db, {
+      ...identity,
+      idempotencyKey: "real-completion",
+      completedAt: 1_772_000_120,
+      outcome: "ok",
+      itemCount: 42,
+      productivity: { productive: true },
+    });
+
+    expect(
+      sqlite
+        .prepare(
+          `SELECT idempotency_key, outcome, productive, item_count, error
+             FROM worker_producer_history`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        idempotency_key: "real-completion",
+        outcome: "ok",
+        productive: 1,
+        item_count: 42,
+        error: null,
+      },
+    ]);
+    expect(await loadProducerHeads(db)).toEqual([
+      expect.objectContaining({
+        lastInvocationId: "shared-invocation",
+        lastOutcome: "ok",
+        invocationCount: 1,
+        productiveCount: 1,
+      }),
+    ]);
     sqlite.close();
   });
 
@@ -230,8 +292,10 @@ describe("producer history", () => {
     insert.run("monthly-old", "monthly", "scheduled-job", "m", now - 400 * 86_400, now - 400 * 86_400, "2025-01", now);
 
     expect(await pruneProducerHistory(db, now)).toBe(1);
-    const ids = sqlite.prepare("SELECT idempotency_key FROM worker_producer_history ORDER BY idempotency_key")
-      .all().map((row) => String((row as { idempotency_key: string }).idempotency_key));
+    const ids = sqlite
+      .prepare("SELECT idempotency_key FROM worker_producer_history ORDER BY idempotency_key")
+      .all()
+      .map((row) => String((row as { idempotency_key: string }).idempotency_key));
     expect(ids).toEqual(["budget-old", "monthly-old"]);
     sqlite.close();
   });

--- a/worker/src/lib/producer-history.ts
+++ b/worker/src/lib/producer-history.ts
@@ -217,7 +217,23 @@ export async function recordProducerOutcome(db: D1Database, input: RecordProduce
          publications_json = excluded.publications_json,
          calendar_period = COALESCE(excluded.calendar_period, worker_producer_history.calendar_period),
          metadata_json = excluded.metadata_json,
-         error = excluded.error`,
+         error = excluded.error
+       ON CONFLICT(schedule_key, job, producer_path, producer_kind, invocation_id) DO UPDATE SET
+         idempotency_key = excluded.idempotency_key,
+         worker_version = excluded.worker_version,
+         slot_started_at = excluded.slot_started_at,
+         invoked_at = excluded.invoked_at,
+         completed_at = excluded.completed_at,
+         outcome = excluded.outcome,
+         productive = excluded.productive,
+         item_count = excluded.item_count,
+         publication_count = excluded.publication_count,
+         publications_json = excluded.publications_json,
+         calendar_period = COALESCE(excluded.calendar_period, worker_producer_history.calendar_period),
+         metadata_json = excluded.metadata_json,
+         error = excluded.error,
+         created_at = MIN(worker_producer_history.created_at, excluded.created_at)
+       WHERE worker_producer_history.outcome IN ('abandoned', 'not_started')`,
       )
       .bind(
         input.idempotencyKey,

--- a/worker/src/lib/scheduled-slot-fence.ts
+++ b/worker/src/lib/scheduled-slot-fence.ts
@@ -5,6 +5,7 @@ import {
   reconcileStaleSlotArtifactsAndRecordEvent,
   hasActiveChildLeaseForScheduledSlot,
   type StaleSlotExecutionArtifact,
+  type StaleSlotReconciliationFence,
   type StaleSlotReconciliationSummary,
 } from "./scheduled-slot-reconciliation";
 
@@ -183,7 +184,12 @@ async function finishStaleScheduledSlotExecution(
            AND slot_started_at = ?
            AND state = 'reconciling'
            AND execution_owner = ?
-           AND execution_generation = ?`,
+           AND execution_generation = ?
+           AND NOT EXISTS (
+             SELECT 1
+               FROM cron_run_progress progress
+              WHERE progress.slot_started_at = cron_slot_executions.slot_started_at
+           )`,
       )
       .bind(
         nowSec,
@@ -289,7 +295,11 @@ export async function sweepStaleScheduledSlotExecutions(
     if (reconciliationGeneration == null) {
       continue;
     }
-    const reconciliation = await reconcileStaleSlotArtifactsAndRecordEvent(db, staleSlot, nowSec);
+    const reconciliation = await reconcileStaleSlotArtifactsAndRecordEvent(db, staleSlot, nowSec, {
+      owner: reconciliationOwner,
+      generation: reconciliationGeneration,
+      state: "reconciling",
+    });
     const finished = await finishStaleScheduledSlotExecution(
       db,
       staleSlot,
@@ -417,7 +427,16 @@ async function claimScheduledSlotExecution(
         .run(),
     );
     if ((takeover.meta.changes ?? 0) > 0) {
-      const reconciliation = await reconcileStaleSlotArtifactsAndRecordEvent(db, staleSlot, nowSec);
+      const reconciliation: StaleSlotReconciliationSummary = await reconcileStaleSlotArtifactsAndRecordEvent(
+        db,
+        staleSlot,
+        nowSec,
+        {
+          owner,
+          generation: existing.execution_generation + 1,
+          state: "running",
+        },
+      );
       staleSlotTakeover.reconciliation = reconciliation;
       await runWithOverloadRetry(() =>
         db

--- a/worker/src/lib/scheduled-slot-reconciliation.ts
+++ b/worker/src/lib/scheduled-slot-reconciliation.ts
@@ -34,6 +34,12 @@ type StaleSlotLeaseRow = {
   lease_until: number;
 };
 
+export interface StaleSlotReconciliationFence {
+  owner: string;
+  generation: number;
+  state: "running" | "reconciling";
+}
+
 export interface StaleSlotReconciliationSummary {
   syntheticCronRuns: number;
   jobAttemptsAbandoned: number;
@@ -97,6 +103,7 @@ export async function hasActiveChildLeaseForScheduledSlot(
   slotKey: string,
   slotStartedAt: number,
   nowSec: number,
+  fence?: StaleSlotReconciliationFence,
 ): Promise<boolean> {
   const jobs = getExpectedJobsForScheduledSlot(slotKey);
   if (jobs.length === 0) return false;
@@ -117,6 +124,30 @@ export async function hasActiveChildLeaseForScheduledSlot(
       .first<{ active: number }>(),
   );
   return row?.active === 1;
+}
+
+async function isSlotFenceCurrent(
+  db: D1Database,
+  slot: StaleSlotExecutionArtifact,
+  fence?: StaleSlotReconciliationFence,
+): Promise<boolean> {
+  if (!fence) return true;
+  const row = await runWithOverloadRetry(() =>
+    db
+      .prepare(
+        `SELECT 1 AS current
+           FROM cron_slot_executions
+          WHERE slot_key = ?
+            AND slot_started_at = ?
+            AND state = ?
+            AND execution_owner = ?
+            AND execution_generation = ?
+          LIMIT 1`,
+      )
+      .bind(slot.slot_key, slot.slot_started_at, fence.state, fence.owner, fence.generation)
+      .first<{ current: number }>(),
+  );
+  return row?.current === 1;
 }
 
 async function getCronLeaseForJob(db: D1Database, job: string): Promise<StaleSlotLeaseRow | null> {
@@ -179,6 +210,7 @@ async function insertSyntheticStaleCronRun(
   progress: StaleSlotProgressRow,
   lease: StaleSlotLeaseRow,
   nowSec: number,
+  fence?: StaleSlotReconciliationFence,
 ): Promise<boolean> {
   const startedAt = progress.started_at || slot.started_at || slot.slot_started_at;
   const durationMs = Math.max(0, nowSec - startedAt) * 1000;
@@ -222,6 +254,19 @@ async function insertSyntheticStaleCronRun(
           WHERE NOT EXISTS (
             SELECT 1 FROM cron_runs WHERE job = ? AND slot_started_at = ?
           )
+            AND NOT EXISTS (
+              SELECT 1 FROM cron_run_progress WHERE job = ? AND slot_started_at = ?
+            )
+            AND (
+              ? IS NULL OR EXISTS (
+                SELECT 1 FROM cron_slot_executions
+                 WHERE slot_key = ?
+                   AND slot_started_at = ?
+                   AND state = ?
+                   AND execution_owner = ?
+                   AND execution_generation = ?
+              )
+            )
          ON CONFLICT DO NOTHING`,
       )
       .bind(
@@ -238,6 +283,14 @@ async function insertSyntheticStaleCronRun(
         slot.worker_version ?? null,
         progress.job,
         slot.slot_started_at,
+        progress.job,
+        slot.slot_started_at,
+        fence?.owner ?? null,
+        slot.slot_key,
+        slot.slot_started_at,
+        fence?.state ?? null,
+        fence?.owner ?? null,
+        fence?.generation ?? null,
       )
       .run(),
   );
@@ -270,6 +323,7 @@ async function insertSyntheticNotStartedCronRun(
   slot: StaleSlotExecutionArtifact,
   job: string,
   nowSec: number,
+  fence?: StaleSlotReconciliationFence,
 ): Promise<boolean> {
   const idempotencyKey = ["scheduled-slot-not-started", slot.slot_key, slot.slot_started_at, job].join(":");
   const descriptor = getScheduledTaskDescriptor(slot.slot_key as CronScheduleKey, job);
@@ -306,6 +360,19 @@ async function insertSyntheticNotStartedCronRun(
           WHERE NOT EXISTS (
             SELECT 1 FROM cron_runs WHERE job = ? AND slot_started_at = ?
           )
+            AND NOT EXISTS (
+              SELECT 1 FROM cron_run_progress WHERE job = ? AND slot_started_at = ?
+            )
+            AND (
+              ? IS NULL OR EXISTS (
+                SELECT 1 FROM cron_slot_executions
+                 WHERE slot_key = ?
+                   AND slot_started_at = ?
+                   AND state = ?
+                   AND execution_owner = ?
+                   AND execution_generation = ?
+              )
+            )
          ON CONFLICT DO NOTHING`,
       )
       .bind(
@@ -321,6 +388,14 @@ async function insertSyntheticNotStartedCronRun(
         slot.worker_version ?? null,
         job,
         slot.slot_started_at,
+        job,
+        slot.slot_started_at,
+        fence?.owner ?? null,
+        slot.slot_key,
+        slot.slot_started_at,
+        fence?.state ?? null,
+        fence?.owner ?? null,
+        fence?.generation ?? null,
       )
       .run(),
   );
@@ -352,6 +427,7 @@ async function reconcileStaleSlotArtifacts(
   db: D1Database,
   slot: StaleSlotExecutionArtifact,
   nowSec: number,
+  fence?: StaleSlotReconciliationFence,
 ): Promise<StaleSlotReconciliationSummary> {
   const summary: StaleSlotReconciliationSummary = {
     syntheticCronRuns: 0,
@@ -371,12 +447,30 @@ async function reconcileStaleSlotArtifacts(
   const progressRowsWithoutOwner = progressRows.filter((progress) => !progress.lease_owner);
   const progressJobs = new Set(progressRows.map((progress) => progress.job));
   const noProgressJobs = expectedJobs.filter((job) => !progressJobs.has(job));
-  if (noProgressJobs.length > 0) {
+  const stillMissingProgressJobs: string[] = [];
+  for (const job of noProgressJobs) {
+    const row = await runWithOverloadRetry(() =>
+      db
+        .prepare(
+          `SELECT 1 AS present
+             FROM cron_run_progress
+            WHERE job = ?
+              AND slot_started_at = ?
+            LIMIT 1`,
+        )
+        .bind(job, slot.slot_started_at)
+        .first<{ present: number }>(),
+    );
+    if (!row && (await isSlotFenceCurrent(db, slot, fence))) {
+      stillMissingProgressJobs.push(job);
+    }
+  }
+  if (stillMissingProgressJobs.length > 0) {
     try {
       summary.jobAttemptsAbandoned += await markWorkerJobAttemptsAbandonedForSlot(db, {
         scheduleKey: slot.slot_key,
         slotStartedAt: slot.slot_started_at,
-        jobs: noProgressJobs,
+        jobs: stillMissingProgressJobs,
         nowSec,
         error: STALE_SLOT_ERROR,
         metadata: {
@@ -396,14 +490,31 @@ async function reconcileStaleSlotArtifacts(
     }
   }
 
-  for (const job of noProgressJobs) {
-    if (await insertSyntheticNotStartedCronRun(db, slot, job, nowSec)) {
+  for (const job of stillMissingProgressJobs) {
+    if (await insertSyntheticNotStartedCronRun(db, slot, job, nowSec, fence)) {
       summary.notStartedCronRuns++;
       summary.syntheticCronRuns++;
     }
   }
 
   for (const progress of progressRowsWithoutOwner) {
+    if (!(await isSlotFenceCurrent(db, slot, fence))) continue;
+    const progressDelete = await runWithOverloadRetry(() =>
+      db
+        .prepare(
+          `DELETE FROM cron_run_progress
+           WHERE job = ?
+             AND slot_started_at = ?
+             AND started_at = ?
+             AND updated_at = ?
+             AND (lease_owner IS NULL OR lease_owner = '')`,
+        )
+        .bind(progress.job, slot.slot_started_at, progress.started_at, progress.updated_at)
+        .run(),
+    );
+    const cleared = progressDelete.meta.changes ?? 0;
+    summary.progressRowsCleared += cleared;
+    if (cleared === 0) continue;
     try {
       summary.jobAttemptsAbandoned += await markWorkerJobAttemptsAbandonedForSlot(db, {
         scheduleKey: slot.slot_key,
@@ -425,18 +536,6 @@ async function reconcileStaleSlotArtifacts(
     } catch (err) {
       console.warn(`[cron-slot] Failed to abandon ownerless attempt for ${progress.job}@${slot.slot_started_at}:`, err);
     }
-    const progressDelete = await runWithOverloadRetry(() =>
-      db
-        .prepare(
-          `DELETE FROM cron_run_progress
-           WHERE job = ?
-             AND slot_started_at = ?
-             AND (lease_owner IS NULL OR lease_owner = '')`,
-        )
-        .bind(progress.job, slot.slot_started_at)
-        .run(),
-    );
-    summary.progressRowsCleared += progressDelete.meta.changes ?? 0;
     summary.abandonedJobs.push({
       job: progress.job,
       progressStage: progress.stage,
@@ -450,7 +549,42 @@ async function reconcileStaleSlotArtifacts(
     const lease = await getCronLeaseForJob(db, progress.job);
     if (!lease || lease.lease_owner !== progress.lease_owner || lease.lease_until >= nowSec) continue;
 
-    if (await insertSyntheticStaleCronRun(db, slot, progress, lease, nowSec)) {
+    if (!(await isSlotFenceCurrent(db, slot, fence))) continue;
+    const progressDelete = await runWithOverloadRetry(() =>
+      db
+        .prepare(
+          `DELETE FROM cron_run_progress
+           WHERE job = ?
+             AND slot_started_at = ?
+             AND started_at = ?
+             AND updated_at = ?
+             AND lease_owner = ?
+             AND EXISTS (
+               SELECT 1 FROM cron_leases
+                WHERE job = ?
+                  AND lease_owner = ?
+                  AND lease_until = ?
+                  AND lease_until < ?
+             )`,
+        )
+        .bind(
+          progress.job,
+          slot.slot_started_at,
+          progress.started_at,
+          progress.updated_at,
+          progress.lease_owner,
+          progress.job,
+          progress.lease_owner,
+          lease.lease_until,
+          nowSec,
+        )
+        .run(),
+    );
+    const cleared = progressDelete.meta.changes ?? 0;
+    summary.progressRowsCleared += cleared;
+    if (cleared === 0) continue;
+
+    if (await insertSyntheticStaleCronRun(db, slot, progress, lease, nowSec, fence)) {
       summary.syntheticCronRuns++;
     }
     summary.abandonedJobs.push({
@@ -486,18 +620,10 @@ async function reconcileStaleSlotArtifacts(
       );
     }
 
-    const progressDelete = await runWithOverloadRetry(() =>
-      db
-        .prepare("DELETE FROM cron_run_progress WHERE job = ? AND slot_started_at = ? AND lease_owner = ?")
-        .bind(progress.job, slot.slot_started_at, progress.lease_owner)
-        .run(),
-    );
-    summary.progressRowsCleared += progressDelete.meta.changes ?? 0;
-
     const leaseDelete = await runWithOverloadRetry(() =>
       db
-        .prepare("DELETE FROM cron_leases WHERE job = ? AND lease_owner = ? AND lease_until < ?")
-        .bind(progress.job, progress.lease_owner, nowSec)
+        .prepare("DELETE FROM cron_leases WHERE job = ? AND lease_owner = ? AND lease_until = ? AND lease_until < ?")
+        .bind(progress.job, progress.lease_owner, lease.lease_until, nowSec)
         .run(),
     );
     summary.leasesCleared += leaseDelete.meta.changes ?? 0;
@@ -547,8 +673,9 @@ export async function reconcileStaleSlotArtifactsAndRecordEvent(
   db: D1Database,
   slot: StaleSlotExecutionArtifact,
   nowSec: number,
+  fence?: StaleSlotReconciliationFence,
 ): Promise<StaleSlotReconciliationSummary> {
-  const reconciliation = await reconcileStaleSlotArtifacts(db, slot, nowSec);
+  const reconciliation = await reconcileStaleSlotArtifacts(db, slot, nowSec, fence);
   await writeStaleSlotEventMarker(db, slot, nowSec, reconciliation);
   return reconciliation;
 }


### PR DESCRIPTION
### Motivation

- Prevent a race where a stale-slot reconciler could overwrite or delete live child progress, leases, and attempts by performing unfenced writes after observing expired leases.
- Ensure stale-slot finalization does not mark a slot finished/error when child progress appears during reconciliation.
- Allow late real producer completions to replace reconciliation-owned synthetic `abandoned`/`not_started` rows instead of failing on the producer identity constraint.

### Description

- Bind a reconciliation fence (owner + generation + state) into artifact cleanup paths and pass it from the sweep/takeover callers into `reconcileStaleSlotArtifactsAndRecordEvent` so child-artifact mutations are revalidated against the claimed owner/generation before destructive writes.
- Prevent finishing a reconciled slot when child progress exists by requiring absence of `cron_run_progress` in the finalizing `UPDATE` (compare-and-swap style predicate) so newly resumed work is preserved.
- Revalidate progress/lease evidence before deleting rows by matching `started_at`/`updated_at` and the originally-observed expired `lease_until`, and require the reconciliation fence to still be current before emitting synthetic runs or abandoning attempts.
- Harden synthetic cron-run inserts to only proceed when no progress exists for the job/slot and when the reconciliation fence matches the expected slot execution row.
- Extend producer history upsert semantics to allow a late real completion to replace reconciliation-owned synthetic rows by adding a conditional `ON CONFLICT(schedule_key, job, producer_path, producer_kind, invocation_id)` update that only replaces existing synthetic outcomes (`'abandoned'`/`'not_started'`) and preserves a sensible `created_at`.
- Add a regression test that verifies a late real producer completion replaces a reconciliation-owned synthetic `abandoned` record, and tidy a few test formatting lines.

### Testing

- Ran TypeScript compile check with `cd worker && npx tsc --noEmit`, which completed successfully.
- Ran focused unit suites with `npx vitest run worker/src/lib/__tests__/scheduled-slot-reconciliation-sqlite.test.ts worker/src/lib/__tests__/producer-history.test.ts`, and all tests passed (10 tests total).
- Ran the repository checks `npm run check:cron-sync`, `npm run check:cron-connections`, and `npm run check:migrations`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c684029648332b14f34584297f15f)