### PR TITLE
fix(worker): enforce AZND price guardrails

### DIFF
--- a/worker/src/lib/__tests__/price-publish-policy.test.ts
+++ b/worker/src/lib/__tests__/price-publish-policy.test.ts
@@ -11,7 +11,7 @@ const USD_CONTEXT: PriceValidationContext = {
 };
 
 describe("validatePrimaryPriceCandidate — severe downside with directional corroboration", () => {
-  it("admits the reviewed AZND exact-pool display route without making the source globally authoritative", () => {
+  it("rejects an AZND exact-pool severe downside without independent corroboration", () => {
     const decision = validatePrimaryPriceCandidate({
       price: 0.38,
       source: "curve-thin-onchain",
@@ -20,17 +20,28 @@ describe("validatePrimaryPriceCandidate — severe downside with directional cor
       validationContext: { ...USD_CONTEXT, stablecoinId: "aznd-mu-digital" },
     });
 
-    expect(decision.accepted).toBe(true);
+    expect(decision.accepted).toBe(false);
+    expect(decision.reason).toBe("severe_downside_requires_corroboration");
+  });
 
-    expect(
-      validatePrimaryPriceCandidate({
-        price: 0.38,
-        source: "curve-thin-onchain",
-        confidence: "fallback",
-        agreeSources: ["curve-thin-onchain"],
-        validationContext: { ...USD_CONTEXT, stablecoinId: "another-stablecoin" },
-      }).reason,
-    ).toBe("severe_downside_requires_corroboration");
+  it("rejects an AZND exact-pool temporal jump without independent corroboration", () => {
+    const decision = validatePrimaryPriceCandidate({
+      price: 0.7,
+      source: "curve-thin-onchain",
+      confidence: "fallback",
+      agreeSources: ["curve-thin-onchain"],
+      validationContext: { ...USD_CONTEXT, stablecoinId: "aznd-mu-digital" },
+      previousTrustedPrice: {
+        price: 1,
+        source: "pyth",
+        confidence: "high",
+        observedAt: null,
+        agreeSources: ["pyth"],
+      },
+    });
+
+    expect(decision.accepted).toBe(false);
+    expect(decision.reason).toBe("temporal_jump_requires_corroboration");
   });
 
   it("rejects severe downside with single source and no corroboration", () => {

--- a/worker/src/lib/price-publish-policy.ts
+++ b/worker/src/lib/price-publish-policy.ts
@@ -9,8 +9,6 @@ import type { PriceConfidence, PriceObservedAtMode } from "@shared/types/core";
 
 const WEAK_FIXED_PEG_JUMP_WITHHOLD_BPS = 2_000;
 const WEAK_FALLBACK_FIXED_PEG_DEPEG_BPS = 500;
-const AZND_ID = "aznd-mu-digital";
-const AZND_EXACT_POOL_SOURCE = "curve-thin-onchain";
 
 export interface TrustedPriceReference {
   price: number;
@@ -92,12 +90,6 @@ function isFallbackSearchOnlySource(source: string | null | undefined): boolean 
   });
 }
 
-function isReviewedAssetScopedDisplayRoute(input: PublishablePriceInput): boolean {
-  return input.validationContext.stablecoinId === AZND_ID
-    && input.source === AZND_EXACT_POOL_SOURCE
-    && input.confidence === "fallback";
-}
-
 function fixedPegDeviationBps(input: PublishablePriceInput): number | null {
   if (!isFixedPegValidationContext(input.validationContext)) return null;
   const referencePrice = getReferencePriceForContext(input.validationContext, input.validationReferences);
@@ -159,10 +151,6 @@ function hasSevereDownsidePublicationCorroboration(input: PublishablePriceInput)
   }
 
   if (isPricingSourceSoftGuardrailExempt(input.source)) {
-    return true;
-  }
-
-  if (isReviewedAssetScopedDisplayRoute(input)) {
     return true;
   }
 
@@ -242,10 +230,6 @@ export function shouldWithholdTemporalJump(input: PublishablePriceInput): boolea
   if (hasAuthoritativeAgreement || isPricingSourceSoftGuardrailExempt(input.source)) {
     return false;
   }
-  if (isReviewedAssetScopedDisplayRoute(input)) {
-    return false;
-  }
-
   if (
     isSevereFixedPegDownside(input.price, input.validationContext, input.validationReferences, FIXED_PEG_SEVERE_DOWNSIDE_RATIO) &&
     hasSevereDownsidePublicationCorroboration(input)


### PR DESCRIPTION
### Motivation
- A recent exception allowed a single AZND (`aznd-mu-digital`) Curve exact-pool fallback quote (`curve-thin-onchain`, `confidence: "fallback"`) to bypass severe-downside corroboration and temporal-jump withholding, weakening published price integrity.
- The Curve exact-pool reader uses very small quote sizes and low minimum balances, making single-pool manipulation economically feasible and enabling an attacker to publish a deep downside without independent corroboration.

### Description
- Remove the AZND-scoped bypass predicate and its early-return usages so `curve-thin-onchain` fallback quotes must satisfy the same severe-downside corroboration checks as other non-exempt sources by deleting the special-case predicate and related short-circuits in `worker/src/lib/price-publish-policy.ts`.
- Keep the general policy paths intact: severe-downside corroboration, independent-candidate corroboration, authoritative-source checks, and temporal-jump withholding remain unchanged and continue to protect other sources.
- Update the unit tests in `worker/src/lib/__tests__/price-publish-policy.test.ts` to assert that an uncorroborated AZND fallback severe-downside is rejected and that an uncorroborated AZND temporal jump is withheld.
- Changed files: `worker/src/lib/price-publish-policy.ts` and `worker/src/lib/__tests__/price-publish-policy.test.ts`.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/lib/__tests__/price-publish-policy.test.ts`, and all tests passed (`19 tests` passed).
- Type-checked the worker with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceac40c8332b80fd2255f8a1088)