### PR TITLE
fix(dex): restrict Raydium pool-implied references

### DIFF
--- a/worker/src/lib/__tests__/dex-api-pool-shaping.test.ts
+++ b/worker/src/lib/__tests__/dex-api-pool-shaping.test.ts
@@ -330,8 +330,12 @@ describe("Raydium standard AMM execution gates", () => {
 describe("Raydium pool-implied counter-asset reference", () => {
   const USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
   const WSOL = "So11111111111111111111111111111111111111112";
+  const USYC = "7LWanZteUKtvFjv4MHYgKXXdAuCQYFPJysL9pxxdRQGn";
   const POOL = "58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2";
-  const chainAddressToId = new Map([[`solana:${USDC}`, "usdc-circle"]]);
+  const chainAddressToId = new Map([
+    [`solana:${USDC}`, "usdc-circle"],
+    [`solana:${USYC}`, "usyc-hashnote"],
+  ]);
   const symbolToChainScopedIds = new Map<string, Map<string, string[]>>();
 
   function raydiumPool(overrides: Partial<DexApiPool> = {}): DexApiPool {
@@ -474,6 +478,25 @@ describe("Raydium pool-implied counter-asset reference", () => {
     expect(shaped?.ammExecutionModel?.tokens[0]).toMatchObject({
       referencePriceUsd: 76.1,
       referencePriceSource: "source-token-usd",
+    });
+  });
+
+  it("does not imply references for unresolved tracked assets", () => {
+    const shaped = modelFor(
+      raydiumPool({
+        price: 0.5,
+        tokens: [
+          { address: USYC, symbol: "USYC", decimals: 6, priceUsd: null },
+          { address: USDC, symbol: "USDC", decimals: 6, priceUsd: null },
+        ],
+        balances: [1_000_000, 500_000],
+      }),
+    );
+
+    expect(shaped?.ammExecutionModel).toBeUndefined();
+    expect(shaped?.executionCapabilityGate).toEqual({
+      family: "raydium-amm",
+      reason: "incomplete-exact-capture",
     });
   });
 });

--- a/worker/src/lib/dex-api-pool-shaping.ts
+++ b/worker/src/lib/dex-api-pool-shaping.ts
@@ -321,6 +321,7 @@ function applyRaydiumPoolImpliedReferences(
       chainAddressToId,
       symbolToChainScopedIds,
     );
+    if (trackedAssetId) return tokens;
     resolved[position] = {
       address,
       symbol,
@@ -328,7 +329,6 @@ function applyRaydiumPoolImpliedReferences(
       balance,
       referencePriceUsd: implied,
       referencePriceSource: "pool-implied",
-      ...(trackedAssetId ? { trackedAssetId } : {}),
     };
   }
   return resolved;


### PR DESCRIPTION
### Motivation
- Prevent Raydium pool-implied pricing from repairing unresolved tokens that resolve to tracked stablecoins (including NAV/wrapper tokens), which could bypass the `navToken` guard and make manipulated/self-referential pool prices score-eligible.

### Description
- In `worker/src/lib/dex-api-pool-shaping.ts` the `applyRaydiumPoolImpliedReferences` function now aborts the pool-implied repair and returns the original `tokens` if the unresolved token maps to a tracked stablecoin ID (i.e. when `resolveStablecoinIdForDexApiToken` returns a `trackedAssetId`).
- The code no longer attaches a `trackedAssetId` to a `pool-implied` repaired token; the fix keeps the exact-capture gate intact for tracked assets and limits the fallback to untracked counter-assets only.
- Added a regression test in `worker/src/lib/__tests__/dex-api-pool-shaping.test.ts` that asserts a USYC/USDC Raydium pool remains `incomplete-exact-capture` when the tracked NAV (`USYC`) lacks an authoritative reference.

### Testing
- Ran the focused unit tests: `npx vitest run worker/src/lib/__tests__/dex-api-pool-shaping.test.ts --testNamePattern "Raydium pool-implied|Raydium standard"`, which passed (all matching tests succeeded).
- Type-checked the worker build with `cd worker && npx tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5df4c41d388332a056796a8aa269db)