### PR TITLE
fix(ci): keep mechanism refresh capture on trusted checkout

### DIFF
--- a/.github/workflows/protocol-api-mechanism-refresh.yml
+++ b/.github/workflows/protocol-api-mechanism-refresh.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Prepare target branch
+      - name: Validate target branch ownership
         env:
           ASSET_ID: ${{ matrix.asset }}
           GH_TOKEN: ${{ github.token }}
@@ -55,22 +55,17 @@ jobs:
               echo "::error title=Closed unmerged mechanism refresh::${BRANCH} has closed-unmerged PR history; refusing to recreate it."
               exit 1
             fi
-            git checkout -B "$BRANCH" origin/main
           elif [ "$REMOTE_STATUS" -ne 0 ]; then
             echo "::error title=Mechanism refresh branch lookup failed::Could not inspect ${BRANCH}."
             exit 1
           elif [ "$OPEN_PR_COUNT" -eq 1 ]; then
-            git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            git rebase origin/main
+            : "Existing open refresh PR may be updated after trusted capture completes."
           elif [ "$OPEN_PR_COUNT" -gt 1 ]; then
             echo "::error title=Ambiguous mechanism refresh PR::${BRANCH} has ${OPEN_PR_COUNT} open PRs."
             exit 1
           else
             git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
-            if git merge-base --is-ancestor "origin/$BRANCH" origin/main; then
-              git checkout -B "$BRANCH" origin/main
-            else
+            if ! git merge-base --is-ancestor "origin/$BRANCH" origin/main; then
               echo "::error title=Unowned mechanism refresh history::${BRANCH} has unmerged commits but no open PR; refusing to overwrite it."
               exit 1
             fi
@@ -174,6 +169,73 @@ jobs:
           set -euo pipefail
           ROOT="shared/data/safety-score-v9/mechanism-measurements/${ASSET_ID}"
           BRANCH="automated/protocol-api-mechanism-refresh/${ASSET_ID}"
