### PR TITLE
fix(liquidity): keep exact direct duplicates evidence-only

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-direct-api.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-direct-api.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DexApiPool } from "../../../lib/dex-api-common";
-import {
-  compactDirectApiFetchPhasePools,
-  integrateDirectApiLiquidityPhase,
-} from "../orchestrator-phases/direct-api";
+import { compactDirectApiFetchPhasePools, integrateDirectApiLiquidityPhase } from "../orchestrator-phases/direct-api";
 import { buildAuthoritativeStagedPoolConfirmationIndex } from "../orchestrator-phases/authoritative";
 import { createKnownPoolIdentityIndex } from "../pool-identity";
 import { initMetrics } from "../pool-helpers";
@@ -105,9 +102,7 @@ describe("integrateDirectApiLiquidityPhase", () => {
       poolType: "balancer-stable",
       tokens: [
         {
-          address: tracked
-            ? trackedAddress
-            : `0x${(index + rawPoolCount).toString(16).padStart(40, "0")}`,
+          address: tracked ? trackedAddress : `0x${(index + rawPoolCount).toString(16).padStart(40, "0")}`,
           symbol: tracked ? "TRACKED" : "UNKNOWN",
           decimals: 6,
         },
@@ -157,9 +152,7 @@ describe("integrateDirectApiLiquidityPhase", () => {
     };
 
     const compacted = compactDirectApiFetchPhasePools(rawPhase, {
-      chainAddressToId: new Map([
-        [buildChainAddressKey("ethereum", trackedAddress), "tracked-stablecoin"],
-      ]),
+      chainAddressToId: new Map([[buildChainAddressKey("ethereum", trackedAddress), "tracked-stablecoin"]]),
       symbolToChainScopedIds: new Map(),
     });
     const authoritativeConfirmation = buildAuthoritativeStagedPoolConfirmationIndex(compacted.phase.results);
@@ -208,9 +201,7 @@ describe("integrateDirectApiLiquidityPhase", () => {
       contractMetaByChainAddress: new Map(),
       metrics: new Map(),
       priceObservations: new Map(),
-      chainAddressToId: new Map([
-        [buildChainAddressKey("solana", "tracked-mint"), "tracked-stablecoin"],
-      ]),
+      chainAddressToId: new Map([[buildChainAddressKey("solana", "tracked-mint"), "tracked-stablecoin"]]),
       symbolToChainScopedIds: new Map(),
       symbolToIds: new Map(),
       validationReferences: {} as never,
@@ -379,5 +370,149 @@ describe("integrateDirectApiLiquidityPhase", () => {
         sourceFamily: "direct_api",
       }),
     ]);
+  });
+
+  it("drops exact duplicate evidence when no matching primary top-pool row was counted", async () => {
+    const poolAddress = "11111111111111111111111111111111";
+    const knownPoolIndex = createKnownPoolIdentityIndex();
+    knownPoolIndex.exactKeys.add(`solana:${poolAddress}`);
+    const metrics = new Map();
+    const priceObservations = new Map();
+
+    const result = await integrateDirectApiLiquidityPhase({
+      directApiPools: [
+        {
+          source: "raydium",
+          chain: "solana",
+          poolAddress,
+          poolType: "raydium-amm",
+          tokens: [
+            { address: "UsdcMint", symbol: "USDC", decimals: 6 },
+            { address: "UsdtMint", symbol: "USDT", decimals: 6 },
+          ],
+          price: 1,
+          tvlUsd: 4_000_000,
+          volume24hUsd: 100_000,
+          feeRate: 0.0025,
+          balances: [2_000_000, 2_000_000],
+          balancesNormalized: true,
+        },
+      ],
+      knownPoolIndex,
+      contractMetaByChainAddress: new Map(),
+      metrics,
+      priceObservations,
+      chainAddressToId: new Map([
+        ["solana:UsdcMint", "usdc-circle"],
+        ["solana:UsdtMint", "usdt-tether"],
+      ]),
+      symbolToChainScopedIds: new Map(),
+      symbolToIds: new Map(),
+      validationReferences: {} as never,
+      stablecoinPriceById: new Map([
+        ["usdc-circle", 1],
+        ["usdt-tether", 1],
+      ]),
+    });
+
+    expect(result.directApiDedupSkippedByAddress).toBe(1);
+    expect(metrics.size).toBe(0);
+    expect(priceObservations.get("usdc-circle")).toEqual([
+      expect.objectContaining({
+        poolKey: `solana:${poolAddress}`,
+        identityConfidence: "exact",
+        sourceFamily: "direct_api",
+      }),
+    ]);
+  });
+
+  it("does not overwrite retained exact-pool evidence when protocol compatibility fails", async () => {
+    const poolAddress = "11111111111111111111111111111111";
+    const knownPoolIndex = createKnownPoolIdentityIndex();
+    knownPoolIndex.exactKeys.add(`solana:${poolAddress}`);
+    const usdcMetrics = initMetrics("usdc-circle", "USDC");
+    usdcMetrics.totalTvlUsd = 4_000_000;
+    usdcMetrics.poolCount = 1;
+    usdcMetrics.topPools.push({
+      poolId: `solana:${poolAddress}`,
+      project: "retained-primary-protocol",
+      chain: "Solana",
+      tvlUsd: 4_000_000,
+      symbol: "USDC / USDT",
+      volumeUsd1d: 100_000,
+      poolType: "primary-stable",
+      source: "dl",
+      extra: {
+        ammExecutionModel: {
+          source: "balancer",
+          invariant: "stableswap",
+          trackedTokenIndex: 0,
+          feeRate: 0.0001,
+          tokens: [
+            {
+              address: "UsdcMint",
+              symbol: "USDC",
+              decimals: 6,
+              balance: 2_000_000,
+              referencePriceUsd: 1,
+              referencePriceSource: "tracked-market",
+            },
+            {
+              address: "UsdtMint",
+              symbol: "USDT",
+              decimals: 6,
+              balance: 2_000_000,
+              referencePriceUsd: 1,
+              referencePriceSource: "tracked-market",
+            },
+          ],
+        },
+      },
+    });
+    const metrics = new Map([["usdc-circle", usdcMetrics]]);
+
+    await integrateDirectApiLiquidityPhase({
+      directApiPools: [
+        {
+          source: "raydium",
+          chain: "solana",
+          poolAddress,
+          poolType: "raydium-amm",
+          tokens: [
+            { address: "UsdcMint", symbol: "USDC", decimals: 6 },
+            { address: "UsdtMint", symbol: "USDT", decimals: 6 },
+          ],
+          price: 1,
+          tvlUsd: 4_000_000,
+          volume24hUsd: 100_000,
+          feeRate: 0.0025,
+          balances: [2_000_000, 2_000_000],
+          balancesNormalized: true,
+        },
+      ],
+      knownPoolIndex,
+      contractMetaByChainAddress: new Map(),
+      metrics,
+      priceObservations: new Map(),
+      chainAddressToId: new Map([
+        ["solana:UsdcMint", "usdc-circle"],
+        ["solana:UsdtMint", "usdt-tether"],
+      ]),
+      symbolToChainScopedIds: new Map(),
+      symbolToIds: new Map(),
+      validationReferences: {} as never,
+      stablecoinPriceById: new Map([
+        ["usdc-circle", 1],
+        ["usdt-tether", 1],
+      ]),
+    });
+
+    expect(usdcMetrics.totalTvlUsd).toBe(4_000_000);
+    expect(usdcMetrics.poolCount).toBe(1);
+    expect(usdcMetrics.topPools[0]?.extra?.ammExecutionModel).toMatchObject({
+      source: "balancer",
+      invariant: "stableswap",
+      feeRate: 0.0001,
+    });
   });
 });

