### PR TITLE
fix(worker): tolerate missing DEX deployment outcomes

### DIFF
--- a/worker/src/lib/__tests__/dex-liquidity.test.ts
+++ b/worker/src/lib/__tests__/dex-liquidity.test.ts
@@ -73,6 +73,39 @@ describe("loadDexLiquiditySnapshot", () => {
     });
   });
 
+  it("falls back to liquidity rows when deployment outcomes table is missing", async () => {
+    const prepare = vi.fn()
+      .mockReturnValueOnce({
+        all: vi.fn().mockRejectedValue(new Error("D1_ERROR: no such table: dex_deployment_outcomes")),
+      })
+      .mockReturnValueOnce({
+        all: vi.fn().mockResolvedValue({ results: [liquidityRow()] }),
+      });
+    const db = { prepare } as unknown as D1Database;
+
+    await expect(loadDexLiquiditySnapshot(db)).resolves.toEqual({
+      map: {
+        "usdc-circle": {
+          liquidityScore: 91,
+          concentrationHhi: 0.2,
+          poolCount: 4,
+          chainCount: 2,
+          coverageClass: "primary",
+          coverageConfidence: 0.9,
+          liquidityEvidenceClass: "measured",
+          hasMeasuredLiquidityEvidence: true,
+          effectiveTvlUsd: 15_000_000,
+          balanceMeasuredTvlUsd: 12_000_000,
+          organicMeasuredTvlUsd: 9_000_000,
+          methodologyVersion: "5.10",
+        },
+      },
+      latestUpdatedAt: 123,
+    });
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(prepare.mock.calls[1][0]).not.toContain("dex_deployment_outcomes");
+  });
+
   it("keeps old rows evidence-neutral", async () => {
     const db = mockDb([
       liquidityRow({

--- a/worker/src/lib/dex-liquidity.ts
+++ b/worker/src/lib/dex-liquidity.ts
@@ -7,6 +7,7 @@ import {
 import { classifyLiquidityEvidence } from "@shared/lib/dex-liquidity-evidence";
 import { canonicalExitRouteAssetKey } from "@shared/lib/exit-route-identity";
 import { ACTIVE_STABLECOINS } from "@shared/lib/stablecoins/registry";
+import { isMissingTableError } from "./db";
 import { parseJsonObject } from "./json-parse";
 
 interface DexLiquidityRow {
@@ -133,27 +134,50 @@ function parseExitRouteDetails(
   };
 }
 
+async function loadDexLiquidityRows(db: D1Database): Promise<DexLiquidityRow[]> {
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT dl.stablecoin_id, dl.liquidity_score, dl.concentration_hhi,
+                dl.pool_count, dl.chain_count, dl.total_tvl_usd, dl.effective_tvl_usd,
+                dl.coverage_class, dl.coverage_confidence, dl.balance_measured_tvl_usd,
+                dl.organic_measured_tvl_usd, dl.score_components_json, dl.methodology_version, dl.updated_at,
+                dco.chain AS deployment_chain,
+                dco.contract_address AS deployment_contract_address,
+                dco.outcome AS deployment_outcome
+         FROM dex_liquidity dl
+         LEFT JOIN dex_deployment_outcomes dco ON dco.stablecoin_id = dl.stablecoin_id
+         WHERE ${DEX_LIQUIDITY_PUBLISHED_ROW_FILTER.replaceAll("publication_generation_id", "dl.publication_generation_id")}`,
+      )
+      .all<DexLiquidityRow>();
+    return rows.results ?? [];
+  } catch (error) {
+    if (!isMissingTableError(error)) throw error;
+    const rows = await db
+      .prepare(
+        `SELECT dl.stablecoin_id, dl.liquidity_score, dl.concentration_hhi,
+                dl.pool_count, dl.chain_count, dl.total_tvl_usd, dl.effective_tvl_usd,
+                dl.coverage_class, dl.coverage_confidence, dl.balance_measured_tvl_usd,
+                dl.organic_measured_tvl_usd, dl.score_components_json, dl.methodology_version, dl.updated_at,
+                NULL AS deployment_chain,
+                NULL AS deployment_contract_address,
+                NULL AS deployment_outcome
+         FROM dex_liquidity dl
+         WHERE ${DEX_LIQUIDITY_PUBLISHED_ROW_FILTER.replaceAll("publication_generation_id", "dl.publication_generation_id")}`,
+      )
+      .all<DexLiquidityRow>();
+    return rows.results ?? [];
+  }
+}
+
 export async function loadDexLiquiditySnapshot(db: D1Database): Promise<DexLiquidityLoadResult> {
-  const rows = await db
-    .prepare(
-      `SELECT dl.stablecoin_id, dl.liquidity_score, dl.concentration_hhi,
-              dl.pool_count, dl.chain_count, dl.total_tvl_usd, dl.effective_tvl_usd,
-              dl.coverage_class, dl.coverage_confidence, dl.balance_measured_tvl_usd,
-              dl.organic_measured_tvl_usd, dl.score_components_json, dl.methodology_version, dl.updated_at,
-              dco.chain AS deployment_chain,
-              dco.contract_address AS deployment_contract_address,
-              dco.outcome AS deployment_outcome
-       FROM dex_liquidity dl
-       LEFT JOIN dex_deployment_outcomes dco ON dco.stablecoin_id = dl.stablecoin_id
-       WHERE ${DEX_LIQUIDITY_PUBLISHED_ROW_FILTER.replaceAll("publication_generation_id", "dl.publication_generation_id")}`,
-    )
-    .all<DexLiquidityRow>();
+  const rows = await loadDexLiquidityRows(db);
 
   const map: DexLiquidityDbMap = {};
   const processedStablecoinIds = new Set<string>();
   const deploymentCoverageById = new Map<string, DeploymentCoverage>();
   let latestUpdatedAt: number | null = null;
-  for (const row of rows.results ?? []) {
+  for (const row of rows) {
     if (
       row.deployment_chain != null &&
       row.deployment_contract_address != null &&


### PR DESCRIPTION
### Motivation
- The shared DEX liquidity snapshot loader began unconditionally joining `dex_deployment_outcomes`, causing snapshot loads to reject when that optional rollout table is not present and degrading report-card/OG flows.

### Description
- Add a missing-table-aware row loader `loadDexLiquidityRows(db)` that tries the joined query and, on `isMissingTableError`, retries a `dex_liquidity`-only query that returns `NULL` deployment fields so the snapshot can still be produced.
- Import `isMissingTableError` and switch `loadDexLiquiditySnapshot()` to consume the new loader while preserving the existing deployment-coverage aggregation when outcomes exist.
- Add a focused regression test `falls back to liquidity rows when deployment outcomes table is missing` to `worker/src/lib/__tests__/dex-liquidity.test.ts` that asserts the fallback path and query shape.

### Testing
- Ran `npm run test -- --run worker/src/lib/__tests__/dex-liquidity.test.ts` and the test suite passed.
- Ran `node scripts/ci/pharos-change-contract.mjs --markdown` for change-contract checks and it completed successfully.
- Ran `cd worker && npx tsc --noEmit` (typecheck) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6ceb786083328da2592d40f20583)