### PR TITLE
fix(dex): mark empty Orca direct fetches unavailable

### DIFF
--- a/worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts
+++ b/worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts
@@ -1386,7 +1386,7 @@ describe("fetchOrcaPools", () => {
     expect(pools.degraded).toBe(true);
   });
 
-  it("skips pools below TVL threshold", async () => {
+  it("marks Orca pages with no pools above the TVL threshold as unavailable", async () => {
     mockJsonFetch({
       data: [{
         address: "pool1",
@@ -1404,8 +1404,9 @@ describe("fetchOrcaPools", () => {
 
     const pools = await fetchOrcaPools();
     expect(pools.pools).toHaveLength(0);
-    expect(pools.ok).toBe(true);
+    expect(pools.ok).toBe(false);
     expect(pools.degraded).toBe(true);
+    expect(pools.errors).toContain("page 1 had no eligible pools despite minTvl filter");
   });
 
   it("returns empty array on HTTP error", async () => {
@@ -1416,14 +1417,14 @@ describe("fetchOrcaPools", () => {
     expect(pools.degraded).toBe(true);
   });
 
-  it("returns empty array when data is empty", async () => {
+  it("marks empty Orca responses as unavailable", async () => {
     mockJsonFetch({
       data: [],
       meta: { cursor: { next: null } },
     });
     const pools = await fetchOrcaPools();
     expect(pools.pools).toHaveLength(0);
-    expect(pools.ok).toBe(true);
+    expect(pools.ok).toBe(false);
     expect(pools.degraded).toBe(false);
   });
 

--- a/worker/src/cron/dex-liquidity/fetch-orca.ts
+++ b/worker/src/cron/dex-liquidity/fetch-orca.ts
@@ -275,7 +275,7 @@ export async function fetchOrcaPools(signal?: AbortSignal, db?: D1Database): Pro
     console.warn("[fetch-orca]", error);
   }
   return makeDexApiFetchResult(results, {
-    ok: successfulPages > 0,
+    ok: results.length > 0,
     degraded: degraded || errors.length > 0,
     errors,
     warnings,


### PR DESCRIPTION
### Motivation
- Prevent parseable-but-unusable Orca API pages from being classified as "partial" coverage when they produce no usable pool rows.
- Align `failedSources` / fallback signals with the intended meaning that a failed source is one that produced no usable data, not merely a successful HTTP/JSON response.

### Description
- Change Orca fetch success semantics so a fetch is `ok` only when at least one usable normalized pool row was produced by setting `ok: results.length > 0` in `fetch-orca.ts`.
- Preserve existing degraded/errors diagnostics for pages that were parsed but produced no eligible pools (e.g. below-TV L filter or malformed rows). 
- Update focused Orca unit tests in `dex-liquidity-direct-api.test.ts` to expect `ok: false` for below-threshold and empty responses and to assert the corresponding error message is emitted.

### Testing
- Ran the focused unit suite with `npm test -- --run worker/src/cron/__tests__/dex-liquidity-direct-api.test.ts` and all tests passed (`56 passed`).
- Type-checked the worker with `cd worker && npx tsc --noEmit` which completed without errors.
- Ran cron checks `npm run check:cron-sync` and `npm run check:cron-connections` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ce9ff74833281769466f857fa52)