### PR TITLE
Fix parity gate handling of missing V9 cards

### DIFF
--- a/scripts/maintenance/check-safety-score-v9-parity.mjs
+++ b/scripts/maintenance/check-safety-score-v9-parity.mjs
@@ -60,7 +60,10 @@ let justified = 0;
 const violations = [];
 for (const v8Card of v8Graded) {
   const v9Card = v9ById.get(v8Card.id);
-  if (!v9Card) continue; // active-set drift between captures is not a parity violation
+  if (!v9Card) {
+    violations.push({ id: v8Card.id, v8Grade: v8Card.grade, unjustified: ["missing-v9-card"] });
+    continue;
+  }
   if (v9Card.grade !== "NR") continue;
   const codes = (v9Card.nrReasons ?? []).map((reason) => reason.code);
   const unjustified = codes.filter((code) => !STAYS_NR.has(code));


### PR DESCRIPTION
### Motivation
- The V9 parity-check script could silently skip V8-graded assets that were absent from the V9 replay, allowing truncated or mismatched replay inputs to pass the gate despite the script's contract that every V8-graded asset must be checked.

### Description
- Update `scripts/maintenance/check-safety-score-v9-parity.mjs` so that when a V8-graded asset is missing from the V9 replay it is recorded as a parity violation with an `"missing-v9-card"` unjustified reason, while preserving the existing NR/allowlist evaluation for present V9 cards.

### Testing
- Created temporary fixtures and ran the script: an empty V9 replay with `--replay <v9-empty.json>` and `--v8-cards <v8.json>` now exits non-zero and prints `missing-v9-card` violations, and a matching V9 replay (`v9-ok.json`) still results in `parity gate PASSED`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceaf46c83329a16f4515d00d20a)