+          ARTIFACT_TMP="$(mktemp -d)"
+          trap 'rm -rf "$ARTIFACT_TMP"' EXIT
+          NEW_FILES="$(git ls-files --others --exclude-standard -- "$ROOT")"
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            mkdir -p "$ARTIFACT_TMP/$(dirname "$path")"
+            cp "$path" "$ARTIFACT_TMP/$path"
+          done <<< "$NEW_FILES"
+
+          PR_HISTORY="$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --base main --head "$BRANCH" --limit 100 --json number,state,mergedAt)"
+          OPEN_PR_COUNT="$(jq '[.[] | select(.state == "OPEN")] | length' <<< "$PR_HISTORY")"
+          CLOSED_UNMERGED_COUNT="$(jq '[.[] | select(.state == "CLOSED" and .mergedAt == null)] | length' <<< "$PR_HISTORY")"
+          set +e
+          git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null
+          REMOTE_STATUS=$?
+          set -e
+          if [ "$REMOTE_STATUS" -eq 2 ]; then
+            if [ "$OPEN_PR_COUNT" -ne 0 ]; then
+              echo "::error title=Inconsistent mechanism refresh branch::${BRANCH} has an open PR but no remote branch."
+              exit 1
+            fi
+            if [ "$CLOSED_UNMERGED_COUNT" -ne 0 ]; then
+              echo "::error title=Closed unmerged mechanism refresh::${BRANCH} has closed-unmerged PR history; refusing to recreate it."
+              exit 1
+            fi
+            git checkout -B "$BRANCH" origin/main
+          elif [ "$REMOTE_STATUS" -ne 0 ]; then
+            echo "::error title=Mechanism refresh branch lookup failed::Could not inspect ${BRANCH}."
+            exit 1
+          elif [ "$OPEN_PR_COUNT" -eq 1 ]; then
+            git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            git rebase origin/main
+          elif [ "$OPEN_PR_COUNT" -gt 1 ]; then
+            echo "::error title=Ambiguous mechanism refresh PR::${BRANCH} has ${OPEN_PR_COUNT} open PRs."
+            exit 1
+          else
+            git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
+            if git merge-base --is-ancestor "origin/$BRANCH" origin/main; then
+              git checkout -B "$BRANCH" origin/main
+            else
+              echo "::error title=Unowned mechanism refresh history::${BRANCH} has unmerged commits but no open PR; refusing to overwrite it."
+              exit 1
+            fi
+          fi
+
+          while IFS=$'\t' read -r status path; do
+            [ -z "$status" ] && continue
+            if [ "$status" != "A" ]; then
+              echo "::error title=Non-append-only mechanism PR::${path} has status ${status}."
+              exit 1
+            fi
+            case "$path" in
+              "$ROOT"/*-protocol-api.json) ;;
+              *)
+                echo "::error title=Unexpected mechanism PR diff::${path} is outside the target artifact set."
+                exit 1
+                ;;
+            esac
+          done < <(git diff --name-status origin/main...HEAD)
+
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            mkdir -p "$(dirname "$path")"
+            cp "$ARTIFACT_TMP/$path" "$path"
+          done <<< "$NEW_FILES"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- "$ROOT"

--- a/docs/process/protocol-api-mechanism-refresh.md
+++ b/docs/process/protocol-api-mechanism-refresh.md
@@ -33,7 +33,9 @@ The weekly workflow runs an explicit matrix over `usde-ethena` and `usdf-falcon`
 - `automated/protocol-api-mechanism-refresh/usde-ethena`
 - `automated/protocol-api-mechanism-refresh/usdf-falcon`
 
-If a target already has an open refresh PR, the workflow checks out that branch and rebases it onto `origin/main` before capturing another snapshot. This preserves unmerged append-only history. With no open PR, the workflow inspects the remote branch and PR history before starting from `origin/main`; closed-unmerged, orphaned, or otherwise ambiguous branch state fails for operator review.
+The workflow captures and replays evidence from the trusted default checkout. It inspects the target branch and PR history before capture, but it does not check out an existing automation branch until after the focused producer test, repository-wide replay, and local additions-only artifact validation pass. This keeps repository-local actions, npm lifecycle behavior, and producer scripts sourced from `main` rather than from an unreviewed refresh PR branch.
+
+If a target already has an open refresh PR and a new artifact was produced, the token-gated update step copies the validated artifact aside, checks out that branch, rebases it onto `origin/main`, revalidates the pre-existing PR diff as append-only target artifacts, restores the new artifact, and commits it. This preserves unmerged append-only history. With no open PR, the workflow inspects the remote branch and PR history before starting from `origin/main`; closed-unmerged, orphaned, or otherwise ambiguous branch state fails for operator review.
 
 Jobs use target-specific concurrency, stage only the target's evidence directory, run focused tests and repository-wide replay, and require the PR diff to contain additions only under that directory. They open or update a non-auto-merge PR only after those checks pass.
 


### PR DESCRIPTION
### Motivation

- Prevent execution of unreviewed automation-branch code before validation because checking out a refresh PR branch pre-capture could let branch-controlled scripts persist state and later read exposed tokens.
- Keep repository-local workspace setup, producer capture, npm lifecycle, and focused tests sourced from the trusted default checkout so only validated artifacts can reach token-bearing update steps.

### Description

- Update `.github/workflows/protocol-api-mechanism-refresh.yml` to validate target branch ownership from the default checkout and avoid checking out/rebasing an existing `automated/protocol-api-mechanism-refresh/*` branch before capture and local validation. 
- Move the automation-branch `git fetch`/`checkout`/`rebase` logic into the token-gated `Open or update refresh PR` step and add an artifact staging flow that copies validated new artifacts aside, then checks out the automation branch, revalidates its append-only diff, restores the validated artifact, and commits it. 
- Add a temporary artifact staging area (`ARTIFACT_TMP`) and explicit copy/restore logic to ensure validated files are produced from the trusted checkout and cannot be injected by branch-controlled code. 
- Update `docs/process/protocol-api-mechanism-refresh.md` to describe the trusted-checkout capture and delayed branch-update semantics.

### Testing

- Ran `node scripts/ci/pharos-change-contract.mjs --markdown` to confirm the change-contract and matched docs, which completed successfully. 
- Ran `npm run check:script-entrypoints` and `npx prettier --check .github/workflows/protocol-api-mechanism-refresh.yml docs/process/protocol-api-mechanism-refresh.md`, both of which passed formatting and entrypoint validation. 
- Verified the workflow YAML parses with Ruby (`require "yaml"`) and ran `git diff --check`, which reported no issues; a local Python `yaml` check was skipped due to missing `PyYAML` in the environment. 
- No automated test failures were observed from the focused checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6161d3230c8332bbe782e62bce2501)