### PR TITLE
fix(pricing): guard missing-price alert timestamps

### DIFF
--- a/worker/src/lib/__tests__/stablecoin-publication-alerts.test.ts
+++ b/worker/src/lib/__tests__/stablecoin-publication-alerts.test.ts
@@ -68,6 +68,20 @@ describe("alertOnMissingActiveStablecoinPrices", () => {
     }));
   });
 
+  it("does not throw when persisted accepted timestamps are outside the JavaScript Date range", async () => {
+    const unsafeCoverage = coverage();
+    unsafeCoverage.missingActiveAssets[0]!.lastAcceptedObservedAt = 9_000_000_000_000_000;
+
+    const result = await alertOnMissingActiveStablecoinPrices({} as D1Database, unsafeCoverage, "webhook");
+
+    expect(result).toEqual({ eligibleCount: 1, dueCount: 1, sent: true, suppressedByCooldown: 0 });
+    expect(sendAlertMock).toHaveBeenCalledWith(
+      "webhook",
+      "Active stablecoin prices missing",
+      expect.stringContaining("last accepted at=invalid timestamp"),
+    );
+  });
+
   it("retries when webhook delivery fails", async () => {
     sendAlertMock.mockResolvedValue(false);
     const result = await alertOnMissingActiveStablecoinPrices({} as D1Database, coverage(), "webhook");

--- a/worker/src/lib/__tests__/stablecoin-publication-coverage.test.ts
+++ b/worker/src/lib/__tests__/stablecoin-publication-coverage.test.ts
@@ -193,6 +193,32 @@ describe("evaluateStablecoinActivePriceCoverage", () => {
     });
   });
 
