### PR TITLE
fix(redemption): model Tether $1,000 minimum redemption fee

### DIFF
--- a/shared/lib/redemption-backstop-configs/offchain-issuer/coverage-and-stablecoin-audit.ts
+++ b/shared/lib/redemption-backstop-configs/offchain-issuer/coverage-and-stablecoin-audit.ts
@@ -278,6 +278,7 @@ export const COVERAGE_AND_STABLECOIN_AUDIT_OFFCHAIN_CONFIGS: Record<string, Rede
       // T1: the issuer fee page states the redemption fee outright — 0.10%
       // (greater of that or $1,000) — a citable documented ceiling.
       feeBpsMax: 10,
+      minFeeUsd: 1000,
     },
     docs: [
       sourceRef("Tether Transparency", "https://tether.to/en/transparency", ["capacity"]),

--- a/worker/src/lib/__tests__/redemption-backstop-cost.test.ts
+++ b/worker/src/lib/__tests__/redemption-backstop-cost.test.ts
@@ -79,6 +79,23 @@ describe("resolveCostScenarioScores", () => {
     expect(scores?.institutional).toBe(100);
   });
 
+  it("applies minimum documented fees to small redemption scenarios", () => {
+    const scores = resolveCostScenarioScores(
+      {
+        kind: "dynamic-or-unclear",
+        confidence: "formula",
+        feeBpsMax: 10,
+        minFeeUsd: 1000,
+        feeDescription: "0.10% with a $1,000 minimum",
+      },
+      null,
+    );
+
+    expect(scores?.retail).toBe(40);
+    expect(scores?.activeUser).toBe(40);
+    expect(scores?.institutional).toBe(100);
+  });
+
   it("uses documented fee ranges for scenario scoring", () => {
     const scores = resolveCostScenarioScores(
       {


### PR DESCRIPTION
### Motivation
- The Tether cost model text states “0.10% with a $1,000 minimum” but only set `feeBpsMax: 10`, which caused scenario scoring to treat small redemptions as a 10 bps fee and understate documented costs.

### Description
- Add `minFeeUsd: 1000` to the `usdt-tether` `costModel` in `shared/lib/redemption-backstop-configs/offchain-issuer/coverage-and-stablecoin-audit.ts` so the scorer applies the documented greater-of floor.
- Add a focused regression test in `worker/src/lib/__tests__/redemption-backstop-cost.test.ts` that verifies retail and active-user scenario scores reflect the documented minimum while institutional scoring is preserved.

### Testing
- Ran `npm test -- worker/src/lib/__tests__/redemption-backstop-cost.test.ts` (Vitest) and the suite passed.
- Ran `npm run check:worker-boundary`, `npm run check:shared-cycles`, `npm run check:stablecoin-data`, and `cd worker && npx tsc --noEmit`, and each check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a609ea875c08332b8c6d16c9d90ecca)