### PR TITLE
fix(dex): guard Curve fingerprint addresses

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/fetch-primary.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/fetch-primary.test.ts
@@ -408,6 +408,70 @@ describe("buildCurveLookups", () => {
     ]);
   });
 
+  it("skips Curve fingerprinting for malformed coin addresses while preserving later pools", async () => {
+    const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+    const USDT = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+    const makeApiPool = (address: string, coins: Array<{ symbol: string; address: unknown }>, usdTotal = 200_000) => ({
+      address,
+      name: coins.map((coin) => coin.symbol).join("/"),
+      amplificationCoefficient: "1000",
+      coins: coins.map((coin) => ({
+        ...coin,
+        poolBalance: "100000000000",
+        usdPrice: 1,
+        decimals: "6",
+      })),
+      usdTotal,
+      isMetaPool: false,
+      assetTypeName: "USD",
+      totalSupply: 0,
+      registryId: "factory-stable-ng",
+      isBroken: false,
+      virtualPrice: "1",
+      usdTotalExcludingBasePool: 0,
+      creationTs: 123,
+      basePoolAddress: null,
+      gaugeCrvApy: null,
+    });
+    const curvePayloads = [
+      {
+        data: {
+          poolData: [
+            makeApiPool("0x1111111111111111111111111111111111111111", [
+              { symbol: "USDC", address: null },
+              { symbol: "USDT", address: USDT },
+            ]),
+            makeApiPool("0x2222222222222222222222222222222222222222", [
+              { symbol: "USDC", address: USDC },
+              { symbol: "USDT", address: USDT },
+            ]),
+          ],
+        },
+      },
+    ];
+
+    const { curvePoolMap, priceObservations } = await buildCurveLookups(
+      curvePayloads as never,
+      new Map([["USDC", ["usd-coin"]]]),
+      new Map([["USDC", new Map([["ethereum", ["usd-coin"]]])]]),
+      new Map([[`ethereum:${USDC}`, "usd-coin"]]),
+    );
+
+    expect(curvePoolMap.has("ethereum:0x1111111111111111111111111111111111111111")).toBe(true);
+    expect(curvePoolMap.has("ethereum:0x2222222222222222222222222222222222222222")).toBe(true);
+    expect(curvePoolMap.get(`fp:ethereum:curve:${[USDC, USDT].sort().join(":")}`)).toBe(
+      curvePoolMap.get("ethereum:0x2222222222222222222222222222222222222222"),
+    );
+    expect(priceObservations.get("usd-coin")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          poolKey: "ethereum:0x2222222222222222222222222222222222222222",
+          identityConfidence: "exact",
+        }),
+      ]),
+    );
+  });
+
   it("indexes pools by coin-set fingerprint and fails closed on duplicates", async () => {
     const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
     const USDT = "0xdac17f958d2ee523a2206206994597c13d831ec7";

--- a/worker/src/cron/dex-liquidity/fetch-primary.ts
+++ b/worker/src/cron/dex-liquidity/fetch-primary.ts
@@ -404,11 +404,13 @@ export async function buildCurveLookups(
             : {}),
         };
         curvePoolMap.set(`${chain}:${pool.address.toLowerCase()}`, entry);
-        const fingerprintKey = buildPoolFingerprint(
-          chain,
-          "curve",
-          pool.coins.map((coin) => coin.address),
+        const curveCoinAddresses = pool.coins.map((coin) => coin.address);
+        const hasCompleteCurveCoinAddresses = curveCoinAddresses.every(
+          (address): address is string => typeof address === "string" && address.trim().length > 0,
         );
+        const fingerprintKey = hasCompleteCurveCoinAddresses
+          ? buildPoolFingerprint(chain, "curve", curveCoinAddresses)
+          : null;
         if (
           fingerprintKey &&
           pool.usdTotal >= DEX_LIQUIDITY_POOL_MIN_TVL_USD &&
@@ -431,14 +433,14 @@ export async function buildCurveLookups(
             chain,
             protocol: "curve",
             poolAddressOrId: pool.address,
-            tokenAddresses: pool.coins.map((coin) => coin.address),
+            tokenAddresses: hasCompleteCurveCoinAddresses ? curveCoinAddresses : [],
             poolType: isCryptoSwap(pool.registryId ?? "") ? "curve-cryptoswap" : "curve-stableswap",
             isStable: true,
           });
           for (const coin of pool.coins) {
             if (!coin.usdPrice || coin.usdPrice <= 0) continue;
             const resolved = resolveTrackedStablecoinId(
-              { chain, address: coin.address, symbol: coin.symbol },
+              { chain, address: typeof coin.address === "string" ? coin.address : "", symbol: coin.symbol },
               { chainAddressToId, symbolToChainScopedIds },
             );
             if (resolved.status !== "matched" || !resolved.stablecoinId) continue;


### PR DESCRIPTION
### Motivation
- Curve API rows can contain missing or non-string `coin.address` values which could throw when trimmed and abort processing of the entire chain payload. 
- The change hardens Curve ingestion so a single malformed low-TVL or irrelevant pool row cannot suppress later valid Curve enrichment, price observations, and execution-model activation. 

### Description
- Validate Curve `coin.address` values before calling `buildPoolFingerprint()` and only compute an address-grade fingerprint when every token address is a non-empty string. 
- When addresses are incomplete, fall back to preserving the exact pool address and symbol-combo indexing while passing an empty token-address list into derived-identity construction so no trim/substring operations are executed on invalid values. 
- Coerce per-coin resolution calls to use `""` for non-string addresses to avoid runtime throws, and keep ambiguous-fingerprint logic unchanged. 
- Add a regression test in `worker/src/cron/dex-liquidity/__tests__/fetch-primary.test.ts` that verifies a malformed Curve coin address does not prevent subsequent valid pools from receiving fingerprint enrichment and price observations. 

### Testing
- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/fetch-primary.test.ts` and all tests in that file passed (11/11). 
- Ran TypeScript check with `cd worker && npx tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceae2d08332bd15cd149fa259e9)