### PR TITLE
Bind Safety Score V9 fresh captures to candidate asset set

### DIFF
--- a/scripts/maintenance/analyze-safety-score-v9-calibration.mjs
+++ b/scripts/maintenance/analyze-safety-score-v9-calibration.mjs
@@ -1048,7 +1048,7 @@ export function repeatedRealAAssetIds(candidateRealAIds, qualifyingByCapture) {
     .sort(compareText);
 }
 
-function validateFreshCaptureSeries(values, candidateRealAIds) {
+function validateFreshCaptureSeries(values, candidateAssetIds, candidateRealAIds) {
   const captures = Array.isArray(values) ? values : [];
   for (const [index, capture] of captures.entries()) {
     assertReplay(capture, `fresh capture ${index + 1}`);
@@ -1066,12 +1066,12 @@ function validateFreshCaptureSeries(values, candidateRealAIds) {
       (capture) =>
         stableStringify(capture.pipeline.candidateIdentity) === stableStringify(ordered[0].pipeline.candidateIdentity),
     );
+  const expectedAssetSet = stableStringify([...candidateAssetIds].sort(compareText));
   const assetSetsMatch =
     ordered.length > 0 &&
     ordered.every(
       (capture) =>
-        stableStringify([...capture.pipeline.fixedInput.activeAssetIds].sort(compareText)) ===
-        stableStringify([...ordered[0].pipeline.fixedInput.activeAssetIds].sort(compareText)),
+        stableStringify([...capture.pipeline.fixedInput.activeAssetIds].sort(compareText)) === expectedAssetSet,
     );
   const distinctAndOrdered =
     new Set(baseIds).size === 3 &&
@@ -1362,6 +1362,7 @@ export function analyzeV9Calibration(baseline, candidate, fridayEvidence = {}) {
   const changes = changesFromBaseline(baseline, candidate);
   const captureSeries = validateFreshCaptureSeries(
     fridayEvidence.freshCaptures,
+    candidate.pipeline.fixedInput.activeAssetIds,
     realA.map((entry) => entry.assetId),
   );
   const composite = evaluateCompositeReplay(fridayEvidence.composite);

--- a/worker/scripts/__tests__/analyze-safety-score-v9-calibration.test.ts
+++ b/worker/scripts/__tests__/analyze-safety-score-v9-calibration.test.ts
@@ -349,6 +349,24 @@ describe("Safety Score V9 calibration analysis", { timeout: 30_000 }, () => {
     expect(report.gates.threeFreshCaptures).toBe(false);
   });
 
+  it("rejects fresh captures that omit candidate assets", () => {
+    const activeAssetIds = ["usdc-circle", "usdt-tether"];
+    const baseline = productionReplay(BASE_CLOCK_SEC, { activeAssetIds });
+    const candidate = productionReplay(BASE_CLOCK_SEC, { activeAssetIds });
+    const captures = [0, 100, 200].map((offset) =>
+      productionReplay(BASE_CLOCK_SEC + offset, { activeAssetIds: ["usdc-circle"] }),
+    );
+
+    const report = analyzeV9Calibration(baseline, candidate, { freshCaptures: captures });
+
+    expect(report.fridayEvidence.freshCaptures).toMatchObject({
+      providedCount: 3,
+      distinctAndOrdered: true,
+      assetSetsMatch: false,
+    });
+    expect(report.gates.threeFreshCaptures).toBe(false);
+  });
+
   it("rejects a stale capture even when all three generations are distinct", () => {
     const replay = productionReplay();
     const captures = [0, 100, 200].map((offset) => productionReplay(BASE_CLOCK_SEC + offset));


### PR DESCRIPTION
### Motivation
- Prevent Friday fresh-capture evidence from supplying a reduced cohort that omits candidate assets and thereby bypasses capture-stability and three-capture gates.
- Ensure the fresh-capture series is validated against the full analyzed candidate replay asset set rather than only matching captures to each other.
- Preserve the existing repeated real‑A intersection logic while eliminating the possibility of an evidence bundle omitting problematic assets.

### Description
- Change `validateFreshCaptureSeries` to accept the candidate active asset IDs (`candidateAssetIds`) and require each fresh capture's `pipeline.fixedInput.activeAssetIds` to match that expected asset set instead of comparing captures to the first capture. (`scripts/maintenance/analyze-safety-score-v9-calibration.mjs`)
- Pass `candidate.pipeline.fixedInput.activeAssetIds` into the fresh-capture validation call inside `analyzeV9Calibration`. (`scripts/maintenance/analyze-safety-score-v9-calibration.mjs`)
- Keep the existing `repeatedRealAAssetIds` logic unchanged so repeated real‑A checks remain scoped to `realA` IDs. (`scripts/maintenance/analyze-safety-score-v9-calibration.mjs`)
- Add a regression test that supplies three distinct captures containing only `usdc-circle` while the candidate includes `usdt-tether`, asserting the fresh-capture gate fails. (`worker/scripts/__tests__/analyze-safety-score-v9-calibration.test.ts`)

### Testing
- Ran the focused Vitest file: `npx vitest run worker/scripts/__tests__/analyze-safety-score-v9-calibration.test.ts`, and the test suite passed (`21 tests passed`).
- Ran type checking for tests with `npm run typecheck:tests`, which completed successfully.
- Verified local lint/checks: `git diff --check` produced no spacing/patch errors (pre-commit validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea9a38833297a0910384e275d9)