--- a/worker/src/cron/dex-liquidity/orchestrator-phases/direct-api.ts
+++ b/worker/src/cron/dex-liquidity/orchestrator-phases/direct-api.ts
@@ -1,10 +1,8 @@
+import { canonicalExitRouteAssetKey } from "@shared/lib/exit-route-identity";
 import type { PriceValidationReferences } from "../../../lib/price-validation";
 import type { ChainRpcConfig } from "../../../lib/chain-registry";
 import { CIRCUIT_SOURCE } from "../../../lib/constants";
-import {
-  type CircuitOutcomeRecord,
-  type CircuitState,
-} from "../../../lib/circuit-breaker";
+import { type CircuitOutcomeRecord, type CircuitState } from "../../../lib/circuit-breaker";
 import {
   ProviderCircuitOpenError,
   ProviderExecutionError,
@@ -32,6 +30,7 @@ import { fetchMeteoraPools } from "../fetch-meteora";
 import { fetchPancakeSwapPools } from "../fetch-pancakeswap";
 import { fetchSlipstreamPools } from "../fetch-slipstream";
 import { mergeGtPools } from "../fetch-crawlers";
+import { normalizeProtocol } from "../pool-helpers";
 import { buildDirectApiPoolIdentity } from "../direct-source-helpers";
 import {
   countPoolIdentityKeys,
@@ -39,12 +38,9 @@ import {
   registerKnownPoolIdentity,
   type KnownPoolIdentityIndex,
 } from "../pool-identity";
-import type { DexPriceObs, LiquidityMetrics, SymbolLookups } from "../types";
+import type { DexPriceObs, GtNewPool, LiquidityMetrics, PoolEntry, SymbolLookups } from "../types";
 import { mergeDexPriceObservationMap } from "./price-obs";
-import {
-  DIRECT_API_FETCH_PHASE_CONCURRENCY,
-  DIRECT_API_PROVIDER_TIMEOUT_MS,
-} from "../direct-api-policy";
+import { DIRECT_API_FETCH_PHASE_CONCURRENCY, DIRECT_API_PROVIDER_TIMEOUT_MS } from "../direct-api-policy";
 import { toErrorMessage } from "../../../lib/error-utils";
 import { mapWithConcurrency } from "../../../lib/concurrency";
 
@@ -106,12 +102,8 @@ function hasTrackedDirectApiToken(
 ): boolean {
   return pool.tokens.some(
     (token) =>
-      resolveStablecoinIdForDexApiToken(
-        pool.chain,
-        token,
-        lookups.chainAddressToId,
-        lookups.symbolToChainScopedIds,
-      ) != null,
+      resolveStablecoinIdForDexApiToken(pool.chain, token, lookups.chainAddressToId, lookups.symbolToChainScopedIds) !=
+      null,
   );
 }
 
@@ -329,58 +321,80 @@ export async function runDirectApiFetchPhase(
     db,
     signal,
   });
-  const entries = await mapWithConcurrency(fetchers, DIRECT_API_FETCH_PHASE_CONCURRENCY, async ({
-    name,
-    circuitKey,
-    normalizedProtocol,
-    supportedChains,
-    fn,
-  }) => {
-    const failedSources: string[] = [];
-    const fallbackSignals: string[] = [];
-    const sourceWarnings: string[] = [];
-    const circuitEvents: DirectApiCircuitEvent[] = [];
+  const entries = await mapWithConcurrency(
+    fetchers,
+    DIRECT_API_FETCH_PHASE_CONCURRENCY,
+    async ({ name, circuitKey, normalizedProtocol, supportedChains, fn }) => {
+      const failedSources: string[] = [];
+      const fallbackSignals: string[] = [];
+      const sourceWarnings: string[] = [];
+      const circuitEvents: DirectApiCircuitEvent[] = [];
 
-    try {
-      const execution = await withProviderExecution(
-        providerContext,
-        buildDirectApiProviderPolicy(name, circuitKey),
-        ({ signal: providerSignal }) => fn(providerSignal),
-      );
-      const result = execution.value;
-      const event = directApiCircuitEventFromOutcome(circuitKey, execution.circuitOutcome);
-      if (event) circuitEvents.push(event);
-      sourceWarnings.push(...(result.warnings ?? []).map((warning) => `${circuitKey}: ${warning}`));
-      if (result.degraded) {
-        sourceWarnings.push(...result.errors.map((error) => `${circuitKey}: ${error}`));
-      }
-      if (!result.ok) {
+      try {
+        const execution = await withProviderExecution(
+          providerContext,
+          buildDirectApiProviderPolicy(name, circuitKey),
+          ({ signal: providerSignal }) => fn(providerSignal),
+        );
+        const result = execution.value;
+        const event = directApiCircuitEventFromOutcome(circuitKey, execution.circuitOutcome);
+        if (event) circuitEvents.push(event);
+        sourceWarnings.push(...(result.warnings ?? []).map((warning) => `${circuitKey}: ${warning}`));
+        if (result.degraded) {
+          sourceWarnings.push(...result.errors.map((error) => `${circuitKey}: ${error}`));
+        }
+        if (!result.ok) {
+          failedSources.push(circuitKey);
+        }
+        if (!result.ok) {
+          fallbackSignals.push(`${circuitKey}-unavailable`);
+        } else if (result.degraded) {
+          fallbackSignals.push(`${circuitKey}-partial`);
+        }
+        const entry: DirectApiFetchPhaseEntry = {
+          name,
+          circuitKey,
+          normalizedProtocol,
+          supportedChains,
+          result,
+        };
+        return {
+          failedSources,
+          fallbackSignals,
+          sourceWarnings,
+          circuitEvents,
+          entry: lookups ? compactDirectApiProviderEntry(entry, lookups) : entry,
+        };
+      } catch (err) {
+        if (err instanceof ProviderCircuitOpenError) {
+          console.log(`[dex-liquidity] ${name} API circuit open, skipping`);
+          failedSources.push(circuitKey);
+          fallbackSignals.push(`${circuitKey}-circuit-open`);
+          return {
+            failedSources,
+            fallbackSignals,
+            sourceWarnings,
+            circuitEvents,
+            entry: {
+              name,
+              circuitKey,
+              normalizedProtocol,
+              supportedChains,
+              result: makeDexApiFetchResult([], {
+                ok: false,
+                degraded: true,
+                errors: ["circuit open"],
+              }),
+            },
+          };
+        }
+        if (signal?.aborted) throw err;
+        console.warn(`[dex-liquidity] ${name} API failed (non-fatal):`, err);
+        const executionError = err instanceof ProviderExecutionError ? err : null;
+        const event = directApiCircuitEventFromOutcome(circuitKey, executionError?.circuitOutcome ?? null);
+        if (event) circuitEvents.push(event);
         failedSources.push(circuitKey);
-      }
-      if (!result.ok) {
-        fallbackSignals.push(`${circuitKey}-unavailable`);
-      } else if (result.degraded) {
-        fallbackSignals.push(`${circuitKey}-partial`);
-      }
-      const entry: DirectApiFetchPhaseEntry = {
-        name,
-        circuitKey,
-        normalizedProtocol,
-        supportedChains,
-        result,
-      };
-      return {
-        failedSources,
-        fallbackSignals,
-        sourceWarnings,
-        circuitEvents,
-        entry: lookups ? compactDirectApiProviderEntry(entry, lookups) : entry,
-      };
-    } catch (err) {
-      if (err instanceof ProviderCircuitOpenError) {
-        console.log(`[dex-liquidity] ${name} API circuit open, skipping`);
-        failedSources.push(circuitKey);
-        fallbackSignals.push(`${circuitKey}-circuit-open`);
+        fallbackSignals.push(`${circuitKey}-exception`);
         return {
           failedSources,
           fallbackSignals,
@@ -394,37 +408,13 @@ export async function runDirectApiFetchPhase(
             result: makeDexApiFetchResult([], {
               ok: false,
               degraded: true,
-              errors: ["circuit open"],
+              errors: [toErrorMessage(err)],
             }),
           },
         };
       }
-      if (signal?.aborted) throw err;
-      console.warn(`[dex-liquidity] ${name} API failed (non-fatal):`, err);
-      const executionError = err instanceof ProviderExecutionError ? err : null;
-      const event = directApiCircuitEventFromOutcome(circuitKey, executionError?.circuitOutcome ?? null);
-      if (event) circuitEvents.push(event);
-      failedSources.push(circuitKey);
-      fallbackSignals.push(`${circuitKey}-exception`);
-      return {
-        failedSources,
-        fallbackSignals,
-        sourceWarnings,
-        circuitEvents,
-        entry: {
-          name,
-          circuitKey,
-          normalizedProtocol,
-          supportedChains,
-          result: makeDexApiFetchResult([], {
-            ok: false,
-            degraded: true,
-            errors: [toErrorMessage(err)],
-          }),
-        },
-      };
-    }
-  });
+    },
+  );
 
   return {
     results: entries.map((entry) => entry.entry),
@@ -435,10 +425,7 @@ export async function runDirectApiFetchPhase(
   };
 }
 
-function buildDirectApiProviderPolicy(
-  name: string,
-  circuitKey: string,
-): ProviderExecutionPolicy<DexApiFetchResult> {
+function buildDirectApiProviderPolicy(name: string, circuitKey: string): ProviderExecutionPolicy<DexApiFetchResult> {
   return {
     providerId: `dex-direct-api:${name.toLowerCase().replaceAll(/\s+/g, "-")}`,
     maxConcurrent: 1,
@@ -446,7 +433,7 @@ function buildDirectApiProviderPolicy(
     breakerPolicy: { circuitKey },
     countsAgainstLaneBudget: true,
     responseBodyPolicy: "stream",
-    classifyOutcome: (result) => result.ok ? "success" : "failure",
+    classifyOutcome: (result) => (result.ok ? "success" : "failure"),
   };
 }
 
@@ -462,7 +449,7 @@ function directApiCircuitEventFromOutcome(
     circuitKey,
     from: before.state,
     to: after.state,
-    at: after.state === "closed" ? after.lastSuccessAt : after.openedAt ?? after.lastFailureAt,
+    at: after.state === "closed" ? after.lastSuccessAt : (after.openedAt ?? after.lastFailureAt),
   };
 }
 
@@ -484,9 +471,7 @@ export async function integrateDirectApiLiquidityPhase(params: {
     params.preprocessedPoolCounts &&
     params.preprocessedPoolCounts.retainedPoolCount !== params.directApiPools.length
   ) {
-    throw new Error(
-      "dex-liquidity: compacted direct API retained count does not match the integration input",
-    );
+    throw new Error("dex-liquidity: compacted direct API retained count does not match the integration input");
   }
 
   let directApiDedupSkippedByAddress = 0;
@@ -644,10 +629,9 @@ export async function integrateDirectApiLiquidityPhase(params: {
     );
   }
 
-  const directApiPoolsForContribution = [...retainedDirectApiPools, ...exactDuplicatePoolsForEvidence];
-  if (directApiPoolsForContribution.length > 0) {
+  if (retainedDirectApiPools.length > 0) {
     const directApiGtPools = convertToGtNewPools(
-      directApiPoolsForContribution,
+      retainedDirectApiPools,
       params.chainAddressToId,
       params.symbolToChainScopedIds,
       params.validationReferences,
@@ -656,9 +640,23 @@ export async function integrateDirectApiLiquidityPhase(params: {
     if (directApiGtPools.size > 0) {
       await mergeGtPools(params.metrics, directApiGtPools, params.db);
     }
+  }
 
+  if (exactDuplicatePoolsForEvidence.length > 0) {
+    const exactDuplicateGtPools = convertToGtNewPools(
+      exactDuplicatePoolsForEvidence,
+      params.chainAddressToId,
+      params.symbolToChainScopedIds,
+      params.validationReferences,
+      params.stablecoinPriceById,
+    );
+    retainExactDuplicatePoolEvidence(params.metrics, exactDuplicateGtPools);
+  }
+
+  const directApiPoolsForPriceObservation = [...retainedDirectApiPools, ...exactDuplicatePoolsForEvidence];
+  if (directApiPoolsForPriceObservation.length > 0) {
     const directApiPriceObs = extractPriceObservations(
-      directApiPoolsForContribution,
+      directApiPoolsForPriceObservation,
       params.chainAddressToId,
       params.symbolToChainScopedIds,
       params.validationReferences,
@@ -678,6 +676,54 @@ export async function integrateDirectApiLiquidityPhase(params: {
     acceptedByProtocolChain,
     excludedByReason,
   };
+}
+
+function retainExactDuplicatePoolEvidence(
+  metrics: Map<string, LiquidityMetrics>,
+  exactDuplicateGtPools: Map<string, GtNewPool[]>,
+): void {
+  for (const [stablecoinId, pools] of exactDuplicateGtPools) {
+    const metric = metrics.get(stablecoinId);
+    if (!metric) continue;
+
+    for (const pool of pools) {
+      const existingPool = metric.topPools.find(
+        (candidate) => candidate.poolId === canonicalExitRouteAssetKey(pool.chain, pool.address),
+      );
+      if (!existingPool || !isCompatibleExactDuplicateEvidence(existingPool, pool)) continue;
+
+      const existingExtra = existingPool.extra ?? {};
+      if (pool.ammExecutionModel && !existingExtra.ammExecutionModel && !existingExtra.executionCapabilityGate) {
+        existingPool.extra = {
+          ...existingExtra,
+          ammExecutionModel: pool.ammExecutionModel,
+        };
+      } else if (
+        pool.executionCapabilityGate &&
+        !existingExtra.ammExecutionModel &&
+        !existingExtra.executionCapabilityGate
+      ) {
+        existingPool.extra = {
+          ...existingExtra,
+          executionCapabilityGate: pool.executionCapabilityGate,
+        };
+      }
+    }
+  }
+}
+
+function isCompatibleExactDuplicateEvidence(existingPool: PoolEntry, incomingPool: GtNewPool): boolean {
+  if (normalizeProtocol(existingPool.project) !== normalizeProtocol(incomingPool.dexId)) return false;
+  return poolSymbolSet(existingPool.symbol) === poolSymbolSet(incomingPool.symbol);
+}
+
+function poolSymbolSet(symbol: string): string {
+  return symbol
+    .split(/\s*\/\s*/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean)
+    .sort()
+    .join("/");
 }
 
 function incrementReason(record: Record<string, number>, reason: string, count = 1): void {


### PR DESCRIPTION
### Motivation
- Exact-identity direct-API pools were being pushed back through the normal GT contribution pipeline and could create new TVL/pool-count contributions when a matching primary top-pool row did not actually exist in `metrics`.
- Blindly accepting AMM execution models from direct-API duplicates could overwrite trusted primary evidence without validating protocol/source/token compatibility, exposing the system to poisoned provider responses.

### Description
- Stop sending exact-identity duplicate direct-API rows through the normal contribution merge path by keeping `retainedDirectApiPools` and `exactDuplicatePoolsForEvidence` separate and only converting/merging `retainedDirectApiPools` with `convertToGtNewPools()`/`mergeGtPools()`.
- Add `retainExactDuplicatePoolEvidence()` which: locates an already-counted `topPools` row, validates protocol (via `normalizeProtocol`) and token symbol-set compatibility, and attaches only missing execution evidence (`ammExecutionModel` or `executionCapabilityGate`) without overwriting existing evidence.
- Keep duplicates available for price observations but ensure they are evidence-only for metrics contribution by using `directApiPoolsForPriceObservation = [...retainedDirectApiPools, ...exactDuplicatePoolsForEvidence]` while handling contribution separately.
- Update imports/types and add two regression tests in `worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-direct-api.test.ts` that assert (1) exact duplicates do not create `metrics` when no primary top-pool row exists and (2) incompatible retained primary evidence is not overwritten by duplicate direct-API data.

### Testing
- Ran targeted unit tests: `npx vitest run worker/src/cron/dex-liquidity/__tests__/orchestrator-phases-direct-api.test.ts worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts`, and all tests passed (65 tests across suites).
- Verified TypeScript build with `cd worker && npx tsc --noEmit`, which succeeded with no errors.
- Ran lint/format checks (`prettier` + `eslint`) on the modified files and they completed with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceac634833299e10140d68275a9)