### PR TITLE
fix(telegram): fence execution-unknown acknowledgement deletes

### DIFF
--- a/worker/src/api/__tests__/admin-telegram-delivery-control.test.ts
+++ b/worker/src/api/__tests__/admin-telegram-delivery-control.test.ts
@@ -208,4 +208,100 @@ describe("admin Telegram delivery control", () => {
     expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_pending_alerts").get()).toEqual({ count: 1 });
     expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_dead_letters").get()).toEqual({ count: 0 });
   });
+
+  it("refuses a stale execution-unknown acknowledgement without partial archival side effects", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1_000);
+    const { sqlite, db } = setupLatestSchema();
+    const insert = sqlite.prepare(
+      `INSERT INTO telegram_pending_alerts (
+         chat_id, message_html, created_at, updated_at, dedupe_key, source_type,
+         delivery_state, delivery_owner, delivery_generation, delivery_started_at,
+         delivery_completed_at, last_error_class
+       ) VALUES (?, ?, ?, ?, ?, 'risk_alert', 'execution_unknown', ?, 1, ?, ?, ?)`
+    );
+    const firstId = Number(insert.run(
+      "42",
+      "<b>First ambiguous alert</b>",
+      NOW - 600,
+      NOW - 300,
+      "42:v1:0:ambiguous:first",
+      "pending-owner",
+      NOW - 500,
+      NOW - 300,
+      "pending_effect_owner_lost",
+    ).lastInsertRowid);
+    const secondId = Number(insert.run(
+      "43",
+      "<b>Second ambiguous alert</b>",
+      NOW - 600,
+      NOW - 300,
+      "43:v1:0:ambiguous:second",
+      "pending-owner",
+      NOW - 500,
+      NOW - 300,
+      "pending_effect_owner_lost",
+    ).lastInsertRowid);
+    let raced = false;
+    const racingDb = {
+      ...db,
+      prepare(sql: string) {
+        const statement = db.prepare(sql);
+        if (!sql.includes("DELETE FROM telegram_pending_alerts") || !sql.includes("SELECT COUNT(*)")) {
+          return statement;
+        }
+        return {
+          ...statement,
+          bind: (...args: unknown[]) => {
+            const bound = statement.bind(...args);
+            return {
+              ...bound,
+              run: async () => {
+                if (!raced) {
+                  raced = true;
+                  sqlite.prepare(
+                    `UPDATE telegram_pending_alerts
+                        SET delivery_state = 'sent', delivery_generation = 2
+                      WHERE id = ?`,
+                  ).run(secondId);
+                }
+                return await bound.run();
+              },
+            } as D1PreparedStatement;
+          },
+        } as D1PreparedStatement;
+      },
+    } as D1Database;
+
+    const response = await handleAdminTelegramDeliveryControl({
+      db: racingDb,
+      request: request("POST", {
+        action: "acknowledge_execution_unknown",
+        pendingIds: [firstId, secondId],
+        operatorReason: "Concurrent change should not partially archive",
+      }),
+      trustedAdmin: true,
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ missingIds: [secondId] });
+    expect(sqlite.prepare(
+      "SELECT id, delivery_state, delivery_generation FROM telegram_pending_alerts ORDER BY id",
+    ).all()).toEqual([
+      { id: firstId, delivery_state: "execution_unknown", delivery_generation: 1 },
+      { id: secondId, delivery_state: "sent", delivery_generation: 2 },
+    ]);
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_dead_letters").get()).toEqual({ count: 0 });
+    const audit = sqlite.prepare(
+      "SELECT result, http_status, details_json FROM admin_action_audit WHERE action = 'telegram-execution-unknown-acknowledge'",
+    ).get() as { result: string; http_status: number; details_json: string };
+    expect(audit.result).toBe("error");
+    expect(audit.http_status).toBe(409);
+    expect(JSON.parse(audit.details_json)).toMatchObject({
+      pendingIds: [firstId, secondId],
+      missingIds: [secondId],
+      operatorReason: "Concurrent change should not partially archive",
+    });
+  });
+
 });

