### PR TITLE
Fix NAV timestamp validation for report-card fixed inputs

### DIFF
--- a/worker/src/lib/__tests__/report-cards-snapshot.test.ts
+++ b/worker/src/lib/__tests__/report-cards-snapshot.test.ts
@@ -3,6 +3,7 @@ import { mockD1 } from "../../test-helpers/__shared/mock-d1";
 import { makeAsset, makeReportCardsDb } from "../../test-helpers/__shared/fixtures";
 import { handleReportCards } from "../../api/report-cards";
 import {
+  buildNavPriceById,
   buildReportCardsSnapshot,
   ReportCardsSnapshotUnavailableError,
   resolveExactRedemptionPublicationGeneration,
@@ -284,6 +285,52 @@ describe("buildReportCardsSnapshot", () => {
         methodologyVersion: "4.08",
       }),
     ).toThrow("producer methodology");
+  });
+
+  it("skips NAV price observations with fractional timestamps", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({
+          id: "thbill-theo",
+          symbol: "thBILL",
+          price: 1.01,
+          priceSource: "defillama",
+          priceObservedAt: nowSec - 10.5,
+          priceUpdatedAt: nowSec - 20,
+          priceSyncedAt: nowSec - 30,
+        }),
+        makeAsset({
+          id: "usdt-tether",
+          symbol: "USDT",
+          priceObservedAt: nowSec - 10.5,
+        }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById).toEqual({});
+  });
+
+  it("includes NAV price observations with integer timestamps", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({
+          id: "thbill-theo",
+          symbol: "thBILL",
+          price: 1.01,
+          priceSource: "defillama",
+          priceObservedAt: nowSec - 10,
+        }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById["thbill-theo"]).toMatchObject({
+      priceUsd: 1.01,
+      sourceId: "defillama",
+      observedAtSec: nowSec - 10,
+      confidence: "high",
+    });
   });
 
   it("throws when stablecoins cache is missing", async () => {

--- a/worker/src/lib/report-cards-snapshot.ts
+++ b/worker/src/lib/report-cards-snapshot.ts
@@ -85,7 +85,7 @@ function navPriceConfidence(
   return "unknown";
 }
 
-function buildNavPriceById(
+export function buildNavPriceById(
   peggedAssets: readonly StablecoinData[],
   clockSec: number,
 ): NonNullable<ReportCardsFixedInput["navPriceById"]> {
@@ -98,6 +98,7 @@ function buildNavPriceById(
     if (
       typeof observedAtSec !== "number" ||
       !Number.isFinite(observedAtSec) ||
+      !Number.isInteger(observedAtSec) ||
       observedAtSec < 0 ||
       observedAtSec > clockSec
     ) {


### PR DESCRIPTION
### Motivation
- Upstream NAV price timestamps could be fractional seconds but the `NavPriceObservationSchema` requires integer `observedAtSec`, which caused fixed-input validation to throw during the report-card publication path and reduced availability.
- The producer should drop malformed/fractional NAV timestamps rather than emit values that the downstream schema will reject. 

### Description
- Require integer Unix-second timestamps by adding an `Number.isInteger` check to `buildNavPriceById` so fractional `observedAtSec` values are skipped before emitting `navPriceById` (`worker/src/lib/report-cards-snapshot.ts`).
- Exported `buildNavPriceById` and added focused tests to assert that fractional NAV timestamps are dropped and integer timestamps are retained (`worker/src/lib/__tests__/report-cards-snapshot.test.ts`).

### Testing
- Ran the focused Vitest suite for the modified file with `npm exec vitest -- worker/src/lib/__tests__/report-cards-snapshot.test.ts --run` and all tests passed (33 tests).
- Verified TypeScript compilation with `cd worker && npx tsc --noEmit` which completed successfully.
- Ran documentation sync checks with `npm run check:doc-sync` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e69878ca08332ad19ba089b97c0af)