### PR TITLE
fix(weekly-recap): preserve blocked digest metadata

### DIFF
--- a/worker/src/cron/__tests__/weekly-recap.test.ts
+++ b/worker/src/cron/__tests__/weekly-recap.test.ts
@@ -370,6 +370,36 @@ describe("generateWeeklyRecap", () => {
     expect(deliverTelegramDigestEdition).not.toHaveBeenCalled();
   });
 
+  it("preserves blocked quality-gate metadata when Telegram delivery is skipped", async () => {
+    const db = mockD1(makeTables(), { requireMatch: true });
+    vi.mocked(fetchWithRetry).mockImplementation(async () => weeklyClaudeResponse({
+      text: "PSI softened by 4 points while USDT stayed near peg and blacklist activity kept tapping the glass, but this hook deliberately runs long enough to trip the hard tweet length validator so the weekly recap remains stored only for operator inspection and must not be published publicly from archive reads.",
+    }));
+
+    const result = await generateWeeklyRecap(
+      db,
+      "anthropic-key",
+      { botToken: "bot", chatId: "chat" },
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.metadata).toContain("telegram: skipped: quality-gate");
+    expect(enqueueTelegramDigestEdition).not.toHaveBeenCalled();
+    expect(deliverTelegramDigestEdition).not.toHaveBeenCalled();
+
+    const insert = db.getHistory().find((entry) => entry.sql.includes("INSERT INTO daily_digest"));
+    const insertedMeta = JSON.parse(String(insert?.binds[5])) as Record<string, unknown>;
+    expect(insertedMeta.qualityGate).toBe("blocked");
+
+    const update = db.getHistory().find((entry) => entry.sql.includes("SET digest_meta = ?"));
+    const finalMeta = JSON.parse(String(update?.binds[0])) as Record<string, unknown>;
+    expect(finalMeta).toMatchObject({
+      qualityGate: "blocked",
+      telegramDelivered: false,
+      telegramDeliveryStatus: "skipped: quality-gate",
+    });
+  });
+
   it("stores failed Telegram delivery state so the weekly row can be retried", async () => {
     const db = mockD1(makeTables(), { requireMatch: true });
     vi.mocked(fetchWithRetry).mockImplementation(async () => weeklyClaudeResponse());

--- a/worker/src/cron/weekly-recap.ts
+++ b/worker/src/cron/weekly-recap.ts
@@ -498,6 +498,11 @@ export async function generateWeeklyRecap(
       },
     },
   });
+  // Hard quality failures are stored for inspection but never published.
+  const storedDigestMeta = digestCopy.hasBlockingQualityIssues
+    ? markDigestMetaBlocked(initialDigestMeta)
+    : initialDigestMeta;
+
   await insertDigestRecord({
     db,
     generatedAt: nowSec,
@@ -505,10 +510,7 @@ export async function generateWeeklyRecap(
     digestTitle: digestCopy.digestTitle || null,
     inputData: weeklyData,
     digestExtended: digestCopy.digestExtended || null,
-    // Hard quality failures are stored for inspection but never published.
-    digestMeta: digestCopy.hasBlockingQualityIssues
-      ? markDigestMetaBlocked(initialDigestMeta)
-      : initialDigestMeta,
+    digestMeta: storedDigestMeta,
     signal,
   });
   throwIfAborted(signal);
@@ -542,7 +544,7 @@ export async function generateWeeklyRecap(
     db,
     {
       generated_at: nowSec,
-      digest_meta: initialDigestMeta,
+      digest_meta: storedDigestMeta,
     },
     {
       nowSec,


### PR DESCRIPTION
### Motivation
- A hard quality-gate failure on weekly recaps was initially stored with `digest_meta.qualityGate = "blocked"` but then overwritten by the Telegram-delivery metadata update because the update was fed the unblocked metadata, allowing blocked weekly rows to become publicly visible.

### Description
- Compute a single `storedDigestMeta` value before persistence and use `markDigestMetaBlocked(initialDigestMeta)` when `digestCopy.hasBlockingQualityIssues`.
- Use `storedDigestMeta` for both the `insertDigestRecord` call and the subsequent `updateWeeklyTelegramDeliveryMeta` call so the `qualityGate: "blocked"` marker is preserved.
- Add a focused regression test `preserves blocked quality-gate metadata when Telegram delivery is skipped` that forces a hard quality-gate skip, verifies Telegram is not sent, and asserts the final written metadata still contains `qualityGate: "blocked"`.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/__tests__/weekly-recap.test.ts --reporter=verbose` and all tests passed.
- Ran the TypeScript build check with `cd worker && npx tsc --noEmit` which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea0acc8332b09cc711ba88e75a)