### PR TITLE
Recover disabled address provider breakers

### DIFF
--- a/worker/src/cron/sync-stablecoins/__tests__/enrich-prices-primary-provider-collection.test.ts
+++ b/worker/src/cron/sync-stablecoins/__tests__/enrich-prices-primary-provider-collection.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CIRCUIT_SOURCE } from "../../../lib/constants";
-import { shouldAttemptFetch } from "../../../lib/circuit-breaker";
-import { buildPrimaryPricePlan } from "../enrich-prices-primary-provider-collection";
+import { recoverBreakerOnNoCandidate, shouldAttemptFetch } from "../../../lib/circuit-breaker";
+import {
+  buildPrimaryPricePlan,
+  collectPrimaryProviderQuotes,
+  type PrimaryPricePlan,
+} from "../enrich-prices-primary-provider-collection";
 import type { PeggedAsset } from "../enrich-prices-shared";
 
 vi.mock("../../../lib/circuit-breaker", () => ({
@@ -58,5 +62,72 @@ describe("buildPrimaryPricePlan", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       "[primary-prices] All live primary fetch circuits are open; continuing with local DL/DEX inputs only",
     );
+  });
+});
+
+describe("collectPrimaryProviderQuotes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recovers stale circuit breakers for every disabled address price provider", async () => {
+    const plan: PrimaryPricePlan = {
+      candidates: [TEST_ASSET],
+      nowSec: 1_700_000_000,
+      dexRows: new Map(),
+      dexPriceSources: new Map(),
+      dexPriceSourceTelemetry: {
+        staleRows: [],
+        malformedRows: [],
+      },
+      geckoIds: [],
+      pythFeedIds: new Map(),
+      coinbaseSymbols: [],
+      krakenSymbols: [],
+      shouldFetchBitstamp: false,
+      redstoneSymbols: [],
+      navPriceIds: [],
+      addressProviders: [],
+      addressProviderTargets: new Map(),
+      sourceAllowed: {
+        cg: false,
+        cgTicker: false,
+        pyth: false,
+        binance: false,
+        kraken: false,
+        bitstamp: false,
+        coinbase: false,
+        redstone: false,
+        curve: false,
+        curveOracle: false,
+        addressProviders: {
+          "dexscreener-address": false,
+          "dexpaprika-address": false,
+          "coingecko-onchain-address": false,
+          "alchemy-address": false,
+          "moralis-address": false,
+          "birdeye-address": false,
+        },
+      },
+    };
+
+    await collectPrimaryProviderQuotes({ plan, db: {} as D1Database });
+
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(
+      expect.anything(),
+      CIRCUIT_SOURCE.DEXSCREENER_ADDRESS_PRICES,
+    );
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(
+      expect.anything(),
+      CIRCUIT_SOURCE.DEXPAPRIKA_PRICES,
+    );
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(expect.anything(), CIRCUIT_SOURCE.CG_ONCHAIN);
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(expect.anything(), CIRCUIT_SOURCE.ALCHEMY_PRICES);
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(expect.anything(), CIRCUIT_SOURCE.MORALIS_PRICES);
+    expect(recoverBreakerOnNoCandidate).toHaveBeenCalledWith(expect.anything(), CIRCUIT_SOURCE.BIRDEYE_PRICES);
   });
 });

--- a/worker/src/cron/sync-stablecoins/enrich-prices-primary-provider-collection.ts
+++ b/worker/src/cron/sync-stablecoins/enrich-prices-primary-provider-collection.ts
@@ -721,8 +721,13 @@ export async function collectPrimaryProviderQuotes(params: {
       await recordOutcomeDecision(db, ADDRESS_PROVIDER_CIRCUIT_SOURCE[provider], outcome);
     }
   }
-  if (!plan.addressProviders.includes("dexscreener-address")) {
-    await recoverBreakerOnNoCandidate(db, CIRCUIT_SOURCE.DEXSCREENER_ADDRESS_PRICES);
+  for (const [provider, source] of Object.entries(ADDRESS_PROVIDER_CIRCUIT_SOURCE) as Array<[
+    AddressPriceProviderKey,
+    string,
+  ]>) {
+    if (!plan.addressProviders.includes(provider)) {
+      await recoverBreakerOnNoCandidate(db, source);
+    }
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Production disables exact-address providers via `ADDRESS_PRICE_PROVIDERS_ENABLED = "none"`, which left stale circuit breaker rows for disabled address-only providers and could cause persistent public-health degradations.
- The sync logic only auto-recovered the DexScreener address breaker, so other disabled address-provider circuits could remain open after deployment.

### Description
- Update `collectPrimaryProviderQuotes` to iterate `ADDRESS_PROVIDER_CIRCUIT_SOURCE` and call `recoverBreakerOnNoCandidate(db, source)` for every address provider that is not in `plan.addressProviders`, instead of only handling `dexscreener-address`.
- Add a regression test in `worker/src/cron/sync-stablecoins/__tests__/enrich-prices-primary-provider-collection.test.ts` that exercises the disabled `addressProviders: []` path and asserts `recoverBreakerOnNoCandidate` is invoked for each address-provider circuit source.
- Adjust test imports to include `collectPrimaryProviderQuotes` and `PrimaryPricePlan` types so the new test can construct a plan and invoke the collector.

### Testing
- Ran the targeted Vitest suite: `npx vitest run worker/src/cron/sync-stablecoins/__tests__/enrich-prices-primary-provider-collection.test.ts` and all tests passed.
- Ran worker TypeScript checks: `npm run typecheck:worker` with no type errors after the change.
- Ran cron connection budget check: `npm run check:cron-connections` and it reported connection headroom within budget.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea084083328667b6daa0d6c15a)