### PR TITLE
fix(telegram): fence collision recovery to terminal duplicates

### DIFF
--- a/worker/src/cron/__tests__/telegram-authoritative-target-plans-sqlite.test.ts
+++ b/worker/src/cron/__tests__/telegram-authoritative-target-plans-sqlite.test.ts
@@ -618,6 +618,92 @@ describe("authoritative Telegram target plans on latest SQLite schema", () => {
     ).toEqual({ status: "planned", final_delivery_state: null, cancellation_reason: null });
   });
 
+  it("keeps degraded hash-only identity collisions closed across coordinator runs", async () => {
+    const { sqlite, db } = setupLatestSchema();
+    const priorSourceEventId = "telegram-source:test:v1:prior-hash-reopen";
+    const currentSourceEventId = "telegram-source:test:v1:current-hash-reopen";
+    insertSubscriber(sqlite, "42");
+
+    insertSource(sqlite, priorSourceEventId);
+    await openDeliveryForRoutes(
+      db,
+      priorSourceEventId,
+      new Map([["42", [routed("42", priorSourceEventId, 1)]]]),
+    );
+    await enqueueTelegramAuthoritativeTargets(db, priorSourceEventId, 1, NOW);
+    sqlite
+      .prepare(
+        `UPDATE telegram_pending_alerts
+            SET delivery_state = 'sent', delivery_completed_at = ?
+          WHERE source_event_id = ?`,
+      )
+      .run(NOW + 1, priorSourceEventId);
+
+    insertSource(sqlite, currentSourceEventId);
+    await openDeliveryForRoutes(
+      db,
+      currentSourceEventId,
+      new Map([["42", [routed("42", currentSourceEventId, 1, "-different")]]]),
+    );
+    const prior = sqlite
+      .prepare("SELECT dedupe_key FROM telegram_pending_alerts WHERE source_event_id = ?")
+      .get(priorSourceEventId) as { dedupe_key: string };
+    sqlite
+      .prepare(
+        `UPDATE telegram_alert_job_targets
+            SET pending_dedupe_key = ?
+          WHERE source_event_id = ?`,
+      )
+      .run(prior.dedupe_key, currentSourceEventId);
+
+    await expect(
+      enqueueTelegramAuthoritativeTargets(db, currentSourceEventId, 1, NOW + 2),
+    ).rejects.toThrow("pending handoff was not confirmed");
+
+    const result = await runTelegramTargetPlanCoordinator({
+      db,
+      sourceEventId: currentSourceEventId,
+      nowSec: NOW + 3,
+      maxSteps: 2,
+      deliveryHandoffLimit: 1,
+      callbacks: {
+        resolveInitialEligibility: async () => {
+          throw new Error("hash-only collision recovery must not recapture subscribers");
+        },
+        planSubscribers: async () => {
+          throw new Error("hash-only collision recovery must not rematerialize targets");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      state: "degraded",
+      steps: 1,
+      enqueued: 0,
+      remainingTargets: 0,
+    });
+    expect(
+      sqlite
+        .prepare(
+          `SELECT target_plan_state, last_error_class, last_attempt_at
+             FROM telegram_alert_source_events WHERE source_event_id = ?`,
+        )
+        .get(currentSourceEventId),
+    ).toEqual({
+      target_plan_state: "degraded",
+      last_error_class: "pending_identity_collision",
+      last_attempt_at: NOW + 2,
+    });
+    expect(
+      sqlite
+        .prepare(
+          `SELECT status, final_delivery_state, cancellation_reason
+             FROM telegram_alert_job_targets WHERE source_event_id = ?`,
+        )
+        .get(currentSourceEventId),
+    ).toEqual({ status: "planned", final_delivery_state: null, cancellation_reason: null });
+  });
+
   it("re-enters handoff for an already-degraded terminal identity collision", async () => {
     const { sqlite, db } = setupLatestSchema();
     const priorSourceEventId = "telegram-source:test:v1:prior-degraded-recovery";

--- a/worker/src/cron/telegram-alert-target-plans/source-state.ts
+++ b/worker/src/cron/telegram-alert-target-plans/source-state.ts
@@ -369,6 +369,17 @@ export async function reopenTelegramTargetPlanDeliveryAfterIdentityCollision(
              WHERE target.source_event_id = telegram_alert_source_events.source_event_id
                AND target.plan_generation = telegram_alert_source_events.target_plan_generation
                AND target.status = 'planned'
+               AND EXISTS (
+                 SELECT 1 FROM telegram_pending_alerts pending
+                  WHERE pending.dedupe_key = target.pending_dedupe_key
+                    AND pending.source_event_id IS NOT target.source_event_id
+                    AND pending.chat_id = target.chat_id
+                    AND pending.message_html = target.message_html
+                    AND COALESCE(pending.chunk_index, 0) = target.chunk_index
+                    AND COALESCE(pending.alert_type, '') = target.alert_type
+                    AND COALESCE(pending.markup_policy_json, '') = target.markup_policy_json
+                    AND pending.delivery_state IN ('sent', 'execution_unknown')
+               )
           )`,
     )
     .bind(nowSec, claim.sourceEventId, claim.generation, claim.owner)


### PR DESCRIPTION
### Motivation
- A recovery path reopened any degraded `pending_identity_collision` source without proving the collision was an exact prior terminal duplicate, causing non-repairable (live or hash-only) collisions to be retried indefinitely and degrading Telegram fanout availability.
- The intent is to only re-enter delivery for collisions that can be repaired by the terminal-duplicate suppression logic in `delivery.ts`.

### Description
- Tighten the reopening predicate in `reopenTelegramTargetPlanDeliveryAfterIdentityCollision` to require that a planned target has a matching `telegram_pending_alerts` row (matching `pending_dedupe_key`, `chat_id`, `message_html`, chunk/index, `alert_type`, and `markup_policy_json`) with `delivery_state` in `('sent','execution_unknown')` before reopening delivery.
- This change keeps live or hash-only dedupe collisions fail-closed while preserving the original terminal-duplicate recovery behavior.
- Add a SQLite regression test `keeps degraded hash-only identity collisions closed across coordinator runs` to `worker/src/cron/__tests__/telegram-authoritative-target-plans-sqlite.test.ts` that verifies the coordinator does not reopen hash-only collisions but still re-enters handoff for true terminal duplicates.

### Testing
- Ran the targeted Vitest suite with `npx vitest run worker/src/cron/__tests__/telegram-authoritative-target-plans-sqlite.test.ts -t "hash-only identity collisions|already-degraded terminal identity collision|different payload"`, and the tests passed (targeted tests passed).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea195c8332ad62425e7f5d48a7)