### PR TITLE
fix(telegram): rate-limit inline status cards

### DIFF
--- a/worker/src/api/__tests__/telegram-inline-queries.test.ts
+++ b/worker/src/api/__tests__/telegram-inline-queries.test.ts
@@ -33,6 +33,10 @@ function makeChosenInlineResultRequest(): Request {
   );
 }
 
+function inlineReadLimitRows() {
+  return [{ match: "INSERT INTO cache", rows: [{ value: "1" }] }];
+}
+
 function inlineAnswerBody(): {
   inline_query_id: string;
   results: Array<{
@@ -59,6 +63,7 @@ describe("Telegram inline status cards", () => {
 
   it("serves one source-attributed status card through the existing status loader", async () => {
     const db = mockD1([
+      ...inlineReadLimitRows(),
       { match: "FROM price_cache WHERE asset_id = ?", rows: [{ price: 0.9997, updated_at: 1_700_000_000 }] },
       { match: "FROM safety_grade_history", rows: [{ grade: "A", score: 88, recorded_at: 1_700_000_000 }] },
       { match: "FROM stress_signals", rows: [{ band: "CALM", score: 5, computed_at: 1_700_000_000 }] },
@@ -120,6 +125,36 @@ describe("Telegram inline status cards", () => {
     if (query) expect(usageRow?.binds).not.toContain(query);
   });
 
+  it("rate-limits repeated equivalent status card reads before loading status rows", async () => {
+    const db = mockD1([
+      { match: "INSERT INTO cache", rows: [{ value: "1" }], runMeta: { changes: 0 } },
+      {
+        match: "SELECT updated_at FROM cache WHERE key = ?",
+        rows: [
+          {
+            key: "telegram:command-cooldown:inline:123456:/status:usdc-circle",
+            updated_at: Math.floor(Date.now() / 1000),
+          },
+        ],
+      },
+      { match: "FROM price_cache WHERE asset_id = ?", rows: [{ price: 1, updated_at: 1_700_000_000 }] },
+    ]);
+
+    const response = await handleTelegramWebhook(db, makeInlineQueryRequest("  usdc  "), "test-secret", "bot-token");
+
+    expect(response.status).toBe(200);
+    expect(inlineAnswerBody()).toMatchObject({
+      results: [],
+      cache_time: TELEGRAM_INLINE_STATUS_POLICY.emptyResultCacheTimeSec,
+    });
+    expect(db.getHistory().some((entry) => entry.sql.includes("FROM price_cache"))).toBe(false);
+    const usageRow = db.getHistory().find((entry) => entry.sql.includes("INSERT INTO telegram_usage_daily"));
+    expect(usageRow?.binds).toContain("inline_query");
+    expect(usageRow?.binds).toContain("rate_limited");
+    expect(usageRow?.binds).not.toContain("usdc");
+    expect(usageRow?.binds).not.toContain(123456);
+  });
+
   it("records chosen cards as an aggregate only and makes no Bot API request", async () => {
     const db = mockD1([]);
 
@@ -138,6 +173,7 @@ describe("Telegram inline status cards", () => {
   it("records a failed inline answer as a bounded aggregate", async () => {
     fetchSpy.mockResolvedValueOnce(new Response("unavailable", { status: 503 }));
     const db = mockD1([
+      ...inlineReadLimitRows(),
       { match: "FROM price_cache WHERE asset_id = ?", rows: [{ price: 1, updated_at: 1_700_000_000 }] },
       { match: "FROM depeg_events WHERE stablecoin_id = ? AND ended_at IS NULL", rows: [] },
     ]);

--- a/worker/src/api/telegram-inline-queries.ts
+++ b/worker/src/api/telegram-inline-queries.ts
@@ -1,10 +1,13 @@
 import { resolveTicker } from "../lib/telegram-alerts";
 import { answerInlineQuery, type TelegramInlineQueryResultArticle } from "../lib/telegram";
+import { CHAT_COMMAND_FLOOD_LIMIT, CHAT_COMMAND_FLOOD_WINDOW_SEC } from "../lib/telegram-constants";
 import { recordTelegramUsageEvent } from "../lib/telegram-usage-analytics";
+import { logTelegramWebhookWarning } from "./telegram-webhook-ingress-policy";
 import { buildStatusMessage } from "./telegram-webhook-messages";
 import type { TelegramWebhookEffectFence } from "./telegram-webhook-effect-fence";
 import type { TelegramWebhookUpdate } from "./telegram-webhook-shared";
 import { loadStatusForCoin } from "./telegram-webhook-status";
+import { acquireTelegramCommandCooldown, recordTelegramChatCommandFlood, unixNow } from "./telegram-webhook-store";
 
 // Inline queries are intentionally exact-match only. This prevents a typed
 // prefix from fanning out into an unbounded read/result set on every keystroke.
@@ -13,6 +16,7 @@ const INLINE_STATUS_CACHE_TIME_SEC = 30;
 const EMPTY_INLINE_STATUS_CACHE_TIME_SEC = 5;
 const INLINE_STATUS_RESULT_ID_PREFIX = "status:";
 const TELEGRAM_INLINE_RESULT_ID_MAX_BYTES = 64;
+const INLINE_STATUS_COOLDOWN_SEC = 20;
 
 type InlineQuery = NonNullable<TelegramWebhookUpdate["inline_query"]>;
 
@@ -70,6 +74,41 @@ function inlineStatusResultId(coinId: string): string {
   return `${INLINE_STATUS_RESULT_ID_PREFIX}${(hash >>> 0).toString(16)}`;
 }
 
+async function enforceInlineStatusReadLimit(
+  db: D1Database,
+  input: { actorUserId: number | undefined; coinId: string },
+): Promise<"allowed" | "rate_limited" | "failure"> {
+  const actorKey = input.actorUserId == null ? "unknown" : String(input.actorUserId);
+  const limitKey = `inline:${actorKey}`;
+  const nowSec = unixNow();
+
+  try {
+    const flood = await recordTelegramChatCommandFlood(db, {
+      chatId: limitKey,
+      nowSec,
+      windowSec: CHAT_COMMAND_FLOOD_WINDOW_SEC,
+      limit: CHAT_COMMAND_FLOOD_LIMIT,
+    });
+    if (!flood.allowed) return "rate_limited";
+  } catch (err) {
+    logTelegramWebhookWarning("inline query flood check failed", "inline-query-flood", err);
+    return "failure";
+  }
+
+  try {
+    const cooldown = await acquireTelegramCommandCooldown(db, {
+      chatId: limitKey,
+      commandKey: `/status:${input.coinId}`,
+      nowSec,
+      cooldownSec: INLINE_STATUS_COOLDOWN_SEC,
+    });
+    return cooldown.allowed ? "allowed" : "rate_limited";
+  } catch (err) {
+    logTelegramWebhookWarning("inline query cooldown check failed", "inline-query-cooldown", err);
+    return "failure";
+  }
+}
+
 /**
  * Serve a single shared, read-only status card. The raw query and Telegram
  * sender are deliberately discarded; telemetry is an aggregate outcome only.
@@ -89,17 +128,25 @@ export async function handleTelegramInlineQueryUpdate(args: {
   let cacheTimeSec = EMPTY_INLINE_STATUS_CACHE_TIME_SEC;
 
   if (classified.kind === "resolved" && classified.coinId && classified.symbol && classified.name) {
-    const status = await loadStatusForCoin(args.db, classified.coinId);
-    results = [
-      buildInlineStatusResult({
-        coinId: classified.coinId,
-        symbol: classified.symbol,
-        name: classified.name,
-        status,
-      }),
-    ];
-    outcome = "served";
-    cacheTimeSec = INLINE_STATUS_CACHE_TIME_SEC;
+    const limitOutcome = await enforceInlineStatusReadLimit(args.db, {
+      actorUserId: args.inlineQuery.from?.id,
+      coinId: classified.coinId,
+    });
+    if (limitOutcome === "allowed") {
+      const status = await loadStatusForCoin(args.db, classified.coinId);
+      results = [
+        buildInlineStatusResult({
+          coinId: classified.coinId,
+          symbol: classified.symbol,
+          name: classified.name,
+          status,
+        }),
+      ];
+      outcome = "served";
+      cacheTimeSec = INLINE_STATUS_CACHE_TIME_SEC;
+    } else {
+      outcome = limitOutcome;
+    }
   }
 
   await args.effectFence?.beforeIrreversibleEffect("inline-query-answer");


### PR DESCRIPTION
### Motivation
- The inline-query path called `loadStatusForCoin` without the existing Telegram flood and command cooldown protections, allowing unbounded D1/cache reads via the public inline surface.
- The goal is to apply the same ingress/flood and heavy-read cooldown controls used by `/status` to inline status-card requests to prevent abusive/backend-heavy usage.

### Description
- Added `enforceInlineStatusReadLimit()` to `worker/src/api/telegram-inline-queries.ts` which applies a per-actor flood check (`recordTelegramChatCommandFlood`) and a per-actor/per-coin cooldown (`acquireTelegramCommandCooldown`, 20s) before calling `loadStatusForCoin`.
- The inline handler now skips calling `loadStatusForCoin` when the checks return `rate_limited` or `failure`, returns an empty bounded inline answer, and records aggregate `rate_limited`/`failure` telemetry instead of performing expensive reads.
- Surface-level changes only touched `worker/src/api/telegram-inline-queries.ts` and updated tests in `worker/src/api/__tests__/telegram-inline-queries.test.ts` to cover the rate-limit case and to account for required cache writes in the successful path.

### Testing
- Ran the focused Vitest suite: `npx vitest run worker/src/api/__tests__/telegram-inline-queries.test.ts`, which passed all tests (7 passed).
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ce9f1c48332941178124fea6544)