### PR TITLE
Repair V9 shadow attribution refresh

### DIFF
--- a/shared/lib/__tests__/safety-score-v9-supply-attribution-journal.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-supply-attribution-journal.test.ts
@@ -110,6 +110,43 @@ describe("Safety Score V9 supply attribution journal runtime", () => {
     ).toThrow(/requires issuer-disclosure-plus-onchain origin/);
   });
 
+  it("admits only the bounded wM finality exception after the scoring clock", () => {
+    expect(() =>
+      createSupplyAttributionJournalV1(
+        payload({
+          completedAtSec: 220,
+          sourceObservedAtSec: 220,
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      createSupplyAttributionJournalV1(
+        payload({
+          completedAtSec: 221,
+          sourceObservedAtSec: 221,
+        }),
+      ),
+    ).toThrow(/scoring clock/);
+    expect(() =>
+      createSupplyAttributionJournalV1(
+        payload({
+          completedAtSec: 101,
+          sourceObservedAtSec: 102,
+        }),
+      ),
+    ).toThrow(/scoring clock/);
+    expect(() =>
+      createSupplyAttributionJournalV1(
+        payload({
+          assetId: "xaut-tether",
+          sourceId: "xaut.canonical-lock-mint-group-partition.v2",
+          sourceOriginClass: "issuer-disclosure-plus-onchain",
+          sourceObservedAtSec: 101,
+        }),
+      ),
+    ).toThrow(/scoring clock/);
+  });
+
   it("rejects incoherent state, future source evidence, secrets, and unknown fields", () => {
     expect(() =>
       createSupplyAttributionJournalV1(
@@ -123,7 +160,12 @@ describe("Safety Score V9 supply attribution journal runtime", () => {
     ).toThrow(/aggregate-only fallback/);
     expect(() =>
       createSupplyAttributionJournalV1(
-        payload({ sourceObservedAtSec: 101 }),
+        payload({
+          assetId: "xaut-tether",
+          sourceId: "xaut.canonical-lock-mint-group-partition.v2",
+          sourceOriginClass: "issuer-disclosure-plus-onchain",
+          sourceObservedAtSec: 101,
+        }),
       ),
     ).toThrow(/scoring clock/);
     expect(() =>

--- a/shared/lib/safety-score-v9-supply-attribution-journal.ts
+++ b/shared/lib/safety-score-v9-supply-attribution-journal.ts
@@ -6,6 +6,7 @@ export const SUPPLY_ATTRIBUTION_JOURNAL_ENTRY_MAX_BYTES = 1_152;
 export const SUPPLY_ATTRIBUTION_JOURNAL_FIXED_INPUT_MAX_BYTES = 32 * 1_024;
 export const SUPPLY_ATTRIBUTION_JOURNAL_FIXED_INPUT_MAX_ENTRIES_PER_ASSET = 2;
 export const SUPPLY_ATTRIBUTION_JOURNAL_FIXED_INPUT_MAX_ASSETS = 32;
+const WM_SUPPLY_ATTRIBUTION_MAX_POST_CLOCK_SEC = 120;
 
 const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 const AssetIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,127}$/);
@@ -118,14 +119,25 @@ const SupplyAttributionJournalV1PayloadSchema = z
           "Accepted supply attribution requires content and source time without a failed route",
       });
     }
+    const boundedWmPostClockObservation =
+      record.assetId === "wm-m0" &&
+      record.sourceId === "wm.reviewed-deployment-unit-partition.v1" &&
+      record.sourceObservedAtSec !== null &&
+      record.sourceObservedAtSec > record.scoringClockSec &&
+      record.sourceObservedAtSec - record.scoringClockSec <=
+        WM_SUPPLY_ATTRIBUTION_MAX_POST_CLOCK_SEC &&
+      record.sourceObservedAtSec <= record.completedAtSec;
     if (
       record.sourceObservedAtSec !== null &&
-      record.sourceObservedAtSec > record.scoringClockSec
+      record.sourceObservedAtSec > record.scoringClockSec &&
+      !boundedWmPostClockObservation
     ) {
       ctx.addIssue({
         code: "custom",
         path: ["sourceObservedAtSec"],
-        message: "Supply attribution evidence cannot follow its scoring clock",
+        message:
+          "Supply attribution evidence cannot follow its scoring clock " +
+          "outside the bounded wM finality exception",
       });
     }
 

--- a/src/app/v9-preview/client.test.tsx
+++ b/src/app/v9-preview/client.test.tsx
@@ -65,6 +65,7 @@ describe("SafetyScoreV9PreviewClient", () => {
     useReportCardsV9Preview.mockReturnValue({
       data: undefined,
       isLoading: false,
+      isFetching: false,
       error: new Error("offline"),
       refetch,
     });
@@ -74,6 +75,24 @@ describe("SafetyScoreV9PreviewClient", () => {
     expect(screen.getByRole("alert").textContent).toContain("live V8 ratings are unaffected");
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows visible progress while retrying the unavailable preview", () => {
+    useReportCardsV9Preview.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: true,
+      error: new Error("offline"),
+      refetch: vi.fn(),
+    });
+
+    render(<SafetyScoreV9PreviewClient />);
+
+    const alert = screen.getByRole("alert");
+    const retry = screen.getByRole("button", { name: "Retrying" });
+    expect(alert.getAttribute("aria-busy")).toBe("true");
+    expect((retry as HTMLButtonElement).disabled).toBe(true);
+    expect(retry.querySelector("svg")?.getAttribute("class")).toContain("animate-spin");
   });
 
   it("renders an accessible loading state", () => {

--- a/src/app/v9-preview/client.tsx
+++ b/src/app/v9-preview/client.tsx
@@ -192,7 +192,7 @@ function PreviewTable({ cards }: { cards: readonly SafetyScoreV9CurrentCard[] })
 }
 
 export function SafetyScoreV9PreviewClient() {
-  const { data, isLoading, error, refetch } = useReportCardsV9Preview();
+  const { data, isLoading, isFetching, error, refetch } = useReportCardsV9Preview();
   const [search, setSearch] = useState("");
   const gradeCounts = useMemo(() => buildGradeCounts(data?.cards ?? []), [data?.cards]);
   const cards = useMemo(() => {
@@ -217,14 +217,26 @@ export function SafetyScoreV9PreviewClient() {
 
   if (error || !data) {
     return (
-      <div className="pharos-empty-note flex flex-col items-start gap-3" role="alert">
+      <div
+        className="pharos-empty-note flex flex-col items-start gap-3"
+        role="alert"
+        aria-busy={isFetching || undefined}
+      >
         <div>
           <p className="font-medium text-foreground">V9 shadow ratings are temporarily unavailable.</p>
           <p className="mt-1 text-sm text-muted-foreground">The live V8 ratings are unaffected.</p>
         </div>
-        <Button variant="outline" size="sm" onClick={() => void refetch()}>
-          <RefreshCw className="h-4 w-4" aria-hidden="true" />
-          Retry
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isFetching}
+          onClick={() => void refetch()}
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${isFetching ? "animate-spin motion-reduce:animate-none" : ""}`}
+            aria-hidden="true"
+          />
+          {isFetching ? "Retrying" : "Retry"}
         </Button>
       </div>
     );

--- a/worker/src/lib/__tests__/safety-score-v9-supply-attribution.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-supply-attribution.test.ts
@@ -263,6 +263,52 @@ describe("Safety Score V9 lock/mint supply attribution", () => {
     });
   });
 
+  it("journals a bounded post-clock wM Solana-finality packet", async () => {
+    rpcMocks.observeWmReviewedDeploymentUnitPartitionAttempt.mockResolvedValue({
+      status: "accepted",
+      attribution: {
+        model: "reviewed-deployment-unit-partition-v1",
+        assetId: "wm-m0",
+        observedAtSec: OBSERVED_AT_SEC + 5,
+        captureStartedAtSec: OBSERVED_AT_SEC - 20,
+        captureEndedAtSec: OBSERVED_AT_SEC + 5,
+        registryFingerprint: "a".repeat(64),
+        routeInventoryDigest: "b".repeat(64),
+        deployments: [],
+      },
+    });
+    const fixedInput = {
+      activeAssetIds: ["wm-m0"],
+      clockSec: OBSERVED_AT_SEC,
+      sourceGeneration: "report-cards:v8:fixture",
+      baseInputGenerationId: `report-cards-input:v1:${"a".repeat(64)}`,
+      registryFingerprint: "a".repeat(64),
+      chainCirculatingById: { "wm-m0": {} },
+      aggregateCirculatingById: {
+        "wm-m0": {
+          circulating: { peggedUSD: 87_020_618.58982982 },
+          observedAtSec: OBSERVED_AT_SEC,
+        },
+      },
+    } as unknown as ReportCardsFixedInput;
+
+    const capture = await captureSafetyScoreV9SupplyAttribution(
+      fixedInput,
+      chainRpcs(),
+    );
+
+    expect(capture.attributionById["wm-m0"]).toMatchObject({
+      observedAtSec: OBSERVED_AT_SEC + 5,
+    });
+    expect(capture.journalRecords).toHaveLength(1);
+    expect(capture.journalRecords[0]).toMatchObject({
+      assetId: "wm-m0",
+      sourceId: "wm.reviewed-deployment-unit-partition.v1",
+      admissionCode: "supply-attribution.admission.accepted",
+      sourceObservedAtSec: OBSERVED_AT_SEC + 5,
+    });
+  });
+
   it.each([
     [
       "transparency-source-config-unavailable",


### PR DESCRIPTION
## Summary
- align the supply-attribution journal with the existing bounded wM Solana-finality contract
- preserve strict post-clock rejection for every other source and for out-of-envelope wM evidence
- show visible progress and block duplicate clicks while the V9 preview retries an unavailable endpoint

## Validation
- 350 critical contract tests
- focused attribution and preview tests
- root, test, and Worker typechecks
- worker boundary and shared cycle checks
- production static build and 1,240-page SEO check
- generated and commit-derived artifact checks

## Scope
V9 remains shadow-only. This change does not read, write, or alter the owner activation marker.