### PR TITLE
Fix NAV timestamp publication and shock refresh history

### DIFF
--- a/.github/workflows/shock-coverage-refresh.yml
+++ b/.github/workflows/shock-coverage-refresh.yml
@@ -70,6 +70,16 @@ jobs:
       - name: Assert both targets produced a fresh scoring measurement
         run: node scripts/ci/check-shock-coverage-freshness.mjs
 
+      # A refresh must pass the shock-coupled Vitest suites the PR gate runs.
+      # Fail here rather than opening a refresh PR that cannot clear its checks.
+      - name: Run shock-coupled test suites against the refreshed artifacts
+        run: |
+          npm exec vitest -- \
+            scripts/maintenance/__tests__/generate-safety-score-v9-shock-coverage-registry.test.ts \
+            worker/src/lib/__tests__/safety-score-v9-extension-shock.test.ts \
+            worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts \
+            --run
+
       - name: Detect journal diff
         id: diff
         run: |

--- a/docs/process/shock-coverage-refresh.md
+++ b/docs/process/shock-coverage-refresh.md
@@ -10,7 +10,7 @@ Until now the measurement was produced by hand. The [Shock Coverage Refresh](../
 
 `.github/workflows/shock-coverage-refresh.yml` runs at **03:41 UTC every other day** (`41 3 */2 * *`), plus `workflow_dispatch` for a manual refresh.
 
-Worst-case gap between runs is 48h, which leaves ~24h of slack against the 72h bound — enough to absorb one failed run, not two. The freshness clock runs on the **pinned block timestamp**, not on merge time, so review latency spends the same budget as scheduler latency.
+Worst-case gap between runs is 48h, which leaves ~24h of slack against the 72h bound — enough to absorb one failed run, not two. The freshness clock runs on the **pinned block timestamp**, not on merge time, so merge latency spends the same budget as scheduler latency; auto-merge (see [Merge path](#merge-path)) keeps that spend bounded by the required checks.
 
 ## What the workflow does
 
@@ -35,7 +35,7 @@ Each stage is a separate step, so a partial refresh (for example V1 succeeding a
 
 `main` is a protected branch with `enforce_admins: true` and force-pushes disabled, so the workflow **cannot** push measurements directly. It pushes to `automated/shock-coverage-refresh` and opens (or force-updates) a pull request against `main`, matching the [OG Refresh](../../.github/workflows/og-refresh.yml) pattern.
 
-Repository auto-merge is disabled, so **the PR requires a human merge**. This is the one manual step the automation does not remove. Merge it promptly: an unmerged refresh PR does not bank the freshness refresh.
+The workflow **arms auto-merge** on the PR it opens (`gh pr merge --squash --auto`; repository auto-merge is enabled) per the owner ruling of 2026-07-20. The merge queues behind the required checks — branch protection is not bypassed — and does not wait for a human review, because a refresh parked on review can still cross the 72h bound and drop LUSD to `unsafe-backing:high`. The trust boundary is the measurement itself: journals must replay byte-identically offline or the job fails before a PR exists (see above). Note that replay proves determinism, not RPC truthfulness; accepting public-RPC measurements without human review is a deliberate freshness-over-review trade (ruling reaffirmed 2026-07-21 by rejecting PR #611, which proposed removing auto-merge).
 
 ### Token
 

--- a/docs/process/shock-coverage-refresh.md
+++ b/docs/process/shock-coverage-refresh.md
@@ -22,6 +22,7 @@ Worst-case gap between runs is 48h, which leaves ~24h of slack against the 72h b
 | Regenerate registry       | `generate-safety-score-v9-shock-coverage-registry.ts`                       | Journal/registry projection is inconsistent              |
 | Verify self-consistency   | both generators with `--check`                                              | A generated artifact is stale after its own run          |
 | Assert scoring freshness  | `scripts/ci/check-shock-coverage-freshness.mjs`                             | A target is missing, incomplete, unattested, or too old  |
+| Run shock-coupled tests   | `vitest` over the registry, extension-shock, and fact-set suites            | The refreshed data would fail the PR gate — the PR would be unmergeable |
 
 Each stage is a separate step, so a partial refresh (for example V1 succeeding and V2 failing) fails the job **before** any branch, commit, or PR is created. Nothing unverified reaches the registry.
 
@@ -30,6 +31,8 @@ Each stage is a separate step, so a partial refresh (for example V1 succeeding a
 `shared/lib/safety-score-v9/archetypes/cdp.ts` rejects any measurement where `exactReplayPassed` is false or `replayVerification` is null, with reason `stress-measurement-exact-replay-not-passed`. A journal committed without a matching attestation therefore scores exactly as if it were missing.
 
 `generate-safety-score-v9-shock-coverage-attestations.ts` replays every journal whose sha256 does not already carry a passing attestation, and reuses cached entries otherwise. Any divergence throws without writing. Re-running it with `--check` verifies the attestations file is current.
+
+Each attestation entry carries its own `attestedAt` — the date that journal was actually byte-replayed. Cached entries keep their original date on later runs, and the registry projects the per-entry date, so a refresh only adds rows for newly attested journals and never rewrites historical `replayVerification` metadata. The file-level `attestedAt` only records the latest replay run.
 
 ## Merge path
 

--- a/scripts/maintenance/__tests__/generate-safety-score-v9-shock-coverage-registry.test.ts
+++ b/scripts/maintenance/__tests__/generate-safety-score-v9-shock-coverage-registry.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { ShockCoverageEvidenceV1Schema } from "../../lib/mechanism-measurement/shock-schema";
 import {
   SHOCK_COVERAGE_REGISTRY_PATH,
+  SHOCK_COVERAGE_REPLAY_ATTESTATIONS_PATH,
   buildShockCoverageMeasurementRegistry,
   collectShockCoverageJournalPaths,
   renderShockCoverageMeasurementRegistry,
@@ -20,6 +21,12 @@ describe("Safety Score v9 shock-coverage measurement registry", () => {
     const registry = buildShockCoverageMeasurementRegistry(REPO_ROOT);
     const rendered = renderShockCoverageMeasurementRegistry(registry);
     const committed = readFileSync(resolve(REPO_ROOT, SHOCK_COVERAGE_REGISTRY_PATH), "utf8");
+    const committedAttestations = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, SHOCK_COVERAGE_REPLAY_ATTESTATIONS_PATH), "utf8"),
+    ) as { attestations: { journalPath: string; journalSha256: string; attestedAt: string }[] };
+    const attestationByKey = new Map(
+      committedAttestations.attestations.map((entry) => [`${entry.journalPath}@${entry.journalSha256}`, entry]),
+    );
 
     expect(committed).toBe(rendered);
     expect(registry.measurements).toHaveLength(journalPaths.length);
@@ -55,8 +62,11 @@ describe("Safety Score v9 shock-coverage measurement registry", () => {
       expect(measurement.complete).toBe(journal.completeness.complete);
       expect(measurement.blockers).toEqual(journal.completeness.blockers);
       expect(measurement.exactReplayPassed).toBe(true);
+      const attestation = attestationByKey.get(`${measurement.journalPath}@${measurement.journalSha256}`);
+      if (!attestation) throw new Error(`Missing committed attestation for ${measurement.journalPath}`);
+      expect(attestation.attestedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       expect(measurement.replayVerification).toMatchObject({
-        attestedAt: "2026-07-20",
+        attestedAt: attestation.attestedAt,
         mode: "offline-byte-identical",
         callsConsumed: journal.calls.length,
         codePinsConsumed: journal.codePins.length,

--- a/scripts/maintenance/generate-safety-score-v9-shock-coverage-attestations.ts
+++ b/scripts/maintenance/generate-safety-score-v9-shock-coverage-attestations.ts
@@ -28,6 +28,7 @@ Options:
 interface Attestation {
   journalPath: string;
   journalSha256: string;
+  attestedAt: string;
   exactReplayPassed: boolean;
   callsConsumed: number;
   codePinsConsumed: number;
@@ -35,10 +36,25 @@ interface Attestation {
 
 function loadPassingAttestations(path: string): Map<string, Attestation> {
   if (!existsSync(path)) return new Map();
-  const parsed = JSON.parse(readFileSync(path, "utf8")) as { attestations?: Attestation[] };
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as {
+    attestedAt?: string;
+    attestations?: (Omit<Attestation, "attestedAt"> & { attestedAt?: string })[];
+  };
   const byKey = new Map<string, Attestation>();
   for (const attestation of parsed.attestations ?? []) {
-    if (attestation.exactReplayPassed) byKey.set(`${attestation.journalPath}@${attestation.journalSha256}`, attestation);
+    if (!attestation.exactReplayPassed) continue;
+    // Entries written before per-journal dates existed inherit the file-level
+    // run date they were attested under.
+    const attestedAt = attestation.attestedAt ?? parsed.attestedAt;
+    if (!attestedAt) continue;
+    byKey.set(`${attestation.journalPath}@${attestation.journalSha256}`, {
+      journalPath: attestation.journalPath,
+      journalSha256: attestation.journalSha256,
+      attestedAt,
+      exactReplayPassed: attestation.exactReplayPassed,
+      callsConsumed: attestation.callsConsumed,
+      codePinsConsumed: attestation.codePinsConsumed,
+    });
   }
   return byKey;
 }
@@ -69,6 +85,7 @@ void runCliEntrypoint(
     const outPath = resolve(REPO_ROOT, SHOCK_COVERAGE_REPLAY_ATTESTATIONS_PATH);
     const cached = loadPassingAttestations(outPath);
     const attestations: Attestation[] = [];
+    const runDate = new Date().toISOString().slice(0, 10);
     let replayed = 0;
 
     for (const absolutePath of collectShockCoverageJournalPaths(REPO_ROOT)) {
@@ -88,6 +105,7 @@ void runCliEntrypoint(
       attestations.push({
         journalPath,
         journalSha256,
+        attestedAt: runDate,
         exactReplayPassed: true,
         callsConsumed: journal.calls.length,
         codePinsConsumed: journal.codePins.length,
@@ -99,9 +117,10 @@ void runCliEntrypoint(
     const previous = existsSync(outPath) ? readFileSync(outPath, "utf8") : null;
     const previousAttestedAt =
       previous === null ? null : ((JSON.parse(previous) as { attestedAt?: string }).attestedAt ?? null);
-    // Hold attestedAt steady when nothing was replayed so the artifact does not
-    // churn on every scheduled run.
-    const attestedAt = replayed === 0 && previousAttestedAt ? previousAttestedAt : new Date().toISOString().slice(0, 10);
+    // Hold the file-level attestedAt steady when nothing was replayed so the
+    // artifact does not churn on every scheduled run. Per-entry attestedAt is
+    // the load-bearing date; this field only records the latest replay run.
+    const attestedAt = replayed === 0 && previousAttestedAt ? previousAttestedAt : runDate;
 
     const contents = `${JSON.stringify(
       {

--- a/scripts/maintenance/generate-safety-score-v9-shock-coverage-registry.ts
+++ b/scripts/maintenance/generate-safety-score-v9-shock-coverage-registry.ts
@@ -77,6 +77,7 @@ const ReplayAttestationsSchema = z
         .object({
           journalPath: z.string().min(1),
           journalSha256: z.string().regex(/^[0-9a-f]{64}$/),
+          attestedAt: z.string().date(),
           exactReplayPassed: z.boolean(),
           callsConsumed: z.number().int().nonnegative(),
           codePinsConsumed: z.number().int().nonnegative(),
@@ -191,7 +192,9 @@ export function projectShockCoverageJournal(
       exactReplayPassed && replayAttestation && replayAttestations
         ? {
             attestationPath: SHOCK_COVERAGE_REPLAY_ATTESTATIONS_PATH,
-            attestedAt: replayAttestations.attestedAt,
+            // Per-entry date: cached attestations keep the date they were
+            // actually replayed, so a refresh never rewrites historical rows.
+            attestedAt: replayAttestation.attestedAt,
             toolPath: replayAttestations.replayTool.path,
             toolVersion: replayAttestations.replayTool.version,
             mode: replayAttestations.replayTool.mode,

--- a/shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json
+++ b/shared/data/safety-score-v9/shock-coverage-replay-attestations-v1.json
@@ -11,6 +11,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-07-16-block-25546976-shock-coverage.json",
       "journalSha256": "51bcb1b5c177ad7b31ff0faab0b055b300edc7ea30be86c0f318ab9fe4056751",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 746,
       "codePinsConsumed": 54
@@ -18,6 +19,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-07-17-block-25551407-shock-coverage.json",
       "journalSha256": "b881670992f4dae0cc94d616e56b6ec617039f45257f056f27cb58acbb76ae65",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 746,
       "codePinsConsumed": 54
@@ -25,6 +27,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/bold-liquity/2026-07-20-block-25573021-shock-coverage.json",
       "journalSha256": "95a8ff85bf8f80f38c010ee1a0d9bb5f01971a90f80ce57067dea74dadb538ad",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 743,
       "codePinsConsumed": 54
@@ -32,6 +35,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2021-05-19-block-12464949-shock-coverage.json",
       "journalSha256": "57c4df5ebea77928fabce5ce262ce8a1097e7562e0b70490a823793311328089",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 2770,
       "codePinsConsumed": 14
@@ -39,6 +43,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2022-01-19-block-14039102-shock-coverage.json",
       "journalSha256": "8069ebeb9afa3e3fef9b1bb77249f6cce6813de4cee0b6927ddc66aaaa447e8e",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 3559,
       "codePinsConsumed": 14
@@ -46,6 +51,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2022-06-18-block-14986729-shock-coverage.json",
       "journalSha256": "61be3ee0859b67571afe0b4edffb16fb4ef8a6f08d793364d4ae2236defd737b",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 1507,
       "codePinsConsumed": 14
@@ -53,6 +59,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-07-16-block-25546976-shock-coverage.json",
       "journalSha256": "82bc042b7276ab49adba285117d171baf63cb0de85759eaffdb33d437eb8612d",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 265,
       "codePinsConsumed": 14
@@ -60,6 +67,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-07-17-block-25551407-shock-coverage.json",
       "journalSha256": "1743d17ab7921f5711926ae4c0eeac9cb25dbbade7f69ea6318aca5eb8e5ffca",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 265,
       "codePinsConsumed": 14
@@ -67,6 +75,7 @@
     {
       "journalPath": "shared/data/safety-score-v9/mechanism-measurements/lusd-liquity/2026-07-20-block-25573021-shock-coverage.json",
       "journalSha256": "f6e8ff87c6ec7afa15100553cea5b9a24372951d8e4c164c2b2b72561bc9a6b6",
+      "attestedAt": "2026-07-20",
       "exactReplayPassed": true,
       "callsConsumed": 268,
       "codePinsConsumed": 14

--- a/worker/src/lib/__tests__/report-cards-snapshot.test.ts
+++ b/worker/src/lib/__tests__/report-cards-snapshot.test.ts
@@ -3,6 +3,7 @@ import { mockD1 } from "../../test-helpers/__shared/mock-d1";
 import { makeAsset, makeReportCardsDb } from "../../test-helpers/__shared/fixtures";
 import { handleReportCards } from "../../api/report-cards";
 import {
+  buildNavPriceById,
   buildReportCardsSnapshot,
   ReportCardsSnapshotUnavailableError,
   resolveExactRedemptionPublicationGeneration,
@@ -284,6 +285,79 @@ describe("buildReportCardsSnapshot", () => {
         methodologyVersion: "4.08",
       }),
     ).toThrow("producer methodology");
+  });
+
+  it("floors fractional NAV price timestamps to integer seconds", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({
+          id: "thbill-theo",
+          symbol: "thBILL",
+          price: 1.01,
+          priceSource: "defillama",
+          priceObservedAt: nowSec - 10.5,
+        }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById["thbill-theo"]).toMatchObject({
+      priceUsd: 1.01,
+      sourceId: "defillama",
+      observedAtSec: nowSec - 11,
+      confidence: "high",
+    });
+  });
+
+  it("includes NAV price observations with integer timestamps unchanged", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({
+          id: "thbill-theo",
+          symbol: "thBILL",
+          price: 1.01,
+          priceSource: "defillama",
+          priceObservedAt: nowSec - 10,
+        }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById["thbill-theo"]).toMatchObject({
+      priceUsd: 1.01,
+      sourceId: "defillama",
+      observedAtSec: nowSec - 10,
+      confidence: "high",
+    });
+  });
+
+  it("tolerates sub-second future clock skew by flooring onto the clock bound", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({
+          id: "thbill-theo",
+          symbol: "thBILL",
+          priceObservedAt: nowSec + 0.5,
+        }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById["thbill-theo"]?.observedAtSec).toBe(nowSec);
+  });
+
+  it("drops NAV price observations with invalid or future timestamps and non-NAV assets", () => {
+    const navPriceById = buildNavPriceById(
+      [
+        makeAsset({ id: "thbill-theo", symbol: "thBILL", priceObservedAt: Number.NaN }),
+        makeAsset({ id: "susds-sky", symbol: "sUSDS", priceObservedAt: nowSec + 10 }),
+        makeAsset({ id: "sdai-sky", symbol: "sDAI", priceObservedAt: -5 }),
+        makeAsset({ id: "usdt-tether", symbol: "USDT", priceObservedAt: nowSec - 10 }),
+      ],
+      nowSec,
+    );
+
+    expect(navPriceById).toEqual({});
   });
 
   it("throws when stablecoins cache is missing", async () => {

--- a/worker/src/lib/report-cards-snapshot.ts
+++ b/worker/src/lib/report-cards-snapshot.ts
@@ -85,7 +85,7 @@ function navPriceConfidence(
   return "unknown";
 }
 
-function buildNavPriceById(
+export function buildNavPriceById(
   peggedAssets: readonly StablecoinData[],
   clockSec: number,
 ): NonNullable<ReportCardsFixedInput["navPriceById"]> {
@@ -94,15 +94,12 @@ function buildNavPriceById(
     if (!ACTIVE_META_BY_ID.get(asset.id)?.flags.navToken) continue;
     if (typeof asset.price !== "number" || !Number.isFinite(asset.price) || asset.price <= 0) continue;
     if (!asset.priceSource || asset.priceSource === "missing") continue;
-    const observedAtSec = asset.priceObservedAt ?? asset.priceUpdatedAt ?? asset.priceSyncedAt;
-    if (
-      typeof observedAtSec !== "number" ||
-      !Number.isFinite(observedAtSec) ||
-      observedAtSec < 0 ||
-      observedAtSec > clockSec
-    ) {
-      continue;
-    }
+    const rawObservedAtSec = asset.priceObservedAt ?? asset.priceUpdatedAt ?? asset.priceSyncedAt;
+    if (typeof rawObservedAtSec !== "number" || !Number.isFinite(rawObservedAtSec)) continue;
+    // NavPriceObservationSchema requires integer Unix seconds; floor sub-second
+    // provider precision rather than dropping the observation.
+    const observedAtSec = Math.floor(rawObservedAtSec);
+    if (observedAtSec < 0 || observedAtSec > clockSec) continue;
     entries.push([
       asset.id,
       {


### PR DESCRIPTION
## Summary
- floor fractional NAV observation timestamps at the fixed-input capture boundary so report-card publication retains valid NAV evidence
- preserve per-journal shock replay attestation dates so scheduled refreshes do not rewrite historical registry rows
- run shock-coupled suites before automation opens or updates a refresh PR, and document the current auto-merge contract

## Validation
- Node 24.16.0
- `npm exec vitest -- worker/src/lib/__tests__/report-cards-snapshot.test.ts scripts/maintenance/__tests__/generate-safety-score-v9-shock-coverage-registry.test.ts worker/src/lib/__tests__/safety-score-v9-extension-shock.test.ts worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts scripts/__tests__/validate-ci-parity.test.ts --run` (99 tests)
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run typecheck:worker`
- `npm run check:doc-sync`
- `npm run check:verified-doc-links`
- `npm run check:doc-source-paths`
- `npm run check:commit-derived-artifacts`
- `npm run check:generated-artifacts`
- explicit attestation and shock registry generator `--check` lanes
- normal pre-push commit-derived artifact guard

## Operational acceptance
The Worker path feeds the 15-minute `publish-report-card-cache` job. After deployment, verify the first matching production execution and the public report-card endpoint.
