### PR TITLE
fix(data): align USDB bridge controller identity

### DIFF
--- a/shared/data/stablecoins/coins/usdb-blast.json
+++ b/shared/data/stablecoins/coins/usdb-blast.json
@@ -104,7 +104,7 @@
         "reviewNote": "Fixed-block reads resolve USDYieldManager.blastBridge() to L1BlastBridge 0x3a05...9115 and both bridge contracts' OTHER_BRIDGE() pointers to each other.",
         "mappingVersion": "bridge-route-facts-v1",
         "controllerChain": "ethereum",
-        "controllerAddress": "0x4300000000000000000000000000000000000005",
+        "controllerAddress": "0xa230285d5683C74935aD14c446e137c8c8828438",
         "failureDomainKeys": [
           "contract:ethereum:0xa230285d5683c74935ad14c446e137c8c8828438",
           "contract:ethereum:0x3a05e5d33d7ab3864d53aaec93c8301c1fa49115",


### PR DESCRIPTION
### Motivation
- Fix an inconsistent bridge-route metadata pairing where `controllerChain: "ethereum"` had been paired with a Blast L2 address, which produced incorrect derived controller identities in downstream consumers.

### Description
- Update `shared/data/stablecoins/coins/usdb-blast.json` to restore the route `controllerAddress` to the Ethereum USDYieldManager `0xa230285d5683C74935aD14c446e137c8c8828438` and preserve the reviewed Blast L2 `failureDomainKeys` so route evidence and coverage remain intact.

### Testing
- Ran `npm run check:stablecoin-data` (OK), `npm run test -- shared/lib/stablecoins/__tests__/schema.test.ts` (all tests passed), and `git diff --check` (no issues); `npm run check:generated-artifacts` was attempted but failed due to an unrelated stale `src/generated/sitemap-dates.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cecbeec8332a929d2cac693360c)