### PR TITLE
Fix PancakeSwap decimal parsing robustness

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/fetch-pancakeswap.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/fetch-pancakeswap.test.ts
@@ -102,6 +102,25 @@ describe("fetchPancakeSwapPools", () => {
     expect(result.pools[0]?.tokens[1]?.decimals).toBe(0);
   });
 
+  it("falls back to 18 decimals for malformed Pancake token metadata", async () => {
+    const malformedDecimalPool = makePool("0xpool");
+    malformedDecimalPool.token0.decimals = 6 as unknown as string;
+    malformedDecimalPool.token1.decimals = null as unknown as string;
+
+    vi.mocked(fetchTextWithRetry)
+      .mockImplementationOnce(async () => textResult(response({ data: { pools: [malformedDecimalPool] } })))
+      .mockImplementationOnce(async () => textResult(response({ data: { poolHourDatas: [] } })))
+      .mockImplementation(async () => textResult(response({ data: { pools: [] } })));
+
+    const result = await fetchPancakeSwapPools("graph-key");
+
+    expect(result.ok).toBe(true);
+    expect(result.degraded).toBe(false);
+    expect(result.errors).toHaveLength(0);
+    expect(result.pools[0]?.tokens[0]?.decimals).toBe(6);
+    expect(result.pools[0]?.tokens[1]?.decimals).toBe(18);
+  });
+
   it("maps Pancake's asymmetric token1Price to the token0/token1 pool ratio", async () => {
     const wonPool = makePool("0xwon-usdt");
     wonPool.token0 = {

--- a/worker/src/cron/dex-liquidity/fetch-pancakeswap.ts
+++ b/worker/src/cron/dex-liquidity/fetch-pancakeswap.ts
@@ -48,8 +48,8 @@ type V3Pool = {
   totalValueLockedToken1: string;
   token0Price: string;
   token1Price: string;
-  token0: { id: string; symbol: string; decimals: string };
-  token1: { id: string; symbol: string; decimals: string };
+  token0: { id: string; symbol: string; decimals: unknown };
+  token1: { id: string; symbol: string; decimals: unknown };
 };
 
 type PoolHourData = {
@@ -58,8 +58,9 @@ type PoolHourData = {
   pool: { id: string };
 };
 
-function parseTokenDecimals(value: string): number {
-  if (value.trim() === "") return 18;
+function parseTokenDecimals(value: unknown): number {
+  if (typeof value === "string" && value.trim() === "") return 18;
+  if (typeof value !== "string" && typeof value !== "number") return 18;
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed >= 0 && parsed <= 255 ? parsed : 18;
 }


### PR DESCRIPTION
### Motivation

- PancakeSwap subgraph `decimals` fields were assumed to be strings and `parseTokenDecimals` called `trim()`, which throws for non-string upstream values and can abort chain ingestion for a run. 
- The intent is to treat external subgraph metadata as untrusted and preserve valid numeric decimals while falling back to `18` for malformed or missing values to avoid availability degradation.

### Description

- Change the V3 pool shape so token `decimals` is `unknown` and make the parser signature `parseTokenDecimals(value: unknown): number` to reflect untrusted input. 
- Implement runtime checks so `parseTokenDecimals` trims only string inputs, accepts numeric values, and returns `18` for null/objects/blank/out-of-range values while preserving valid zeros. 
- Add a focused regression test `falls back to 18 decimals for malformed Pancake token metadata` to `worker/src/cron/dex-liquidity/__tests__/fetch-pancakeswap.test.ts` that verifies numeric decimals are preserved and malformed values fall back without degrading ingestion.

### Testing

- Ran the focused Vitest suite: `npm run test -- --run worker/src/cron/dex-liquidity/__tests__/fetch-pancakeswap.test.ts`, and all tests passed (`9 passed`).
- Verified type-checking with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea99ec8332a6851a4343022f4a)