### PR TITLE
Fix legacy liquidity scoring shadow supply leak

### DIFF
--- a/shared/lib/__tests__/report-card-peg-liquidity.test.ts
+++ b/shared/lib/__tests__/report-card-peg-liquidity.test.ts
@@ -479,6 +479,43 @@ describe("scoreLiquidity", () => {
     expect(result.score).toBe(53);
   });
 
+  it("keeps deployment supply coverage out of legacy redemption capacity scoring", () => {
+    const result = scoreLiquidity(
+      {
+        ...dexLiquidity(10),
+        deploymentSupplyCoverage: {
+          totalSupplyUsd: 100_000_000,
+          observedSupplyUsd: 100_000_000,
+          verifiedNoPoolsSupplyUsd: 0,
+          providerInaccessibleSupplyUsd: 0,
+          unknownSupplyUsd: 0,
+          observedSupplyRatio: 1,
+          verifiedNoPoolsSupplyRatio: 0,
+          providerInaccessibleSupplyRatio: 0,
+          unknownSupplyRatio: 0,
+          unknownChains: [],
+        },
+      },
+      {
+        score: 100,
+        routeFamily: "stablecoin-redeem",
+        immediateCapacityUsd: 1_000_000,
+        immediateCapacityRatio: 0.01,
+        resolutionState: "resolved",
+        modelConfidence: "high",
+        capacitySemantics: "immediate-bounded",
+        capacityProfile: {
+          scoringUsd: 1_000_000,
+          scoringHorizon: "immediate",
+          capacityProfileConfidence: "live-direct",
+        },
+      },
+    );
+
+    expect(result.score).toBe(100);
+    expect(result.detail).toContain("Redemption backstop 100/100");
+  });
+
   it("keeps supply-weighted deployment materiality behind explicit activation", () => {
     const liq: DexLiquidityInput = {
       ...dexLiquidity(95),

--- a/shared/lib/report-card-peg-liquidity.ts
+++ b/shared/lib/report-card-peg-liquidity.ts
@@ -309,12 +309,15 @@ function buildLiquidityScoringFacts(
   const eligibleRedemptionScore = redemptionEligibleForLiquidity
     ? getSafetyEligibleRedemptionScore(redemption, dexScore)
     : null;
+  const exitScoringCirculatingSupplyUsd =
+    options?.circulatingSupplyUsd ??
+    (options?.sameNotionalScoringMode === "active" ? liq?.deploymentSupplyCoverage?.totalSupplyUsd : undefined);
   const exitScoreDiagnostics = computeEffectiveExitScoreDiagnostics(
     dexScore,
     eligibleRedemptionScore,
     redemption
       ? {
-          circulatingSupplyUsd: options?.circulatingSupplyUsd ?? liq?.deploymentSupplyCoverage?.totalSupplyUsd,
+          circulatingSupplyUsd: exitScoringCirculatingSupplyUsd,
           modeledExitSizeUsd: redemption.capacityProfile?.modeledExitSizeUsd,
           currentExecutableCapacityUsd: redemption.capacityProfile?.scoringUsd ?? redemption.immediateCapacityUsd,
           routeExitCorrelation: redemption.routeExitCorrelation,
@@ -331,7 +334,7 @@ function buildLiquidityScoringFacts(
           impairedOutputAssetIds: options?.impairedOutputAssetIds,
         }
       : {
-          circulatingSupplyUsd: options?.circulatingSupplyUsd ?? liq?.deploymentSupplyCoverage?.totalSupplyUsd,
+          circulatingSupplyUsd: exitScoringCirculatingSupplyUsd,
           dexExitRouteObservations: liq?.exitRouteObservations,
           dexExitRouteCoverageComplete: isDexExitRouteCoverageComplete(liq?.exitRouteObservationCoverage),
           dexExitRouteCoverageStatus: liq?.exitRouteObservationCoverage?.status,


### PR DESCRIPTION
### Motivation
- A recent change attached DEX `deploymentSupplyCoverage.totalSupplyUsd` into exit scoring unconditionally, which allowed externally-sourced chain supply to affect legacy redemption capacity scoring and could materially reduce live Safety Scores.
- The intent is to keep the new deployment-supply materiality logic behind the explicit same-notional activation so legacy callers and payloads remain unchanged.

### Description
- Gate the implicit fallback so `deploymentSupplyCoverage.totalSupplyUsd` is only used as `circulatingSupplyUsd` when `sameNotionalScoringMode === "active"`, otherwise leave it undefined and preserve legacy behavior in `computeEffectiveExitScoreDiagnostics` (change in `shared/lib/report-card-peg-liquidity.ts`).
- Add a regression test that attaches `deploymentSupplyCoverage` to a DEX row and verifies `scoreLiquidity` still returns the original 100/100 redemption backstop in the legacy path (new test in `shared/lib/__tests__/report-card-peg-liquidity.test.ts`).
- Adjusted the test redemption payload to match the `capacityProfile` schema (`scoringHorizon` / `capacityProfileConfidence`) while keeping the test focused on legacy scoring invariants.

### Testing
- Ran focused unit tests `vitest` for the touched suites with `npm test -- shared/lib/__tests__/report-card-peg-liquidity.test.ts shared/lib/__tests__/redemption-backstop-scoring.test.ts`, and all tests passed (`104 passed`).
- Ran repo checks and typechecks with `npm run check:worker-boundary`, `npm run check:shared-cycles`, `npm run typecheck`, and `cd worker && npx tsc --noEmit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ce9f6648332a5d3bf187d34627e)