### PR TITLE
Fix stale Telegram recap side effects

### DIFF
--- a/worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts
+++ b/worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts
@@ -240,6 +240,38 @@ describe("telegram recap store on latest SQLite schema", () => {
     expect(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_pending_alerts WHERE source_event_id = 'recap:42:2026-07-12:v1'").get()).toEqual({ count: 0 });
   });
 
+  it("does not commit disable cleanup or operation side effects for stale preferences", async () => {
+    const { sqlite, db } = setup();
+    subscriber(sqlite, "42");
+    await setTelegramRecapPreference(db, preferenceInput("42"));
+    await queueTelegramRecapTarget(db, target("42"));
+    sqlite.exec("CREATE TABLE recap_side_effects (chat_id TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)");
+
+    sqlite.prepare(
+      "UPDATE telegram_subscribers SET preference_generation = preference_generation + 1 WHERE chat_id = ?",
+    ).run("42");
+
+    await expect(setTelegramRecapPreference(db, {
+      chatId: "42", enabled: false, deliveryHourLocal: 9, nextDueAt: null, nowSec: NOW + 1,
+      expectedPreferenceGeneration: 1,
+    }, {
+      operationStatements: [db.prepare(
+        "INSERT INTO recap_side_effects (chat_id, applied_at) VALUES (?, ?)",
+      ).bind("42", NOW + 1)],
+    })).resolves.toBe(false);
+
+    expect(sqlite.prepare(
+      "SELECT enabled, next_due_at, preference_generation FROM telegram_recap_preferences p JOIN telegram_subscribers s USING (chat_id) WHERE p.chat_id = '42'",
+    ).get()).toEqual({ enabled: 1, next_due_at: NOW + 86400, preference_generation: 2 });
+    expect(sqlite.prepare(
+      "SELECT status, terminal_reason FROM telegram_recap_targets WHERE recap_key = 'recap:42:2026-07-11:v1'",
+    ).get()).toEqual({ status: "queued", terminal_reason: null });
+    expect(sqlite.prepare(
+      "SELECT COUNT(*) AS count FROM telegram_pending_alerts WHERE source_event_id = 'recap:42:2026-07-11:v1'",
+    ).get()).toEqual({ count: 1 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM recap_side_effects").get()).toEqual({ count: 0 });
+  });
+
   it("prunes aggregate rows at 30 days and every terminal outcome at 90 days", async () => {
     const { sqlite, db } = setup();
     sqlite.prepare(`INSERT INTO telegram_recap_targets

--- a/worker/src/cron/telegram-recap-store.ts
+++ b/worker/src/cron/telegram-recap-store.ts
@@ -163,8 +163,9 @@ export async function getTelegramRecapPreference(
 }
 
 /**
- * Set recap intent and bump the shared subscriber generation in one atomic
- * transaction. A stale expected generation is a no-op, never a lost update.
+ * Set recap intent and bump the shared subscriber generation behind the
+ * shared generation fence. A stale expected generation is a no-op, never a
+ * lost update, and never commits cleanup or webhook effect-fence side effects.
  */
 export async function setTelegramRecapPreference(
   db: D1Database,
@@ -176,7 +177,7 @@ export async function setTelegramRecapPreference(
   const generationGuard = expected == null ? "1 = 1" : "s.preference_generation = ?";
   const generationBinds = expected == null ? [] : [expected];
   const nextGeneration = expected == null ? null : expected + 1;
-  const statements: D1PreparedStatement[] = [
+  const preferenceStatements: D1PreparedStatement[] = [
     db.prepare(`
       INSERT INTO telegram_recap_preferences (
         chat_id, chat_kind, enabled, cadence, delivery_hour_local, next_due_at,
@@ -208,16 +209,35 @@ export async function setTelegramRecapPreference(
          AND ${expected == null ? "1 = 1" : "preference_generation = ?"}
     `).bind(input.chatId, ...(expected == null ? [] : [expected])),
   ];
+  await executeAtomicBatch(db, preferenceStatements);
+  // The first statement is deliberately guarded by the old generation. The
+  // second statement's changes count is not portable across D1 mocks, so read
+  // back the row and verify the requested state plus the expected bump before
+  // committing cleanup or effect-fence side effects.
+  const current = await getTelegramRecapPreference(db, input.chatId);
+  if (!current) return false;
+  const generationMatches = expected == null || current.preferenceGeneration === nextGeneration;
+  const applied = generationMatches && current.enabled === input.enabled &&
+    current.deliveryHourLocal === input.deliveryHourLocal && current.nextDueAt === input.nextDueAt;
+  if (!applied) return false;
+
+  const sideEffectStatements: D1PreparedStatement[] = [];
   if (!input.enabled) {
     // A disabled recap must not be delivered after the acknowledgement has
     // been sent. Keep the audit target, but cancel only intents that have not
     // crossed the Telegram effect boundary.
-    statements.push(
+    sideEffectStatements.push(
       db.prepare(`
         UPDATE telegram_recap_targets
            SET status = 'cancelled', terminal_reason = 'recap_disabled',
                completed_at = ?, updated_at = ?
          WHERE chat_id = ? AND status IN ('planned', 'queued')
+           AND EXISTS (
+             SELECT 1
+               FROM telegram_recap_preferences p
+              WHERE p.chat_id = telegram_recap_targets.chat_id
+                AND p.enabled = 0
+           )
       `).bind(input.nowSec, input.nowSec, input.chatId),
       db.prepare(`
         DELETE FROM telegram_pending_alerts
@@ -226,19 +246,18 @@ export async function setTelegramRecapPreference(
              SELECT recap_key FROM telegram_recap_targets
               WHERE chat_id = ? AND status = 'cancelled'
            )
+           AND EXISTS (
+             SELECT 1
+               FROM telegram_recap_preferences p
+              WHERE p.chat_id = telegram_pending_alerts.chat_id
+                AND p.enabled = 0
+           )
       `).bind(input.chatId, input.chatId),
     );
   }
-  statements.push(...(options.operationStatements ?? []));
-  await executeAtomicBatch(db, statements);
-  // The first statement is deliberately guarded by the old generation. The
-  // second statement's changes count is not portable across D1 mocks, so read
-  // back the row and verify the requested state plus the expected bump.
-  const current = await getTelegramRecapPreference(db, input.chatId);
-  if (!current) return false;
-  const generationMatches = expected == null || current.preferenceGeneration === nextGeneration;
-  return generationMatches && current.enabled === input.enabled &&
-    current.deliveryHourLocal === input.deliveryHourLocal && current.nextDueAt === input.nextDueAt;
+  sideEffectStatements.push(...(options.operationStatements ?? []));
+  await executeAtomicBatch(db, sideEffectStatements);
+  return true;
 }
 
 /** Return a bounded due page. Pagination is schedule-based, so no cursor is needed. */


### PR DESCRIPTION
### Motivation
- Prevent a stale `expectedPreferenceGeneration` from causing unguarded cleanup or webhook-operation marker side effects even when the guarded preference write did not apply.
- Ensure the recap preference generation fence behaves as a true effect fence so in-memory and persisted markers remain consistent after concurrent mutations.

### Description
- Split the recap write into two phases by running the guarded preference/generation statements first (as `preferenceStatements`) and verifying the persisted state before any side effects run.
- Move disable-cleanup and caller-supplied `operationStatements` into a post-verification `sideEffectStatements` batch that only runs when the guarded write actually applied.
- Add persisted-state guards to the cleanup SQL (`EXISTS` checks against `telegram_recap_preferences`) so cancellation/deletion only executes when the preference is truly disabled.
- Add a SQLite regression test `does not commit disable cleanup or operation side effects for stale preferences` that reproduces the stale-write PoC and asserts no side effects or operation statements were committed.

### Testing
- Ran the focused Vitest suite with `npx vitest run worker/src/cron/__tests__/telegram-recap-store-sqlite.test.ts` and all tests passed.
- Type-checked the worker code with `cd worker && npx tsc --noEmit` which completed successfully.
- Ran repo cron checks with `npm run check:cron-sync` and `npm run check:cron-connections`, both of which passed.
- Verified there are no obvious diff or lint errors via `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6cea17d883328cb0af3b0b6f04d8)