--- a/worker/src/cron/telegram-pending/cleanup.ts
+++ b/worker/src/cron/telegram-pending/cleanup.ts
@@ -62,6 +62,48 @@ const PENDING_ALERT_DEAD_LETTER_COLUMNS = [
 const PENDING_ALERT_DEAD_LETTER_COLUMN_SQL = PENDING_ALERT_DEAD_LETTER_COLUMNS.join(", ");
 export const EXPIRED_PENDING_CLEANUP_BATCH_LIMIT = PENDING_DELETE_CHUNK_SIZE;
 
+function executionUnknownCasPredicate(alias: string): string {
+  return `(
+    ${alias}.id = ?
+    AND ${alias}.delivery_state = 'execution_unknown'
+    AND ${alias}.delivery_owner IS ?
+    AND ${alias}.delivery_generation = ?
+    AND COALESCE(${alias}.delivery_completed_at, ${alias}.delivery_started_at, ${alias}.created_at) = ?
+  )`;
+}
+
+function executionUnknownCasBinds(row: DeadLetterPendingRow): [number, string | null, number, number] {
+  return [
+    row.id,
+    row.delivery_owner ?? null,
+    row.delivery_generation ?? 0,
+    row.delivery_completed_at ?? row.delivery_started_at ?? row.created_at,
+  ];
+}
+
+async function deleteExactExecutionUnknownPendingRowsForAdmin(
+  db: D1Database,
+  rows: readonly DeadLetterPendingRow[],
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  const predicates = rows.map(() => executionUnknownCasPredicate("telegram_pending_alerts")).join(" OR ");
+  const countPredicates = rows.map(() => executionUnknownCasPredicate("candidate")).join(" OR ");
+  const binds = rows.flatMap(executionUnknownCasBinds);
+  const result = await db
+    .prepare(
+      `DELETE FROM telegram_pending_alerts
+        WHERE (${predicates})
+          AND (
+            SELECT COUNT(*)
+              FROM telegram_pending_alerts candidate
+             WHERE ${countPredicates}
+          ) = ?`,
+    )
+    .bind(...binds, ...binds, rows.length)
+    .run();
+  return Number(result.meta?.changes ?? 0);
+}
+
 async function projectTerminalPendingRows(
   db: D1Database,
   rows: readonly DeadLetterPendingRow[],
@@ -181,10 +223,42 @@ export async function acknowledgeExecutionUnknownPendingAlertsForAdmin(
     return { acknowledgedIds: [], missingIds };
   }
 
-  const deleted = await archiveExecutionUnknownPendingRows(db, rows, nowSec);
+  const deleted = await deleteExactExecutionUnknownPendingRowsForAdmin(db, rows);
   if (deleted !== rows.length) {
-    throw new Error(`Archived ${deleted} of ${rows.length} Telegram execution-unknown rows`);
+    const refreshed = await db
+      .prepare(
+        `SELECT ${PENDING_ALERT_DEAD_LETTER_COLUMN_SQL}
+           FROM telegram_pending_alerts
+          WHERE delivery_state = 'execution_unknown'
+            AND id IN (${inClause.sql})`,
+      )
+      .bind(...inClause.binds)
+      .all<DeadLetterPendingRow>();
+    const originalById = new Map(rows.map((row) => [row.id, executionUnknownCasBinds(row).join("\u0000")]));
+    const unchangedIds = new Set(
+      (refreshed.results ?? [])
+        .filter((row) => originalById.get(row.id) === executionUnknownCasBinds(row).join("\u0000"))
+        .map((row) => row.id),
+    );
+    return { acknowledgedIds: [], missingIds: ids.filter((id) => !unchangedIds.has(id)) };
   }
+
+  const deadLettered = await deadLetterTerminalPendingRows(
+    db,
+    rows,
+    nowSec,
+    "execution_unknown_archived",
+  );
+  if (!deadLettered) {
+    throw new Error("Failed to dead-letter acknowledged Telegram execution-unknown rows");
+  }
+  await projectTerminalPendingRows(
+    db,
+    rows,
+    "execution_unknown",
+    nowSec,
+    "execution_unknown_archived",
+  );
   return { acknowledgedIds: rows.map((row) => row.id), missingIds: [] };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent partial archival of `execution_unknown` pending alerts when an acknowledgement request races with concurrent admin actions or automatic cleanup. 
- Ensure the operator's `operatorReason` is always recorded for either the successful acknowledgement or the 409 stale-row error path. 
- Preserve the exact-set / no-partial-mutation contract of the admin acknowledgement route.

### Description
- Replace the previous per-row CAS delete loop with a single guarded delete that only removes the selected set when every row still matches its original id/owner/generation/timestamp identity in one statement. 
- Only after the guarded exact-set delete succeeds do we run `deadLetterTerminalPendingRows()` and `projectTerminalPendingRows()`; if the guarded delete does not remove the full set we refresh matching rows and return the existing 409 `missingIds` path without producing dead-letter or projection side effects. 
- Add a regression test that simulates a concurrent change during `acknowledge_execution_unknown` and verifies the handler returns `409`, no partial deletes or dead-letters occur, and the error audit records the operator reason (test updated at `worker/src/api/__tests__/admin-telegram-delivery-control.test.ts`). 
- Files changed: `worker/src/cron/telegram-pending/cleanup.ts` and `worker/src/api/__tests__/admin-telegram-delivery-control.test.ts`.

### Testing
- Ran the focused Vitest file with `npx vitest run worker/src/api/__tests__/admin-telegram-delivery-control.test.ts` and all tests passed. 
- Type-checked the worker code with `cd worker && npx tsc --noEmit` and it succeeded. 
- Ran repo sanity checks `npm run check:cron-sync` and `npm run check:cron-connections`, both succeeded. 
- The new regression test exercises the race scenario and confirms no partial archival, dead-letter write, or missing audit occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cec93108332bc8cb1ba025dcd8a)