### PR TITLE
Fix capped Telegram recap retention pruning

### DIFF
--- a/worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts
+++ b/worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts
@@ -256,7 +256,22 @@ describe("telegram recap store on latest SQLite schema", () => {
         (recap_key, chat_id, local_date, window_start_at, window_end_at, preference_generation, watchlist_fingerprint, status, created_at, updated_at)
         VALUES (?, ?, ?, ?, ?, 0, 'x', ?, ?, ?)`).run(key, key, "2026-06-01", 1, 2, status, 1, NOW - 91 * 86400);
     }
-    await expect(pruneTelegramRecapTargets(db, NOW)).resolves.toEqual({ deletedTargets: 3 });
+    await expect(pruneTelegramRecapTargets(db, NOW)).resolves.toEqual({ deletedTargets: 3, cappedAtLimit: false });
     expect(sqlite.prepare("SELECT recap_key FROM telegram_recap_targets ORDER BY recap_key").all()).toEqual([{ recap_key: "old-skip" }, { recap_key: "old-unknown" }]);
+  });
+
+  it("caps recap target pruning to the requested batch size", async () => {
+    const { sqlite, db } = setup();
+    for (let i = 0; i < 3; i += 1) {
+      sqlite.prepare(`INSERT INTO telegram_recap_targets
+        (recap_key, chat_id, local_date, window_start_at, window_end_at, preference_generation, watchlist_fingerprint, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, 'x', 'cancelled', ?, ?)`).run(`old-cancelled-${i}`, `${i}`, "2026-06-01", 1, 2, 1, NOW - 91 * 86400);
+    }
+
+    await expect(pruneTelegramRecapTargets(db, NOW, { limit: 2 })).resolves.toEqual({
+      deletedTargets: 2,
+      cappedAtLimit: true,
+    });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_recap_targets").get()).toEqual({ count: 1 });
   });
 });

--- a/worker/src/cron/__tests__/telegram-retention-cleanup.test.ts
+++ b/worker/src/cron/__tests__/telegram-retention-cleanup.test.ts
@@ -35,6 +35,11 @@ interface CacheRow {
   updated_at: number;
 }
 
+interface RecapTargetRow {
+  status: string;
+  updated_at: number;
+}
+
 interface StubState {
   usageDaily: UsageDailyRow[];
   watcherLifecycle: WatcherLifecycleRow[];
@@ -45,6 +50,7 @@ interface StubState {
   adoptionClientQuota: UpdatedAtRow[];
   diagnostics: UpdatedAtRow[];
   cache: CacheRow[];
+  recapTargets: RecapTargetRow[];
 }
 
 function makeState(): StubState {
@@ -58,6 +64,7 @@ function makeState(): StubState {
     adoptionClientQuota: [],
     diagnostics: [],
     cache: [],
+    recapTargets: [],
   };
 }
 
@@ -99,6 +106,19 @@ function createStubDb(state: StubState, options: { afterProcessedUpdateDelete?: 
           // reconcileExpiredTelegramAlertJobTargets: no rows to update in
           // these tests.
           return { success: true, meta: { changes: 0 } };
+        }
+        if (sql.trimStart().startsWith("DELETE FROM telegram_recap_targets")) {
+          const [aggregateCutoff, terminalCutoff, limit] = bound as [number, number, number];
+          const removed = deleteMatching(
+            state.recapTargets,
+            (row) =>
+              (["sent", "skipped_no_changes", "skipped_paused", "skipped_stale"].includes(row.status) &&
+                row.updated_at < aggregateCutoff) ||
+              (["cancelled", "expired", "execution_unknown", "failed_permanent"].includes(row.status) &&
+                row.updated_at < terminalCutoff),
+            limit,
+          );
+          return { success: true, meta: { changes: removed } };
         }
         if (sql.startsWith("DELETE FROM telegram_processed_updates")) {
           const [cutoff, _unknownCutoff, limit] = bound as [number, number, number];
@@ -293,6 +313,27 @@ describe("runTelegramRetentionCleanup", () => {
     expect(metadata.diagnosticsPruned).toBe(10_000);
     expect(metadata.cappedAtLimit.usageDaily).toBe(true);
     expect(metadata.cappedAtLimit.diagnostics).toBe(true);
+  });
+
+  it("caps recap-target pruning and reports the retention run as truncated", async () => {
+    const state = makeState();
+    const now = Math.floor(Date.now() / 1000);
+    for (let i = 0; i < 10_001; i += 1) {
+      state.recapTargets.push({ status: "cancelled", updated_at: now - 91 * 24 * 60 * 60 });
+    }
+    const db = createStubDb(state);
+
+    const result = await runTelegramRetentionCleanup(db);
+
+    expect(state.recapTargets).toHaveLength(1);
+    const metadata = JSON.parse(result.metadata!) as {
+      recapTargetsPruned: number;
+      runBudgetTruncated: boolean;
+      cappedAtLimit: { recapTargets: boolean };
+    };
+    expect(metadata.recapTargetsPruned).toBe(10_000);
+    expect(metadata.cappedAtLimit.recapTargets).toBe(true);
+    expect(metadata.runBudgetTruncated).toBe(true);
   });
 
   it("caps processed-update retention to one bounded run and reports a lower-bound backlog", async () => {

--- a/worker/src/cron/telegram-recap-store.ts
+++ b/worker/src/cron/telegram-recap-store.ts
@@ -623,21 +623,33 @@ export async function projectTelegramRecapTerminalOutcome(
 
 export interface TelegramRecapRetentionResult {
   deletedTargets: number;
+  cappedAtLimit: boolean;
 }
 
 /** Delete only bounded recap audit rows; pending delivery retention remains owned by its queue. */
 export async function pruneTelegramRecapTargets(
   db: D1Database,
   nowSec: number,
-  options: { aggregateRetentionSec?: number; terminalRetentionSec?: number } = {},
+  options: { aggregateRetentionSec?: number; terminalRetentionSec?: number; limit?: number } = {},
 ): Promise<TelegramRecapRetentionResult> {
   const aggregateCutoff = nowSec - (options.aggregateRetentionSec ?? 30 * 86400);
   const terminalCutoff = nowSec - (options.terminalRetentionSec ?? 90 * 86400);
+  const limit = options.limit;
+  if (limit != null && (!Number.isInteger(limit) || limit <= 0)) {
+    throw new RangeError("Telegram recap target prune limit must be a positive integer.");
+  }
   const result = await db.prepare(`
     DELETE FROM telegram_recap_targets
-     WHERE (status IN ('sent', 'skipped_no_changes', 'skipped_paused', 'skipped_stale')
-            AND updated_at < ?)
-        OR (status IN ('cancelled', 'expired', 'execution_unknown', 'failed_permanent') AND updated_at < ?)
-  `).bind(aggregateCutoff, terminalCutoff).run();
-  return { deletedTargets: Number(result.meta?.changes ?? 0) };
+     WHERE rowid IN (
+       SELECT rowid
+         FROM telegram_recap_targets
+        WHERE (status IN ('sent', 'skipped_no_changes', 'skipped_paused', 'skipped_stale')
+               AND updated_at < ?)
+           OR (status IN ('cancelled', 'expired', 'execution_unknown', 'failed_permanent') AND updated_at < ?)
+        ORDER BY updated_at ASC, recap_key ASC
+        LIMIT ?
+     )
+  `).bind(aggregateCutoff, terminalCutoff, limit ?? 10_000).run();
+  const deletedTargets = Number(result.meta?.changes ?? 0);
+  return { deletedTargets, cappedAtLimit: deletedTargets >= (limit ?? 10_000) };
 }

