### PR TITLE
fix(security): require human review for scheduled shock-coverage refresh PRs

### DIFF
--- a/.github/workflows/shock-coverage-refresh.yml
+++ b/.github/workflows/shock-coverage-refresh.yml
@@ -2,8 +2,9 @@ name: Shock Coverage Refresh
 
 # Keeps the V9 CDP shock-coverage fact inside its 72h policy freshness bound.
 #
-# Closes the last manual dependency under the LUSD and BOLD safety scores: the
-# measurement was previously produced by hand. Past the 72h bound the engine
+# Removes the manual measurement dependency under the LUSD and BOLD safety scores;
+# human review and merge remain required before score-bearing data reaches main.
+# Past the 72h bound the engine
 # fails closed to legacy LCR, dropping LUSD to `unsafe-backing:high` (~77/B+ ->
 # 59/C) and taking BOLD's rating down with it.
 #
@@ -123,12 +124,5 @@ jobs:
               --head "$BRANCH" \
               --title "chore(v9): refresh CDP shock-coverage measurements" \
               --body-file /tmp/shock-coverage-pr-body.md
-            # Owner ruling 2026-07-20: auto-merge this PR once required checks pass.
-            # The 72h freshness bound runs from the pinned block timestamp, not from
-            # merge time, so a refresh waiting on a human review can still go stale and
-            # drop LUSD to unsafe-backing:high. Branch protection still applies — this
-            # queues the merge behind the required checks, it does not bypass them, and
-            # the measurement is self-verifying (journals replay byte-identically or the
-            # job fails before opening a PR).
-            gh pr merge "$BRANCH" --squash --auto
+            echo "Refresh PR created. Human review and merge are required before the score-bearing data reaches main."
           fi


### PR DESCRIPTION
### Motivation
- Prevent automated auto-merge of score-bearing V9 CDP shock-coverage data produced from public RPC endpoints so a human reviews measurements before they reach `main`.
- Preserve the automation that measures, replays, and regenerates artifacts while closing the trust boundary that allowed a single untrusted RPC to produce a bot-merged change.

### Description
- Remove the automated merge step (`gh pr merge --squash --auto`) from `.github/workflows/shock-coverage-refresh.yml` and replace it with an explicit message that human review and merge are required.
- Update the workflow header comment to clarify that automation removes manual measurement but not the manual review/merge boundary.
- Commit the workflow file change as `fix(security): require review for shock coverage refresh PRs` so the scheduled job will continue to open PRs but will not auto-merge them.

### Testing
- Ran `git diff --check` and confirmed there were no whitespace or diff errors; the check passed.
- Parsed the modified workflow with `ruby -e 'YAML.load_file(...)'` to validate YAML syntax; parsing succeeded.
- Searched for `gh pr merge`, `--auto`, and `auto-merge` with `rg` to confirm the auto-merge invocation was removed; the search confirmed removal.
- Executed `MERGE_GATE_DRY_RUN=1 npm run test:merge-gate` in the local environment but the run was blocked because this checkout lacks a configured `origin/main` remote, so a full local merge-gate rehearsal could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e786134008332b9eadc16486a4078)