### PR TITLE
fix(v9): rebind CDP metric applicability evidence

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
@@ -1045,6 +1045,65 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
     expect(right.v9FactSetDigest).toBe(left.v9FactSetDigest);
   });
 
+  it("rebinds CDP not-applicable metric evidence refs to the mechanism review evidence", () => {
+    const cdp = extension();
+    cdp.assets[0]!.archetype = "cdp";
+    cdp.assets[0]!.mechanismRiskReview = {
+      archetype: "cdp",
+      collateralizationRatio: 1.5,
+      liquidationCapacityRatio: null,
+      metricApplicability: {
+        collateralizationRatio: { state: "measured" },
+        liquidationCapacityRatio: {
+          state: "not-applicable",
+          rationale: "No liquidation venue exists for this fixture branch.",
+          evidenceRefIds: ["extension-evidence:mechanism:liquidation-capacity-ratio"],
+        },
+      },
+      collateralizationParameters: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+      liquidationMechanics: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+      backstop: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+      branchIsolation: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+      shutdownAndBadDebt: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+      structuralRedemption: {
+        status: status("known", "v9.backing.mechanism-review"),
+        quality: "strong",
+        failureDomains: [],
+      },
+    };
+
+    const compiled = compileSafetyScoreV9FactSetFromFixedInput(exactFixedInput(), cdp).assets[0]!;
+    if (compiled.mechanismRiskReview.review?.archetype !== "cdp") throw new Error("Fixture archetype changed");
+
+    const applicability = compiled.mechanismRiskReview.review.metricApplicability.liquidationCapacityRatio;
+    expect(applicability.state).toBe("not-applicable");
+    if (applicability.state !== "not-applicable") throw new Error("Fixture applicability changed");
+    const metricEvidenceRefs = applicability.evidenceRefIds;
+    expect(metricEvidenceRefs).toEqual(compiled.mechanismRiskReview.status.evidenceRefIds);
+    expect(metricEvidenceRefs).toEqual(["alpha:research-overlay"]);
+    expect(compiled.evidence.map((evidence) => evidence.evidenceId)).toContain(metricEvidenceRefs[0]);
+  });
+
   it("turns unavailable classifications, valuation, dependencies, and controls into typed gaps", () => {
     const incomplete = extension();
     const asset = incomplete.assets[0]!;

--- a/worker/src/lib/safety-score-v9-fact-set.ts
+++ b/worker/src/lib/safety-score-v9-fact-set.ts
@@ -734,6 +734,14 @@ function normalizeMechanismReview(
   let hasStale = false;
   let hasIncomplete = false;
 
+  if (normalized.archetype === "cdp") {
+    for (const applicability of Object.values(normalized.metricApplicability)) {
+      if (applicability.state !== "not-applicable") continue;
+      applicability.evidenceRefIds = evidenceIds;
+      for (const evidenceId of evidenceIds) componentEvidenceIds.add(evidenceId);
+    }
+  }
+
   for (const [componentKey, value] of Object.entries(normalized)) {
     if (value === null || typeof value !== "object" || !("status" in value)) continue;
     const fact = value as { status: V9FactStatusV2 };


### PR DESCRIPTION
### Motivation

- CDP `metricApplicability` entries emitted extension-sentinel evidence references like `extension-evidence:mechanism:...` which were not rebound during fact-set normalization, allowing internal sentinel IDs to leak into compiled/public facts.
- The change ensures nested metric applicability evidence references are normalized to the canonical mechanism-review evidence so compiled facts remain referentially consistent.

### Description

- In `worker/src/lib/safety-score-v9-fact-set.ts` `normalizeMechanismReview` now injects the canonical mechanism review evidence IDs into CDP `metricApplicability` entries that are `not-applicable` and records those evidence IDs for the component.
- This change rebinds any `extension-evidence:mechanism:*` sentinel IDs to the real compiled evidence ID produced by `componentResearchEvidence` for the mechanism review.
- Added a focused regression test in `worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts` that builds a CDP fixture with a `not-applicable` metric, compiles the fact set, and asserts the metric applicability `evidenceRefIds` match the mechanism review evidence and correspond to an actual compiled evidence entry.

### Testing

- Ran the focused test suite with `npm test -- worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts`, which completed with all tests passing (32 tests passed).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit`, which succeeded without errors.
- Note: an initial attempt using the Jest-style `--runInBand` flag failed because `vitest` does not recognize that option, but the correct `npm test` run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea06148332921c49e15b5c136c)