### PR TITLE
fix(depegs): skip USD hard confirms for native pending

### DIFF
--- a/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
+++ b/worker/src/cron/__tests__/confirm-pending-depegs.test.ts
@@ -482,6 +482,76 @@ describe("confirmPendingDepegs", () => {
     expect(outcome?.boundValues[21]).toBe("confirmed-by:native:brl");
   });
 
+  it("does not promote native-origin pending rows from USD-denominated hard sources", async () => {
+    const nowSec = 1_700_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(nowSec * 1000);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(fetchBinancePricesDetailed).mockResolvedValueOnce({
+      kind: "ok",
+      value: {
+        prices: new Map([["BRZ", 0.191895]]),
+        diagnostics: [{
+          source: "binance",
+          stage: "primary",
+          endpoint: "data-api.binance.vision/api/v3/ticker/price",
+          status: 200,
+          ok: true,
+          success: true,
+          matchedCount: 1,
+        }],
+      },
+    });
+
+    await confirmPendingDepegs(
+      makeDb({
+        pendingRows: [
+          makePendingRow({
+            id: 24,
+            stablecoin_id: "brz-transfero",
+            symbol: "BRZ",
+            peg_type: "peggedREAL",
+            direction: "below",
+            first_seen_bps: -242,
+            first_seen_at: nowSec - DEPEG_PENDING_MIN_AGE_SEC - 60,
+            first_price: 0.9758,
+            peak_seen_bps: -242,
+            peak_price: 0.9758,
+            peg_reference: 1,
+            reason: "large-cap+native-origin",
+          }),
+        ],
+        dexRows: [
+          {
+            stablecoin_id: "brz-transfero",
+            dex_price_usd: 0.191895,
+            updated_at: nowSec - 30,
+            source_pool_count: 4,
+            source_total_tvl: 5_000_000,
+            price_sources_json: JSON.stringify([
+              { price: 0.191895, tvl: 3_000_000, protocol: "curve", sourceFamily: "curve", chain: "ethereum" },
+              { price: 0.191895, tvl: 2_000_000, protocol: "uniswap", sourceFamily: "uniswap", chain: "ethereum" },
+            ]),
+          },
+        ],
+      }),
+      [
+        makeAuthoritativeUsdAsset(nowSec, {
+          id: "brz-transfero",
+          name: "Brazilian Digital",
+          symbol: "BRZ",
+          geckoId: "brz",
+          pegType: "peggedREAL",
+          price: 0.191895,
+        }),
+        ...makeNeutralUsdAssets(),
+      ],
+      { peggedREAL: 0.191895 },
+    );
+
+    expect(fetchWithRetry).not.toHaveBeenCalled();
+    expect(batchExecute).not.toHaveBeenCalled();
+  });
+
   it("keeps native-origin pending rows in native units and does not promote them from the same direct quote", async () => {
     const nowSec = 1_700_000_000;
     vi.spyOn(Date, "now").mockReturnValue(nowSec * 1000);

--- a/worker/src/cron/pending-depeg-confirmation-evidence.ts
+++ b/worker/src/cron/pending-depeg-confirmation-evidence.ts
@@ -272,7 +272,9 @@ export async function collectConfirmationEvidence(
   }
 
   const dexRow = dexPriceRows.get(row.stablecoin_id);
-  if (dexRow != null && isTrustedDexPriceRow(dexRow, now, "depeg")) {
+  if (isNativeOrigin) {
+    addSource(evidence.unavailableSources, "dex:usd-native-origin");
+  } else if (dexRow != null && isTrustedDexPriceRow(dexRow, now, "depeg")) {
     const dexSignal = deriveDepegSignal(dexRow.dex_price_usd, pegReference);
     const aggregateDexStatus = classifyDirectionalSignal(dexSignal, secondaryBar, pendingState.direction);
     const protocolSources = dexPriceSources.get(row.stablecoin_id);
@@ -328,7 +330,9 @@ export async function collectConfirmationEvidence(
     addSource(evidence.unavailableSources, "dex:aggregate");
   }
 
-  if (!cexAllowed) {
+  if (isNativeOrigin) {
+    addSource(evidence.unavailableSources, "cex:usd-native-origin");
+  } else if (!cexAllowed) {
     addSource(evidence.circuitOpenSources, "cex:binance");
   } else if (cexPrices == null) {
     addSource(evidence.unavailableSources, "cex:binance");
@@ -356,7 +360,9 @@ export async function collectConfirmationEvidence(
   const poolRecoverGroups = new Set<string>();
   let poolHighTvlConfirm: PoolConfirmation | null = null;
   const pools = poolChallengers.get(row.stablecoin_id);
-  if (pools?.length) {
+  if (isNativeOrigin) {
+    addSource(evidence.unavailableSources, "pool:usd-native-origin");
+  } else if (pools?.length) {
     for (const pool of pools) {
       const poolSignal = deriveDepegSignal(pool.price, pegReference);
       if (poolSignal == null) continue;


### PR DESCRIPTION
### Motivation
- Prevent mixed-unit confirmations where native-origin pending rows (stored with `peg_reference=1`) are compared against USD-denominated hard sources, which can cause false or massively distorted confirmed depeg events for non-USD pegs.

### Description
- Treat USD-denominated DEX, CEX, and pool hard-source evidence as unavailable for native-origin pending rows by skipping those checks in `collectConfirmationEvidence` (`worker/src/cron/pending-depeg-confirmation-evidence.ts`).
- Add a regression test that ensures a BRZ native-origin pending row is not promoted when normal USD DEX/CEX/pool prices are present (`worker/src/cron/__tests__/confirm-pending-depegs.test.ts`).
- Commit message: `fix(depegs): skip USD hard confirms for native pending` with the corresponding test and code changes.

### Testing
- Ran the focused test suite with `npx vitest run worker/src/cron/__tests__/confirm-pending-depegs.test.ts`, and the suite passed (`41` tests passed).
- Type-checked the worker code with `cd worker && npx tsc --noEmit`, which completed without errors.
- Ran `git diff --check` and basic repo hygiene checks; no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ced1e888332b3a4cd507fb0c27f)