### PR TITLE
fix(liquidity): harden tracked reference price gate

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-lookups.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-lookups.test.ts
@@ -71,6 +71,28 @@ describe("loadTrackedStablecoinMaps", () => {
     expect(stablecoinPriceById.get("susn-noon")).toBe(1.2055005012280287);
   });
 
+  it("rejects fallback-only multi-source tracked prices for CL target references", async () => {
+    loadStablecoinsCache.mockResolvedValue({
+      kind: "ok",
+      updatedAt: NOW_SEC,
+      payload: {
+        peggedAssets: [
+          makeAsset({
+            id: "usdc-circle",
+            price: 0.42,
+            priceConfidence: "high",
+            priceSource: "dexscreener-address+alchemy-address",
+            agreeSources: ["dexscreener-address", "alchemy-address"],
+          }),
+        ],
+      },
+    });
+
+    const { stablecoinPriceById } = await loadTrackedStablecoinMaps({} as D1Database, NOW_SEC);
+
+    expect(stablecoinPriceById.has("usdc-circle")).toBe(false);
+  });
+
   it("still rejects a soft price without fresh multi-source agreement", async () => {
     loadStablecoinsCache.mockResolvedValue({
       kind: "ok",

--- a/worker/src/lib/__tests__/depeg-trust-policy.test.ts
+++ b/worker/src/lib/__tests__/depeg-trust-policy.test.ts
@@ -70,14 +70,32 @@ describe("classifyPrimaryDepegTrust", () => {
 describe("hasFreshMultiSourcePrimaryAgreement", () => {
   const nowSec = 1_700_000_000;
 
-  it("accepts fresh corroborated multi-source agreement", () => {
+  it("accepts fresh high-confidence corroborated independent-family agreement", () => {
     expect(hasFreshMultiSourcePrimaryAgreement({
       price: 0.999,
       priceSource: "coingecko+defillama-list",
-      priceConfidence: "single-source",
+      priceConfidence: "high",
       priceObservedAt: nowSec - 60,
       agreeSources: ["coingecko", "defillama-list"],
     }, nowSec)).toBe(true);
+  });
+
+  it("rejects non-high-confidence or fallback-only agreement", () => {
+    expect(hasFreshMultiSourcePrimaryAgreement({
+      price: 0.42,
+      priceSource: "dexscreener-address+alchemy-address",
+      priceConfidence: "single-source",
+      priceObservedAt: nowSec - 60,
+      agreeSources: ["dexscreener-address", "alchemy-address"],
+    }, nowSec)).toBe(false);
+
+    expect(hasFreshMultiSourcePrimaryAgreement({
+      price: 0.42,
+      priceSource: "dexscreener-address+alchemy-address",
+      priceConfidence: "high",
+      priceObservedAt: nowSec - 60,
+      agreeSources: ["dexscreener-address", "alchemy-address"],
+    }, nowSec)).toBe(false);
   });
 
   it("rejects stale or low-confidence clusters", () => {

--- a/worker/src/lib/depeg-trust-policy.ts
+++ b/worker/src/lib/depeg-trust-policy.ts
@@ -156,7 +156,16 @@ export function hasFreshMultiSourcePrimaryAgreement(
     return false;
   }
 
-  return getPrimaryTrustSources(input).length >= 2;
+  if (input.priceConfidence !== "high") {
+    return false;
+  }
+
+  const sourceFamilies = getPrimaryDepegSourceFamilies(input);
+  if (sourceFamilies.size < 2) {
+    return false;
+  }
+
+  return [...sourceFamilies].some((family) => !family.startsWith("fallback:"));
 }
 
 


### PR DESCRIPTION
### Motivation
- Prevent soft/fallback multi-source price clusters (e.g. address-price aggregators) from poisoning measured-execution reference prices and overriding safer peg/reference fallbacks used by DEX liquidity/exit-targets. 
- The previous change broadened the acceptance gate to `hasFreshMultiSourcePrimaryAgreement()`, which was too permissive for measured-execution references and allowed non-authoritative, fallback-only two-source clusters to be retained.

### Description
- Tighten `hasFreshMultiSourcePrimaryAgreement()` in `worker/src/lib/depeg-trust-policy.ts` to require `priceConfidence === "high"`, require at least two independent depeg source families via `getPrimaryDepegSourceFamilies()`, and require at least one non-`fallback:` family before returning true.
- Update unit tests in `worker/src/lib/__tests__/depeg-trust-policy.test.ts` to require/verify high-confidence independent-family agreement and to reject fallback-only or non-high-confidence clusters.
- Add a regression test in `worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-lookups.test.ts` asserting fallback-only address-price clusters are not retained by `loadTrackedStablecoinMaps()` while preserving existing NAV retention behavior.

### Testing
- Ran the focused Vitest suites: `npx vitest run worker/src/lib/__tests__/depeg-trust-policy.test.ts worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-lookups.test.ts --reporter=dot`, and all tests passed.
- Type-checked the Worker code with `cd worker && npx tsc --noEmit`, which completed successfully.
- Ran repository cron checks `npm run check:cron-sync` and `npm run check:cron-connections`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea00248332b237980b30410dcc)