### PR TITLE
Fix redemption exit-route timestamp normalization

### DIFF
--- a/worker/src/lib/__tests__/redemption-exit-route-observations.test.ts
+++ b/worker/src/lib/__tests__/redemption-exit-route-observations.test.ts
@@ -99,6 +99,25 @@ describe("redemption same-notional route observations", () => {
     });
   });
 
+  it("normalizes fractional live telemetry timestamps before publishing integer observations", () => {
+    const observedAt = Date.UTC(2026, 6, 13, 10) / 1_000;
+    const observation = build({
+      sourceMode: "dynamic",
+      capacityConfidence: "live-direct",
+      capacityKind: "live-direct-bounded",
+      freshnessKind: "verified-source-timestamp",
+      sourceTimestamp: observedAt + 0.75,
+      now: observedAt + 61.25,
+    });
+    expect(observation).toMatchObject({
+      evidenceKind: "live-reserve-state",
+      confidence: "high",
+      observedAt,
+      freshnessSeconds: 61,
+      scoreEligible: true,
+    });
+  });
+
   it("returns no observation when the immediate capacity request is undefined", () => {
     expect(build({ capacityProfile: undefined })).toBeNull();
     expect(build({ scoringCapacityUsd: null })).toBeNull();

--- a/worker/src/lib/redemption-exit-route-observations.ts
+++ b/worker/src/lib/redemption-exit-route-observations.ts
@@ -40,6 +40,11 @@ interface BuildRedemptionExitRouteObservationInput {
   now: number;
 }
 
+function floorTimestampSec(timestamp: number | undefined): number | null {
+  if (timestamp == null || !Number.isFinite(timestamp) || timestamp < 0) return null;
+  return Math.floor(timestamp);
+}
+
 function reviewedAtSec(reviewedAt: string | undefined): number | null {
   if (!reviewedAt) return null;
   const timestamp = Date.parse(`${reviewedAt}T00:00:00.000Z`);
@@ -61,7 +66,7 @@ function resolveRouteEvidence(input: BuildRedemptionExitRouteObservationInput): 
     return {
       evidenceKind: input.freshnessKind === "same-run-onchain" ? "onchain-contract-state" : "live-reserve-state",
       confidence: "high",
-      observedAt: input.sourceTimestamp ?? input.now,
+      observedAt: floorTimestampSec(input.sourceTimestamp) ?? floorTimestampSec(input.now) ?? 0,
       supportsScoring: true,
     };
   }
@@ -80,7 +85,7 @@ function resolveRouteEvidence(input: BuildRedemptionExitRouteObservationInput): 
   return {
     evidenceKind: hasReviewedTerms ? "documented-terms" : "manual-review",
     confidence: input.capacityConfidence === "heuristic" ? "low" : "unknown",
-    observedAt: reviewTimestamp ?? input.sourceTimestamp ?? input.now,
+    observedAt: reviewTimestamp ?? floorTimestampSec(input.sourceTimestamp) ?? floorTimestampSec(input.now) ?? 0,
     supportsScoring: false,
   };
 }
@@ -220,7 +225,7 @@ export function buildRedemptionExitRouteObservation(
     confidence: evidence.confidence,
     scoreEligible,
     observedAt: evidence.observedAt,
-    freshnessSeconds: Math.max(0, input.now - evidence.observedAt),
+    freshnessSeconds: Math.max(0, (floorTimestampSec(input.now) ?? 0) - evidence.observedAt),
     commonModeKeys,
     capacityCurve,
   };
@@ -310,7 +315,7 @@ export function deriveSupplyModelExitRouteObservation(
     confidence: "medium",
     scoreEligible: routeFamily !== "eventual-redemption" && withinCost,
     observedAt: reviewTimestamp,
-    freshnessSeconds: Math.max(0, now - reviewTimestamp),
+    freshnessSeconds: Math.max(0, (floorTimestampSec(now) ?? 0) - reviewTimestamp),
     commonModeKeys,
     capacityCurve,
   };


### PR DESCRIPTION
### Motivation
- Provider-supplied `sourceTimestamp` could be fractional and was copied directly into `observedAt` and used to compute `freshnessSeconds`, which violates the integer-only `ExitRouteObservationSchema` and can abort redemption snapshot writes.
- Normalize telemetry timestamps to prevent malformed upstream values from breaking snapshot serialization while preserving existing observation semantics.

### Description
- Add `floorTimestampSec()` to normalize/validate provider timestamps to integer seconds and return `null` for invalid inputs.
- Use `floorTimestampSec()` when assigning `observedAt` for live/direct and fallback evidence paths so published observations are integer seconds.
- Compute `freshnessSeconds` from the normalized integer `now` minus `observedAt` in both `buildRedemptionExitRouteObservation` and `deriveSupplyModelExitRouteObservation` to ensure integer freshness values.
- Add a focused unit test that supplies fractional `sourceTimestamp`/`now` values and verifies published `observedAt` and `freshnessSeconds` are integers.

### Testing
- Ran the focused Vitest suite `npx vitest run worker/src/lib/__tests__/redemption-exit-route-observations.test.ts`, all tests passed (11 tests).
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, which succeeded.
- Verified the repository change contract check with `node scripts/ci/pharos-change-contract.mjs --markdown --staged`, which reported the changed files and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceacc308332934c79f9814fe0db)