+  it("drops accepted observation timestamps outside the JavaScript Date range", () => {
+    const previousAcceptedAssetsById = new Map([[
+      "missing",
+      {
+        id: "missing",
+        symbol: "MISS",
+        price: 0.998,
+        priceSource: "pyth",
+        priceObservedAt: 9_000_000_000_000_000,
+      },
+    ]]);
+
+    const result = evaluateStablecoinActivePriceCoverage(
+      [{ id: "missing", symbol: "MISS", price: null, priceObservedAt: 9_000_000_000_000_000 }],
+      ["missing"],
+      { previousAcceptedAssetsById },
+    );
+
+    expect(result.missingActiveAssets[0]).toMatchObject({
+      currentObservedAt: null,
+      lastAcceptedPrice: 0.998,
+      lastAcceptedSource: "pyth",
+      lastAcceptedObservedAt: null,
+    });
+  });
+
   it("loads bounded streak state from the latest prior cron metadata", async () => {
     const db = mockD1([{
       match: "activePriceCoverage",

--- a/worker/src/lib/stablecoin-publication-alerts.ts
+++ b/worker/src/lib/stablecoin-publication-alerts.ts
@@ -5,6 +5,7 @@ import type { StablecoinActivePriceCoverage } from "./stablecoin-publication-cov
 
 const ALERT_COOLDOWN_SEC = 24 * 60 * 60;
 const ALERT_MARKER_PREFIX = "sync-stablecoins:missing-active-price-alert:v1";
+const MAX_VALID_DATE_SECONDS = 8_640_000_000_000;
 
 export interface StablecoinPriceCoverageAlertResult {
   eligibleCount: number;
@@ -18,7 +19,11 @@ function markerKey(stablecoinId: string): string {
 }
 
 function formatLastAccepted(observedAt: number | null): string {
-  return observedAt == null ? "never" : new Date(observedAt * 1_000).toISOString();
+  if (observedAt == null) return "never";
+  if (!Number.isFinite(observedAt) || Math.abs(observedAt) > MAX_VALID_DATE_SECONDS) {
+    return "invalid timestamp";
+  }
+  return new Date(observedAt * 1_000).toISOString();
 }
 
 export async function alertOnMissingActiveStablecoinPrices(

--- a/worker/src/lib/stablecoin-publication-coverage.ts
+++ b/worker/src/lib/stablecoin-publication-coverage.ts
@@ -3,6 +3,8 @@ import { getCirculatingRaw } from "@shared/lib/supply";
 
 export const ACTIVE_PRICE_COVERAGE_ALERT_GENERATIONS = 2;
 
+const MAX_VALID_DATE_SECONDS = 8_640_000_000_000;
+
 const ACTIVE_STABLECOIN_SYMBOL_BY_ID = new Map(
   ACTIVE_STABLECOINS.map((stablecoin) => [stablecoin.id, stablecoin.symbol] as const),
 );
@@ -197,6 +199,11 @@ function positiveFiniteNumberOrNull(value: unknown): number | null {
   return parsed != null && parsed > 0 ? parsed : null;
 }
 
+function dateSecondsOrNull(value: unknown): number | null {
+  const parsed = finiteNumberOrNull(value);
+  return parsed != null && Math.abs(parsed) <= MAX_VALID_DATE_SECONDS ? parsed : null;
+}
+
 function stringOrNull(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
@@ -219,7 +226,7 @@ function acceptedObservation(asset: StablecoinPriceCoverageAsset | undefined): {
   return {
     price,
     source: stringOrNull(asset?.priceSource),
-    observedAt: finiteNumberOrNull(asset?.priceObservedAt ?? asset?.priceUpdatedAt),
+    observedAt: dateSecondsOrNull(asset?.priceObservedAt ?? asset?.priceUpdatedAt),
   };
 }
 
@@ -237,12 +244,12 @@ function parsePriorMissingDetail(value: unknown): MissingActivePriceDetail | nul
     marketCapUsd: finiteNumberOrNull(entry.marketCapUsd),
     currentPrice: finiteNumberOrNull(entry.currentPrice),
     currentSource: stringOrNull(entry.currentSource),
-    currentObservedAt: finiteNumberOrNull(entry.currentObservedAt),
+    currentObservedAt: dateSecondsOrNull(entry.currentObservedAt),
     currentConfidence: stringOrNull(entry.currentConfidence),
     consecutiveMissingGenerations,
     lastAcceptedPrice: positiveFiniteNumberOrNull(entry.lastAcceptedPrice),
     lastAcceptedSource: stringOrNull(entry.lastAcceptedSource),
-    lastAcceptedObservedAt: finiteNumberOrNull(entry.lastAcceptedObservedAt),
+    lastAcceptedObservedAt: dateSecondsOrNull(entry.lastAcceptedObservedAt),
     rejectionReason: stringOrNull(entry.rejectionReason) ?? "no-accepted-price",
     alertEligible: entry.alertEligible === true
       || consecutiveMissingGenerations >= ACTIVE_PRICE_COVERAGE_ALERT_GENERATIONS,
@@ -266,7 +273,7 @@ function parsePersistedMissingState(value: unknown): MissingActivePriceDetail | 
     consecutiveMissingGenerations,
     lastAcceptedPrice: positiveFiniteNumberOrNull(value[2]),
     lastAcceptedSource: stringOrNull(value[3]),
-    lastAcceptedObservedAt: finiteNumberOrNull(value[4]),
+    lastAcceptedObservedAt: dateSecondsOrNull(value[4]),
     rejectionReason: stringOrNull(value[5]) ?? "no-accepted-price",
     alertEligible: consecutiveMissingGenerations >= ACTIVE_PRICE_COVERAGE_ALERT_GENERATIONS,
   };
@@ -424,7 +431,7 @@ export function evaluateStablecoinActivePriceCoverage(
       marketCapUsd,
       currentPrice,
       currentSource: typeof asset?.priceSource === "string" ? asset.priceSource : null,
-      currentObservedAt: finiteNumberOrNull(asset?.priceObservedAt ?? asset?.priceUpdatedAt),
+      currentObservedAt: dateSecondsOrNull(asset?.priceObservedAt ?? asset?.priceUpdatedAt),
       currentConfidence: typeof asset?.priceConfidence === "string" ? asset.priceConfidence : null,
       consecutiveMissingGenerations,
       lastAcceptedPrice,


### PR DESCRIPTION
### Motivation
- Prevent a RangeError during the stablecoin sync cron caused by persisted `lastAcceptedObservedAt` values outside JavaScript's valid `Date` range, which could abort the cron and degrade ingestion/alerts.

### Description
- Add a `MAX_VALID_DATE_SECONDS` bound and `dateSecondsOrNull()` helper to validate seconds-based timestamps against the JS `Date` range. 
- Use `dateSecondsOrNull()` when reading/parsing persisted or upstream observation timestamps (e.g. in `acceptedObservation`, `parsePriorMissingDetail`, `parsePersistedMissingState`, and when populating `currentObservedAt`).
- Harden alert rendering by updating `formatLastAccepted()` to avoid constructing an invalid `Date` and to return `"invalid timestamp"` for out-of-range values instead of calling `toISOString()`.
- Add regression tests to verify that out-of-range persisted timestamps are sanitized and that alert construction does not throw.

### Testing
- Ran unit tests with `npm test -- --run worker/src/lib/__tests__/stablecoin-publication-alerts.test.ts worker/src/lib/__tests__/stablecoin-publication-coverage.test.ts` and all tests passed (2 test files, 13 tests).
- Type-checked the worker with `cd worker && npx tsc --noEmit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceb629483329b93f6247fb4b928)