### PR TITLE
fix(dex): cap exit route observation payloads

### DIFF
--- a/shared/types/exit-route.ts
+++ b/shared/types/exit-route.ts
@@ -95,6 +95,9 @@ export const ExitRouteCapacityPointSchema = z.object({
 });
 export type ExitRouteCapacityPoint = z.infer<typeof ExitRouteCapacityPointSchema>;
 
+export const MAX_EXIT_ROUTE_COMMON_MODE_KEYS = 16;
+export const MAX_DEX_EXIT_ROUTE_OBSERVATIONS = 10;
+
 const ExitRouteObservationBaseSchema = z.object({
   routeId: z.string().min(1),
   routeFamily: ExitRouteFamilySchema,
@@ -110,7 +113,7 @@ const ExitRouteObservationBaseSchema = z.object({
   scoreEligible: z.boolean(),
   observedAt: z.number().int().nonnegative(),
   freshnessSeconds: z.number().int().nonnegative(),
-  commonModeKeys: z.array(z.string().min(1)),
+  commonModeKeys: z.array(z.string().min(1)).max(MAX_EXIT_ROUTE_COMMON_MODE_KEYS),
   capacityCurve: z.array(ExitRouteCapacityPointSchema).min(1).max(16).optional(),
 });
 

--- a/shared/types/market.ts
+++ b/shared/types/market.ts
@@ -34,6 +34,8 @@ export {
   ExitRouteOutputKindSchema,
   ExitRouteOutputSchema,
   ExitRouteScopeSchema,
+  MAX_DEX_EXIT_ROUTE_OBSERVATIONS,
+  MAX_EXIT_ROUTE_COMMON_MODE_KEYS,
   type DexExitEvidenceKind,
   type DexExitRouteObservation,
   type ExitRouteCapacityPoint,

--- a/worker/src/api/__tests__/p4-route-response.test.ts
+++ b/worker/src/api/__tests__/p4-route-response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MAX_DEX_EXIT_ROUTE_OBSERVATIONS } from "@shared/types/market";
 import { normalizeDexScoreDetails } from "../dex-liquidity-response";
 
 describe("P4 route observation API compatibility", () => {
@@ -83,6 +84,46 @@ describe("P4 route observation API compatibility", () => {
     );
 
     expect(result.scoreComponents).toBeNull();
+    expect(result.exitRouteObservations).toBeNull();
+    expect(result.exitRouteObservationCoverage.status).toBe("unknown");
+  });
+  it("quarantines oversized observation envelopes", () => {
+    const observation = {
+      routeId: "dex:usdc:cg-tickers:coinbase",
+      routeFamily: "dex-orderbook" as const,
+      scope: { kind: "venue" as const, venue: "coinbase", protocol: "coinbase" },
+      requestedNotionalUsd: 1_000_000,
+      settlementHorizonSec: 300,
+      maxCostBps: 200,
+      executableUsd: 500_000,
+      completionRatio: 0.5,
+      output: { kind: "fiat" as const, currency: "USD" },
+      evidenceKind: "direct-orderbook-depth" as const,
+      confidence: "medium" as const,
+      scoreEligible: false,
+      observedAt: 1_720_000_000,
+      freshnessSeconds: 0,
+      commonModeKeys: ["protocol:coinbase", "fiat:usd"],
+      capacityCurve: [
+        {
+          requestedNotionalUsd: 1_000_000,
+          maxCostBps: 200,
+          executableUsd: 500_000,
+          completionRatio: 0.5,
+        },
+      ],
+    };
+
+    const result = normalizeDexScoreDetails(
+      JSON.stringify({
+        tvlDepth: 10,
+        exitRouteObservations: Array.from({ length: MAX_DEX_EXIT_ROUTE_OBSERVATIONS + 1 }, (_, index) => ({
+          ...observation,
+          routeId: `${observation.routeId}:${index}`,
+        })),
+      }),
+    );
+
     expect(result.exitRouteObservations).toBeNull();
     expect(result.exitRouteObservationCoverage.status).toBe("unknown");
   });

--- a/worker/src/api/dex-liquidity-history.ts
+++ b/worker/src/api/dex-liquidity-history.ts
@@ -3,7 +3,11 @@ import { CACHE_PROFILES } from "../lib/constants";
 import { getLiquidityMethodologyVersionAt } from "@shared/lib/liquidity-score-version";
 import { classifyLiquidityEvidence } from "./dex-liquidity-evidence";
 import { safeJsonParse } from "../lib/api-utils";
-import { ExitRouteObservationCoverageSchema, ExitRouteObservationSchema } from "@shared/types/market";
+import {
+  ExitRouteObservationCoverageSchema,
+  ExitRouteObservationSchema,
+  MAX_DEX_EXIT_ROUTE_OBSERVATIONS,
+} from "@shared/types/market";
 
 interface LiquidityHistoryRow {
   total_tvl_usd: number;
@@ -20,7 +24,9 @@ function parseRouteSummary(json: string | null) {
   const raw = safeJsonParse<unknown>(json, null, "dex-liquidity-history:exit_route_summary_json");
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
   const summary = raw as Record<string, unknown>;
-  const observations = ExitRouteObservationSchema.array().safeParse(summary.observations);
+  const observations = ExitRouteObservationSchema.array()
+    .max(MAX_DEX_EXIT_ROUTE_OBSERVATIONS)
+    .safeParse(summary.observations);
   const coverage = ExitRouteObservationCoverageSchema.safeParse(summary.coverage);
   return {
     ...(observations.success ? { exitRouteObservations: observations.data } : {}),

--- a/worker/src/api/dex-liquidity-response.ts
+++ b/worker/src/api/dex-liquidity-response.ts
@@ -3,6 +3,7 @@ import { DexLiquidityCronMetadataSchema } from "../lib/schemas";
 import {
   ExitRouteObservationCoverageSchema,
   ExitRouteObservationSchema,
+  MAX_DEX_EXIT_ROUTE_OBSERVATIONS,
   type ExitRouteObservation,
   type ExitRouteObservationCoverage,
   type LiquidityPoolSourceFamily,
@@ -123,7 +124,9 @@ export function normalizeDexScoreDetails(
   }
 
   const details = parsed as Record<string, unknown>;
-  const observations = ExitRouteObservationSchema.array().safeParse(details.exitRouteObservations);
+  const observations = ExitRouteObservationSchema.array()
+    .max(MAX_DEX_EXIT_ROUTE_OBSERVATIONS)
+    .safeParse(details.exitRouteObservations);
   const coverage = ExitRouteObservationCoverageSchema.safeParse(details.exitRouteObservationCoverage);
   return {
     scoreComponents: projectLegacyScoreComponents(details),

--- a/worker/src/cron/dex-liquidity/scoring.ts
+++ b/worker/src/cron/dex-liquidity/scoring.ts
@@ -1,6 +1,7 @@
 import { ACTIVE_IDS, ACTIVE_STABLECOINS, TRACKED_META_BY_ID } from "@shared/lib/stablecoins/registry";
 import { roundTo } from "@shared/lib/math";
 import { buildP4DexExitRouteObservations } from "@shared/lib/p4-exit-route-capacity";
+import { MAX_DEX_EXIT_ROUTE_OBSERVATIONS } from "@shared/types/market";
 import type { ExitRouteObservation, ExitRouteObservationCoverage } from "@shared/types/market";
 import { rethrowIfAborted, throwIfAborted } from "../../lib/abort";
 import { batchExecute, executeAtomicBatch } from "../../lib/db";
@@ -396,9 +397,13 @@ export async function computeStablecoinScores(
     throwIfAborted(signal);
     const retainedPools = preparedRetainedPools.get(id) ?? [];
     const rebuilt = rebuildMetricsFromPools(retainedPools);
+    const routeObservationPools = [...rebuilt.visiblePools, ...(p4OnlyRetainedPools.get(id) ?? [])].slice(
+      0,
+      MAX_DEX_EXIT_ROUTE_OBSERVATIONS,
+    );
     const routeObservationResult = buildP4DexExitRouteObservations({
       stablecoinId: id,
-      retainedPools: [...retainedPools, ...(p4OnlyRetainedPools.get(id) ?? [])],
+      retainedPools: routeObservationPools,
       observedAt: routeObservedAt,
     });
     stripDexMeasuredExecutionInternalFields(retainedPools);

--- a/worker/src/lib/dex-liquidity.ts
+++ b/worker/src/lib/dex-liquidity.ts
@@ -1,5 +1,6 @@
 import {
   DexExitRouteObservationSchema,
+  MAX_DEX_EXIT_ROUTE_OBSERVATIONS,
   ExitRouteObservationCoverageSchema,
   type DexLiquidityData,
   type LiquidityCoverageClass,
@@ -107,7 +108,9 @@ function parseExitRouteDetails(
   const observations =
     raw.exitRouteObservations === undefined
       ? null
-      : DexExitRouteObservationSchema.array().safeParse(raw.exitRouteObservations);
+      : DexExitRouteObservationSchema.array()
+          .max(MAX_DEX_EXIT_ROUTE_OBSERVATIONS)
+          .safeParse(raw.exitRouteObservations);
   const coverage =
     raw.exitRouteObservationCoverage === undefined
       ? null


### PR DESCRIPTION
### Motivation
- Prevent unbounded `exitRouteObservations` from retained provider pools from bloating persisted `score_components_json` or causing OOM/cpu issues on API parse.  
- Ensure the P4a route-observation producer respects the same visible-top-pool budget used for persisted metrics so poisoned/large upstream responses cannot expand public payloads.

### Description
- Add shared caps: `MAX_DEX_EXIT_ROUTE_OBSERVATIONS` and `MAX_EXIT_ROUTE_COMMON_MODE_KEYS` in `shared/types/exit-route.ts` and re-export them via `shared/types/market.ts`.  
- Limit `commonModeKeys` length via the added `MAX_EXIT_ROUTE_COMMON_MODE_KEYS` constraint.  
- Produce route observations from the bounded visible pool set (plus the P4-only paused set) and slice to `MAX_DEX_EXIT_ROUTE_OBSERVATIONS` before calling `buildP4DexExitRouteObservations` in `worker/src/cron/dex-liquidity/scoring.ts`.  
- Apply the observation-array cap when parsing persisted/current/history envelopes so oversized arrays are quarantined: `worker/src/api/dex-liquidity-response.ts`, `worker/src/api/dex-liquidity-history.ts`, and `worker/src/lib/dex-liquidity.ts`.  
- Add a focused API compatibility test that verifies oversized observation envelopes are rejected (`worker/src/api/__tests__/p4-route-response.test.ts`).

### Testing
- Ran Worker typecheck with `cd worker && npx tsc --noEmit`, which passed.  
- Ran unit suites: `npm exec vitest -- worker/src/api/__tests__/p4-route-response.test.ts worker/src/cron/dex-liquidity/__tests__/p4-route-persistence.test.ts shared/lib/__tests__/p4-exit-route-capacity.test.ts`, all tests passed.  
- Ran boundary and cycle checks `npm run check:worker-boundary` and `npm run check:shared-cycles`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea2bcc8332b34d4ec3b37d095b)