### PR TITLE
fix(pricing): reject stale non-replay-safe parents

### DIFF
--- a/worker/src/lib/__tests__/authoritative-price-sources.test.ts
+++ b/worker/src/lib/__tests__/authoritative-price-sources.test.ts
@@ -2473,6 +2473,12 @@ describe("authoritative-price-sources", () => {
       },
       {
         priceSource: "alchemy-address+coingecko+moralis-address",
+        priceConfidence: "high" as const,
+        priceObservedAt: nowSec - 20 * 60,
+        priceSyncedAt: nowSec - 30,
+      },
+      {
+        priceSource: "alchemy-address+coingecko+moralis-address",
         priceConfidence: "low" as const,
         priceObservedAt: nowSec - 60,
       },

--- a/worker/src/lib/authoritative-price-sources/helpers.ts
+++ b/worker/src/lib/authoritative-price-sources/helpers.ts
@@ -344,6 +344,7 @@ function resolveTrustedInheritedParent(
     if (
       freshness.accepted === false &&
       freshness.reason === "stale_observed_at" &&
+      replaySafe &&
       syncedAt != null &&
       splitCompositePriceSource(parentSource).length > 1
     ) {


### PR DESCRIPTION
### Motivation
- Prevent a stale non-replay-safe composite parent price from being laundered into a high-confidence protocol-derived override via the `priceSyncedAt` fallback.
- The sAID ERC-4626 config had been allowed to use `allowFreshNonReplaySafeParent`, which made the existing synced-time fallback accept stale upstream quotes when a recent local sync timestamp existed.
- Make the minimal change to preserve the existing fallback for legitimately replay-safe parents while closing the attack/poisoning vector for non-replay-safe sources.

### Description
- Require the parent to be `replaySafe` before permitting the `priceSyncedAt` fallback in `resolveTrustedInheritedParent` (added `replaySafe` guard in `worker/src/lib/authoritative-price-sources/helpers.ts`).
- Add a regression case to `worker/src/lib/__tests__/authoritative-price-sources.test.ts` that covers a stale high-confidence non-replay-safe AID parent with a fresh `priceSyncedAt` so the path remains closed.
- Keep the change minimal and local to the inherited-parent resolver so existing behavior for replay-safe parents and other sources is preserved.

### Testing
- Ran the focused authoritative-price-sources test suite with `npx vitest run worker/src/lib/__tests__/authoritative-price-sources.test.ts --reporter=verbose`, which passed (all tests in the file succeeded).
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, which completed without errors.
- Verified repository diffs for the two modified files contain only the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ce9f0c08332a991204c227be8f8)