### PR TITLE
fix(ci): scope maintenance API key to queue generation

### DIFF
--- a/.github/workflows/agent-maintenance-candidates.yml
+++ b/.github/workflows/agent-maintenance-candidates.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      PHAROS_API_KEY: ${{ secrets.PHAROS_API_KEY }}
       PHAROS_WORKER_BASE_URL: https://api.pharos.watch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -25,6 +24,8 @@ jobs:
           tooling-cache: "true"
       - name: Generate review queues
         id: generate
+        env:
+          PHAROS_API_KEY: ${{ secrets.PHAROS_API_KEY }}
         shell: bash
         run: |
           set +e


### PR DESCRIPTION
### Motivation
- Prevent the production `PHAROS_API_KEY` secret from being inherited by early job steps (checkout, shared setup, and `npm ci`) to eliminate a supply-chain exfiltration risk. This is a minimal scoping fix to reduce blast radius while keeping scheduled maintenance behavior unchanged.

### Description
- Remove `PHAROS_API_KEY` from the job-level `env` and add it to the `Generate review queues` step only in `.github/workflows/agent-maintenance-candidates.yml`, preserving `PHAROS_WORKER_BASE_URL` and existing queue-generation commands.

### Testing
- Validated the workflow YAML programmatically with a small Ruby YAML check to assert the job no longer contains `PHAROS_API_KEY` and the `Generate review queues` step does; the check passed.
- Ran `node scripts/ci/pharos-change-contract.mjs --markdown` and `git diff --check` to ensure no contract or formatting issues; both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceaad888332b268447bb3628c4f)