### PR TITLE
fix(security): gate site API sync secret by origin

### DIFF
--- a/scripts/__tests__/sync-from-api.test.ts
+++ b/scripts/__tests__/sync-from-api.test.ts
@@ -21,13 +21,40 @@ describe("fetchWithRetry", () => {
     }
   });
 
-  it("adds the site API credential for deploy-time internal reads", () => {
+  it("keeps the site API credential off untrusted or unresolved API reads", () => {
     vi.stubEnv("DIGEST_API_KEY", "public-key");
     vi.stubEnv("SITE_API_SHARED_SECRET", "site-secret");
 
     expect(apiFetchHeaders(["DIGEST_API_KEY"])).toEqual({
       Accept: "application/json",
       "X-API-Key": "public-key",
+    });
+    expect(apiFetchHeaders(["DIGEST_API_KEY"], { url: "https://attacker.example/api/digest-archive" })).toEqual({
+      Accept: "application/json",
+      "X-API-Key": "public-key",
+    });
+  });
+
+  it("adds the site API credential only for trusted direct site API reads", () => {
+    vi.stubEnv("DIGEST_API_KEY", "public-key");
+    vi.stubEnv("SITE_API_SHARED_SECRET", "site-secret");
+
+    expect(apiFetchHeaders(["DIGEST_API_KEY"], { url: "https://site-api.pharos.watch/api/digest-archive" })).toEqual({
+      Accept: "application/json",
+      "X-Pharos-Site-Proxy-Secret": "site-secret",
+    });
+    expect(
+      apiFetchHeaders(["DIGEST_API_KEY"], { url: "https://pharos-watch-preview.workers.dev/api/digest-archive" }),
+    ).toEqual({
+      Accept: "application/json",
+      "X-API-Key": "public-key",
+    });
+
+    vi.stubEnv("SITE_API_SHARED_SECRET_TRUSTED_ORIGINS", "https://pharos-watch-preview.workers.dev");
+    expect(
+      apiFetchHeaders(["DIGEST_API_KEY"], { url: "https://pharos-watch-preview.workers.dev/api/digest-archive" }),
+    ).toEqual({
+      Accept: "application/json",
       "X-Pharos-Site-Proxy-Secret": "site-secret",
     });
   });

--- a/scripts/lib/sync-from-api.ts
+++ b/scripts/lib/sync-from-api.ts
@@ -10,7 +10,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { SITE_DATA_PATH_PREFIX, SITE_DATA_PROXY_SECRET_HEADER, toSiteDataPath } from "@shared/lib/site-data-lane";
-import { SITE_ORIGIN } from "@shared/lib/runtime-origins";
+import { SITE_API_ORIGIN, SITE_ORIGIN } from "@shared/lib/runtime-origins";
 
 import { sleep } from "./smoke-runtime.mjs";
 
@@ -180,13 +180,34 @@ function isSiteDataBase(rawUrl: string): boolean {
   }
 }
 
-function isSiteDataRequestUrl(rawUrl: string | undefined): boolean {
-  if (!rawUrl) return false;
+function parseFetchUrl(rawUrl: string | undefined): URL | null {
+  if (!rawUrl) return null;
   try {
-    return new URL(rawUrl).pathname.startsWith(`${SITE_DATA_PATH_PREFIX}/`);
+    return new URL(rawUrl);
   } catch {
-    return false;
+    return null;
   }
+}
+
+function isSiteDataRequestUrl(url: URL | null): boolean {
+  return url?.pathname.startsWith(`${SITE_DATA_PATH_PREFIX}/`) === true;
+}
+
+function configuredTrustedSiteApiSecretOrigins(): Set<string> {
+  const configured = process.env.SITE_API_SHARED_SECRET_TRUSTED_ORIGINS?.split(",") ?? [];
+  const origins = new Set([SITE_API_ORIGIN]);
+  for (const rawOrigin of configured) {
+    const origin = parseFetchUrl(rawOrigin.trim());
+    if (origin?.protocol === "https:" && origin.hostname.endsWith(".workers.dev")) {
+      origins.add(origin.origin);
+    }
+  }
+  return origins;
+}
+
+function isTrustedSiteApiSecretUrl(url: URL | null): boolean {
+  if (!url || url.protocol !== "https:" || url.username || url.password) return false;
+  return configuredTrustedSiteApiSecretOrigins().has(url.origin);
 }
 
 /**
@@ -215,13 +236,14 @@ export function resolveApiPathUrl(apiBaseOrEndpoint: string, apiPath: string): s
 export function apiFetchHeaders(envNames: readonly string[], options: { url?: string } = {}): Record<string, string> {
   const apiKey = envNames.map((name) => process.env[name]?.trim()).find((value) => value);
   const siteApiSharedSecret = process.env.SITE_API_SHARED_SECRET?.trim();
-  const isSiteDataRequest = isSiteDataRequestUrl(options.url);
-  const siteDataOrigin = isSiteDataRequest ? SITE_ORIGIN : null;
+  const fetchUrl = parseFetchUrl(options.url);
+  const isSiteDataRequest = isSiteDataRequestUrl(fetchUrl);
+  const shouldSendSiteApiSecret = !isSiteDataRequest && isTrustedSiteApiSecretUrl(fetchUrl);
   return {
     Accept: "application/json",
-    ...(siteDataOrigin ? { Origin: siteDataOrigin } : {}),
-    ...(apiKey && !isSiteDataRequest ? { "X-API-Key": apiKey } : {}),
-    ...(siteApiSharedSecret && !isSiteDataRequest ? { [SITE_DATA_PROXY_SECRET_HEADER]: siteApiSharedSecret } : {}),
+    ...(isSiteDataRequest ? { Origin: SITE_ORIGIN } : {}),
+    ...(apiKey && !isSiteDataRequest && !shouldSendSiteApiSecret ? { "X-API-Key": apiKey } : {}),
+    ...(siteApiSharedSecret && shouldSendSiteApiSecret ? { [SITE_DATA_PROXY_SECRET_HEADER]: siteApiSharedSecret } : {}),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of `SITE_API_SHARED_SECRET` when maintenance syncs or release jobs are pointed at an attacker-controlled or overridden API base.
- Ensure release/maintenance scripts keep browser-shaped `/_site-data/*` reads intact while only emitting the site-proxy secret to known, trusted upstreams.

### Description
- Parse the resolved fetch URL in `apiFetchHeaders()` and only attach `SITE_API_SHARED_SECRET` when the request targets the canonical `SITE_API_ORIGIN` or an explicitly configured trusted Worker preview origin.
- Add a small trusted-origin configuration via the `SITE_API_SHARED_SECRET_TRUSTED_ORIGINS` environment variable to allow additional HTTPS Worker preview origins (validated to be `https:` and `*.workers.dev`).
- Preserve existing behavior for `/_site-data/*` reads by sending the `Origin` header (browser-shaped) and continue sending `X-API-Key` only to non-site-data, non-secret destinations.
- Update and extend `scripts/__tests__/sync-from-api.test.ts` to cover unresolved/untrusted API bases, canonical `site-api` reads, and explicitly trusted Worker preview origins.

### Testing
- Ran the focused unit tests: `npm run test -- scripts/__tests__/sync-from-api.test.ts` and the related suites `npm run test -- scripts/__tests__/generate-public-datasets.test.ts scripts/__tests__/check-env-contract.test.ts`, all passed.
- Ran typecheck with `npm run typecheck -- --pretty false` which completed without errors.
- Ran environment-contract check with `npm run check:env-contract` which reported the env contract in sync.
- Ran repository checks (`git diff --check`) and local test smoke; no issues were detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceab4ec8332bb43586bd6315898)