--- a/worker/src/cron/telegram-retention-cleanup.ts
+++ b/worker/src/cron/telegram-retention-cleanup.ts
@@ -183,7 +183,11 @@ export async function runTelegramRetentionCleanup(
   const expiredTargetsReconciled = await reconcileExpiredTelegramAlertJobTargets(db, nowSec, signal);
   throwIfAborted(signal);
 
-  const recapTargets = await pruneTelegramRecapTargets(db, nowSec);
+  const recapTargets = await runWithOverloadRetry(
+    () => pruneTelegramRecapTargets(db, nowSec, { limit: RETENTION_DELETE_BATCH_LIMIT }),
+    3,
+    signal,
+  );
   throwIfAborted(signal);
 
   const processedUpdates = await pruneTelegramProcessedUpdatesCapped(db, nowSec, signal, options);
@@ -791,7 +795,7 @@ export async function runTelegramRetentionCleanup(
       groupWelcomeCachePruned: groupWelcomeCache.pruned,
       reEngagementWarningCachePruned: reEngagementWarningCache.pruned,
       expiredTargetsReconciled,
-      runBudgetTruncated: processedUpdates.remainingBacklog.count > 0 || retentionDeleteCapped,
+      runBudgetTruncated: processedUpdates.remainingBacklog.count > 0 || recapTargets.cappedAtLimit || retentionDeleteCapped,
       deleteBatchLimit: RETENTION_DELETE_BATCH_LIMIT,
       highVolumeDeleteLimit: HIGH_VOLUME_RETENTION_DELETE_LIMIT,
       processedUpdatePruneBudget: {
@@ -808,7 +812,7 @@ export async function runTelegramRetentionCleanup(
       },
       cappedAtLimit: {
         processedUpdates: processedUpdates.cappedAtLimit,
-        recapTargets: false,
+        recapTargets: recapTargets.cappedAtLimit,
         targetPlanItems: targetPlanItems.cappedAtLimit,
         targetPlans: targetPlans.cappedAtLimit,
         targetPlanPages: targetPlanPages.cappedAtLimit,


### PR DESCRIPTION
### Motivation
- The daily Telegram retention job invoked an uncapped `DELETE` on `telegram_recap_targets`, which can exceed D1 per-statement time/budget limits when many recap targets are eligible and abort the whole retention run. 
- Other retention paths use bounded deletes plus the `runWithOverloadRetry` wrapper, so recap pruning needed to follow the same bounded/retry pattern to avoid scheduled availability failures.

### Description
- Change `pruneTelegramRecapTargets` to delete via a `rowid` subquery with `ORDER BY` and `LIMIT` and accept an optional `limit` parameter, returning `{ deletedTargets, cappedAtLimit }` to signal truncation. 
- Add input validation for the `limit` and compute `cappedAtLimit` from the returned changes. 
- Run recap pruning inside `runTelegramRetentionCleanup` through `runWithOverloadRetry(...)` using `RETENTION_DELETE_BATCH_LIMIT`, and surface `recapTargets.cappedAtLimit` in `runBudgetTruncated` / `cappedAtLimit` metadata. 
- Add regression tests covering the capped-prune helper and the retention cron path, and update existing tests to assert the new `cappedAtLimit` field.

### Testing
- Ran the focused Vitest suites: `npm exec vitest -- worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts worker/src/cron/__tests__/telegram-retention-cleanup.test.ts --run`, and all tests passed. 
- Verified TypeScript build with `cd worker && npx tsc --noEmit`, which succeeded. 
- Ran `git diff --check` for whitespace/checks with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceaca988332b06e911ee1f5cb39)