### PR TITLE
Bound V9 measured-route validation memory

### DIFF
--- a/shared/data/safety-score-v8/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v8/evaluation-build-manifest-v1.ts
@@ -50,7 +50,7 @@ const SAFETY_SCORE_V8_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/p4-exit-route-capacity.ts",
-      "sha256": "60d4a8c4a118e81d17c543cad8f56c4bf9fa60fe1316f3f12f6068d23503c759"
+      "sha256": "ef57d4c185f5234909c74f2eee53172a8ba6affb1aecde19ee0fb23ae85bb0bd"
     },
     {
       "path": "shared/lib/redemption-backstop-scoring.ts",
@@ -149,7 +149,7 @@ const SAFETY_SCORE_V8_EVALUATION_BUILD_MANIFEST = {
       "sha256": "e70bfddf6d253f0d37ed74449dff45e9af02858d80c0ca0931579796c080b85e"
     }
   ],
-  "digest": "23caca0fa0eb892e37086f96e929d36716f7f4ed74fac38fb1a204402a822f54"
+  "digest": "0695f2642ecb1af99cd74bad219a30de0c3338a905e07195fa62654bdabb900e"
 } as const;
 
 export const SAFETY_SCORE_V8_EVALUATION_BUILD_DIGEST =

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -50,7 +50,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "shared/lib/p4-exit-route-capacity.ts",
-      "sha256": "60d4a8c4a118e81d17c543cad8f56c4bf9fa60fe1316f3f12f6068d23503c759"
+      "sha256": "ef57d4c185f5234909c74f2eee53172a8ba6affb1aecde19ee0fb23ae85bb0bd"
     },
     {
       "path": "shared/lib/redemption-backstop-capacity.ts",
@@ -437,7 +437,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "4975f2ee93c68be8481d2dc4977128552912a7936ab9ba368c3ce2d91e4fd060"
     }
   ],
-  "digest": "4bb6c8ca74b479f0b3c6f8484d7ddab255db26442c01dd354b87f0ab80165109"
+  "digest": "16f5520f4ec41a51fa682e409701c5baeb3d1bceee13232dca58c98cb3bf4c69"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/lib/p4-exit-route-capacity.ts
+++ b/shared/lib/p4-exit-route-capacity.ts
@@ -661,15 +661,15 @@ function validateMeasuredExecutionProfile(
   context: { pool: P4DexRoutePoolInput; stablecoinId: string; observedAt: number },
 ): string[] {
   const issues: string[] = [];
-  const parsedEvm = DexMeasuredExecutionPublicProfileSchema.safeParse(profile);
-  const parsedSolana = SolanaMeasuredExecutionPublicProfileSchema.safeParse(profile);
-  const parsedTron = TronMeasuredExecutionPublicProfileSchema.safeParse(profile);
   const isNative = isNativeMeasuredExecutionAdapter(profile.adapterProfileId);
-  if (
-    isNative
-      ? !parsedSolana.success && !parsedTron.success
-      : !parsedEvm.success
-  ) issues.push("invalid-profile-schema");
+  const schemaValid =
+    profile.adapterProfileId === "raydium-clmm-trade-api-v1" ||
+    profile.adapterProfileId === "orca-whirlpool-jupiter-v1"
+      ? SolanaMeasuredExecutionPublicProfileSchema.safeParse(profile).success
+      : profile.adapterProfileId === "sunswap-v2-router-v1"
+        ? TronMeasuredExecutionPublicProfileSchema.safeParse(profile).success
+        : DexMeasuredExecutionPublicProfileSchema.safeParse(profile).success;
+  if (!schemaValid) issues.push("invalid-profile-schema");
   if (!isNative) {
     if (
       profile.adapterProfileId !== "uniswap-v3-quoter-v2" &&

--- a/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
@@ -3360,7 +3360,7 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
 
     expect(build(true).registryFingerprint).toBe(build(true, transferFact("permissionless")).registryFingerprint);
     expect(SAFETY_SCORE_V8_EVALUATION_BUILD_DIGEST).toBe(
-      "23caca0fa0eb892e37086f96e929d36716f7f4ed74fac38fb1a204402a822f54",
+      "0695f2642ecb1af99cd74bad219a30de0c3338a905e07195fa62654bdabb900e",
     );
   });
 


### PR DESCRIPTION
## Summary
- select one measured-execution public schema from the adapter family instead of deep-parsing EVM, Solana, and Tron schemas for every route
- preserve existing fail-closed profile, identity, freshness, and activation behavior
- reseal the V8 and V9 evaluation-build manifests for the shared implementation change

## Production evidence
The 2026-07-24 19:10 UTC `sync-dex-liquidity` execution on Worker `59955779-f0dc-4fac-85eb-9652e7ef90cc` reached the scoring boundary and terminated with `exceededMemory`. The last successful DEX generation predates the triple-schema validation change. The stale DEX generation prevents the already-published exact USDC Curve measurements from reaching the V9 shadow input.

## Validation
- `npm test -- --run shared/lib/__tests__/p4-exit-route-capacity.test.ts worker/src/cron/dex-liquidity/__tests__/route-observation-selection.test.ts worker/src/cron/__tests__/dex-liquidity-scoring.test.ts` (65 passed)
- `npm run typecheck`
- `npm run typecheck:worker`
- `npm run lint:typed -- --quiet`
- `npm run check:worker-boundary`
- `npm run check:shared-cycles`
- `npm run check:generated-artifacts`
- `git diff --check`

Operational acceptance requires the first successful post-deploy `sync-dex-liquidity` publication and the following V9 shadow build. No V9 activation state is changed.