### PR TITLE
fix(yield): require exact Safety Score V8 publication identity before live hydration

### DIFF
--- a/worker/src/api/__tests__/yield-rankings.test.ts
+++ b/worker/src/api/__tests__/yield-rankings.test.ts
@@ -502,7 +502,7 @@ describe("handleYieldRankings", () => {
     expect(body._meta.ageSeconds).toBe(30);
   });
 
-  it("hydrates across ordinary compact publication generations and reports the live identity", async () => {
+  it("returns explicit NR fields instead of crossing compact publication generations", async () => {
     const hourlyPublishedAt = Math.floor(Date.now() / 1000) - 3_600;
     const hourlyGenerationId = `report-cards:${SAFETY_SCORE_METHODOLOGY_VERSION}:${hourlyPublishedAt}`;
     const payload = {
@@ -538,25 +538,29 @@ describe("handleYieldRankings", () => {
     const res = await handleYieldRankings(db);
     const body = await res.json() as YieldRankingsResponse;
 
+    expect(res.status).toBe(200);
     expect(body.rankings[0]).toMatchObject({
       id: "rated-coin",
-      safetyScore: 66,
-      safetyGrade: "B-",
+      safetyScore: null,
+      safetyGrade: "NR",
+      safetyReason: "safety-identity-mismatch",
+      pharosYieldScore: null,
+      pysNullReason: "safety-unrated",
     });
     expect(body.provenance?.safetySnapshot).toMatchObject(payload.provenance.safetySnapshot);
     expect(body.provenance?.liveSafetyHydration).toMatchObject({
-      kind: "ok",
-      coverageRatio: 1,
-      coveredCount: 1,
+      kind: "degraded",
+      coverageRatio: 0,
+      coveredCount: 0,
       trackedCount: 1,
-      reason: null,
+      reason: "safety-identity-mismatch",
       source: "report-card-cache",
       publicationGenerationId: liveGenerationId,
       methodologyVersion: SAFETY_SCORE_METHODOLOGY_VERSION,
       publishedAt: expect.any(Number),
     });
     expect(body.provenance?.liveSafetyHydration?.publicationGenerationId).toBe(liveGenerationId);
-    expect(body.rankings[0]?.provenance?.safetyScoreIdentity).toEqual(currentSafetyIdentity);
+    expect(body.warnings?.some((warning) => warning.code === "yield-safety-hydration-degraded")).toBe(true);
   });
 
   it("returns explicit NR fields instead of crossing compact safety identities", async () => {

--- a/worker/src/api/yield-rankings-cache.ts
+++ b/worker/src/api/yield-rankings-cache.ts
@@ -1,5 +1,5 @@
 import type { SafetyScoreV8PublicationIdentity } from "@shared/types/safety-score-publication";
-import { safetyScoreV8MethodologyIdentitiesMatch } from "@shared/lib/safety-score-v8-publication";
+import { safetyScoreV8PublicationIdentitiesMatch } from "@shared/lib/safety-score-v8-publication";
 import { CRON_INTERVALS } from "@shared/lib/cron-jobs";
 import {
   YieldRankingsResponseSchema,
@@ -549,7 +549,7 @@ function hasCompatibleSafetyIdentity(
   identity: SafetyScoreV8PublicationIdentity,
 ): boolean {
   const published = payload.provenance?.safetySnapshot.safetyScoreIdentity;
-  return published != null && safetyScoreV8MethodologyIdentitiesMatch(published, identity);
+  return published != null && safetyScoreV8PublicationIdentitiesMatch(published, identity);
 }
 
 function removeSafetyDerivedSourceRisk(sourceRisk: YieldRanking["sourceRisk"]): YieldRanking["sourceRisk"] {


### PR DESCRIPTION
### Motivation
- The yield rankings handler was using a methodology-level identity check which omitted `baseInputGenerationId` and `publicationGenerationId`, allowing cached yield payloads to be re-hydrated with a different Safety Score publication and leading to a fail-open data-integrity regression.
- The change restores fail-closed behavior so public PYS/rank outputs do not mix cached yield provenance with an unrelated live safety publication during report-card publication skew.

### Description
- Replace the methodology-only comparison with the exact publication identity comparison by using `safetyScoreV8PublicationIdentitiesMatch` in `worker/src/api/yield-rankings-cache.ts` for the `hasCompatibleSafetyIdentity` check.
- Update the focused yield rankings test in `worker/src/api/__tests__/yield-rankings.test.ts` to assert that mismatched compact publication generations degrade to `NR` with a `safety-identity-mismatch` degradation rather than hydrating live safety-derived PYS/ranks.
- Preserve the existing degradation path and warnings so hydration still proceeds only when the cached safety snapshot identity exactly matches the live compact snapshot identity.

### Testing
- Ran the focused suite with `npm test -- worker/src/api/__tests__/yield-rankings.test.ts`, and the test file passed (all tests succeeded).
- Ran the worker typecheck with `npm run typecheck:worker`, and the TypeScript checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceae258833290a30a811914b9f8)