### PR TITLE
Bound measured execution history loading

### DIFF
--- a/worker/src/cron/measured-execution/__tests__/persistence.test.ts
+++ b/worker/src/cron/measured-execution/__tests__/persistence.test.ts
@@ -109,8 +109,8 @@ function evidenceDb(input: {
   }>;
 }) {
   const preparedSql: string[] = [];
-  const makeStmt = (sql: string): Record<string, unknown> => ({
-    bind: () => makeStmt(sql),
+  const makeStmt = (sql: string, binds: unknown[] = []): Record<string, unknown> => ({
+    bind: (...nextBinds: unknown[]) => makeStmt(sql, nextBinds),
     first: async () => {
       if (sql.includes("state IN ('published', 'superseded')")) {
         return {
@@ -137,22 +137,39 @@ function evidenceDb(input: {
       return null;
     },
     all: async () => {
-      if (sql.includes("q.generation_id IN")) {
+      if (sql.includes("SELECT history_generation.generation_id")) {
         return {
-          results: (input.historical ?? []).map((entry, index) => {
-            const profile = entry.profile ?? null;
-            return {
-              generation_id: entry.generationId ?? profile?.quoteGenerationId ?? `quote-generation-failed-${index}`,
-              target_generation_id:
-                entry.targetGenerationId ?? profile?.targetGenerationId ?? `target-generation-failed-${index}`,
-              target_id: entry.target.targetId,
-              status: entry.status ?? "measured",
-              failure_reason: entry.failureReason ?? null,
-              quote_profile_json: profile ? JSON.stringify(profile) : null,
-              quote_published_at: entry.publishedAt ?? 1_900 - index,
-              target_json: JSON.stringify(entry.target),
-            };
-          }),
+          results: (input.historical ?? []).length > 0
+            ? [{ generation_id: "historical-generation" }]
+            : [],
+        };
+      }
+      if (sql.includes("SELECT DISTINCT target_id")) {
+        return {
+          results: [
+            ...new Set((input.historical ?? []).map((entry) => entry.target.targetId)),
+          ].map((target_id) => ({ target_id })),
+        };
+      }
+      if (sql.includes("q.generation_id IN")) {
+        const selectedTargetIds = new Set(JSON.parse(String(binds[2] ?? "[]")) as string[]);
+        return {
+          results: (input.historical ?? [])
+            .filter((entry) => selectedTargetIds.has(entry.target.targetId))
+            .map((entry, index) => {
+              const profile = entry.profile ?? null;
+              return {
+                generation_id: entry.generationId ?? profile?.quoteGenerationId ?? `quote-generation-failed-${index}`,
+                target_generation_id:
+                  entry.targetGenerationId ?? profile?.targetGenerationId ?? `target-generation-failed-${index}`,
+                target_id: entry.target.targetId,
+                status: entry.status ?? "measured",
+                failure_reason: entry.failureReason ?? null,
+                quote_profile_json: profile ? JSON.stringify(profile) : null,
+                quote_published_at: entry.publishedAt ?? 1_900 - index,
+                target_json: JSON.stringify(entry.target),
+              };
+            }),
         };
       }
       if (sql.includes("FROM dex_measured_execution_quotes")) {
@@ -383,6 +400,9 @@ describe("measured execution raw payload policy", () => {
         return null;
       },
       all: async () => {
+        if (sql.includes("SELECT history_generation.generation_id")) {
+          return { results: [] };
+        }
         if (sql.includes("FROM dex_measured_execution_quotes")) {
           return {
             results: [
@@ -468,11 +488,12 @@ describe("measured execution last-known-good selection", () => {
       consecutiveSuccessCount: 0,
       latestOperationalFailureAt: 2_010,
     });
-    const historicalSql = preparedSql.find((sql) => sql.includes("q.generation_id IN"));
+    const historicalSql = preparedSql.find((sql) => sql.includes("SELECT history_generation.generation_id"));
     expect(historicalSql).toContain("state = 'superseded'");
     expect(historicalSql).toContain("published_rows = history_generation.expected_rows");
     expect(historicalSql).toContain("SELECT COUNT(*)");
-    expect(historicalSql).not.toContain("q.status = 'measured'");
+    const historicalRowsSql = preparedSql.find((sql) => sql.includes("q.generation_id IN"));
+    expect(historicalRowsSql).not.toContain("q.status = 'measured'");
   });
 
   it("preserves mature conservative history across a latest operational failure", async () => {
@@ -651,6 +672,41 @@ describe("measured execution last-known-good selection", () => {
       latestFailureReason: "quote-missing",
       quoteGenerationId: "quote-generation-lkg",
       targetGenerationId: "target-generation-lkg",
+    });
+  });
+
+  it("loads and summarizes large historical target sets in bounded batches", async () => {
+    const latestTarget = fixtureTarget("ethereum");
+    const historical = Array.from({ length: 65 }, (_, index) => {
+      const target = fixtureTarget(`history-${index}`);
+      return {
+        target,
+        profile: fixtureProfile(target, {
+          targetGenerationId: `target-generation-${index}`,
+          quoteGenerationId: `quote-generation-${index}`,
+          quotedAt: 1_900,
+        }),
+        publishedAt: 1_900,
+      };
+    });
+    const { db, preparedSql } = evidenceDb({
+      target: latestTarget,
+      latest: {
+        status: "failed",
+        failureReason: "pool-revert",
+        profile: null,
+      },
+      historical,
+    });
+
+    const evidence = await loadLatestPublishedDexMeasuredQuoteEvidence(db);
+
+    expect(evidence?.byTargetId).toHaveLength(66);
+    expect(preparedSql.filter((sql) => sql.includes("q.generation_id IN"))).toHaveLength(2);
+    expect(evidence?.byTargetId.get(historical[64]!.target.targetId)).toMatchObject({
+      status: "measured",
+      resolution: "last-known-good",
+      quoteGenerationId: "quote-generation-64",
     });
   });
 });

--- a/worker/src/cron/measured-execution/persistence.ts
+++ b/worker/src/cron/measured-execution/persistence.ts
@@ -35,6 +35,7 @@ const GENERATION_RETENTION_SEC = 3 * 24 * 60 * 60;
 const GENERATION_PRUNE_MAX_PER_RUN = 16;
 const DEX_MEASURED_HISTORY_LOOKBACK_MAX_SEC =
   DEX_CURVE_STABLESWAP_MEASURED_FRESHNESS_MAX_SEC;
+const DEX_MEASURED_HISTORY_TARGET_BATCH_SIZE = 64;
 
 export function getDexMeasuredHistoryFreshnessSec(adapterProfileId: string): number {
   return getDexMeasuredExecutionFreshnessMaxSec(adapterProfileId);
@@ -532,12 +533,14 @@ export async function loadLatestPublishedDexMeasuredQuoteEvidence(
     )
     .bind(targetGenerationId)
     .all<TargetRow>();
+  const targetRows = targetResult.results ?? [];
   const targets = new Map(
-    (targetResult.results ?? []).map((row) => {
+    targetRows.map((row) => {
       const target = DexMeasuredExecutionTargetSchema.parse(parsePersistedJson(row.target_json, "DEX measured target JSON"));
       return [target.targetId, target] as const;
     }),
   );
+  targetRows.length = 0;
   if (
     (targetGeneration.expected_rows != null && targetGeneration.expected_rows !== targets.size) ||
     (targetGeneration.published_rows != null && targetGeneration.published_rows !== targets.size)
@@ -588,128 +591,178 @@ export async function loadLatestPublishedDexMeasuredQuoteEvidence(
       },
     ]);
   }
+  quoteRows.length = 0;
 
   // A transport or runtime-budget failure says nothing about executable depth.
   // Reuse the newest still-fresh measured row for that exact target identity;
   // consumer validation below retains the original quote clock and snapshot.
   try {
-    const lkgBlockedTargetIds = new Set<string>();
-    const historicalResult = await runWithOverloadRetry(
+    const historyGenerationResult = await runWithOverloadRetry(
       () =>
         db
           .prepare(
-            `SELECT q.generation_id, q.target_generation_id, q.target_id, q.status, q.failure_reason,
-              q.quote_profile_json, g.published_at AS quote_published_at, t.target_json
-       FROM dex_measured_execution_quotes q
-       JOIN surface_publication_generations g ON g.surface = ? AND g.generation_id = q.generation_id
-       JOIN dex_measured_execution_targets t
-         ON t.generation_id = q.target_generation_id AND t.target_id = q.target_id
-       WHERE q.generation_id IN (
-         SELECT history_generation.generation_id
-         FROM surface_publication_generations history_generation
-         WHERE history_generation.surface = ? AND history_generation.state = 'superseded'
-           AND history_generation.published_at IS NOT NULL AND history_generation.published_at >= ?
-           AND history_generation.expected_rows IS NOT NULL
-           AND history_generation.published_rows = history_generation.expected_rows
-           AND history_generation.expected_rows = (
-             SELECT COUNT(*)
-             FROM dex_measured_execution_quotes complete_quotes
-             WHERE complete_quotes.generation_id = history_generation.generation_id
-           )
-       )
-       ORDER BY g.published_at DESC, q.target_id`,
+            `SELECT history_generation.generation_id
+       FROM surface_publication_generations history_generation
+       WHERE history_generation.surface = ? AND history_generation.state = 'superseded'
+         AND history_generation.published_at IS NOT NULL AND history_generation.published_at >= ?
+         AND history_generation.expected_rows IS NOT NULL
+         AND history_generation.published_rows = history_generation.expected_rows
+         AND history_generation.expected_rows = (
+           SELECT COUNT(*)
+           FROM dex_measured_execution_quotes complete_quotes
+           WHERE complete_quotes.generation_id = history_generation.generation_id
+         )
+       ORDER BY history_generation.published_at DESC, history_generation.generation_id DESC`,
           )
-          .bind(
-            DEX_MEASURED_QUOTE_SURFACE,
-            DEX_MEASURED_QUOTE_SURFACE,
-            latestPublishedAt - DEX_MEASURED_HISTORY_LOOKBACK_MAX_SEC,
-          )
-          .all<HistoricalQuoteRow>(),
+          .bind(DEX_MEASURED_QUOTE_SURFACE, latestPublishedAt - DEX_MEASURED_HISTORY_LOOKBACK_MAX_SEC)
+          .all<{ generation_id: string }>(),
       3,
       signal,
     );
-    for (const row of historicalResult.results ?? []) {
-      const currentTarget = targets.get(row.target_id);
-      if (
-        currentTarget &&
-        latestPublishedAt - row.quote_published_at >
-          getDexMeasuredHistoryFreshnessSec(currentTarget.adapterProfileId)
-      ) {
-        continue;
-      }
-      const recordCycle = (cycle: DexMeasuredExecutionHistoryCycle) => {
-        const cycles = historyCyclesByTargetId.get(row.target_id) ?? [];
-        cycles.push(cycle);
-        historyCyclesByTargetId.set(row.target_id, cycles);
-      };
-      const recordIntegrityBarrier = () => {
-        recordCycle({
-          generationId: row.generation_id,
-          publishedAt: row.quote_published_at,
-          status: "failed",
-          operationalFailure: false,
-          profile: null,
-        });
-        lkgBlockedTargetIds.add(row.target_id);
-      };
-      const targetJson = parseJson(row.target_json, { onFailure: () => undefined });
-      const profileJson = row.quote_profile_json
-        ? parseJson(row.quote_profile_json, { onFailure: () => undefined })
-        : null;
-      if (!targetJson.ok || (row.quote_profile_json != null && !profileJson?.ok)) {
-        recordIntegrityBarrier();
-        continue;
-      }
-      const targetResult = DexMeasuredExecutionTargetSchema.safeParse(targetJson.value);
-      const profileResult = profileJson?.ok
-        ? DexMeasuredExecutionProfileSchema.safeParse(profileJson.value)
-        : null;
-      const profile = profileResult?.success ? profileResult.data : null;
-      if (
-        !targetResult.success ||
-        targetResult.data.targetId !== row.target_id ||
-        (row.status === "measured" &&
-          (profile === null ||
-            row.failure_reason !== null ||
-            profile.targetId !== row.target_id ||
-            profile.targetGenerationId !== row.target_generation_id ||
-            profile.quoteGenerationId !== row.generation_id)) ||
-        (row.status === "failed" && (profile !== null || !row.failure_reason?.trim()))
-      ) {
-        recordIntegrityBarrier();
-        continue;
-      }
-      recordCycle({
-        generationId: row.generation_id,
-        publishedAt: row.quote_published_at,
-        status: row.status,
-        operationalFailure: row.status === "failed" && isOperationalDexMeasuredFailure(row.failure_reason),
-        profile,
-      });
-      if (row.status === "failed" && !isOperationalDexMeasuredFailure(row.failure_reason)) {
-        lkgBlockedTargetIds.add(row.target_id);
-      }
+    const historyGenerationIds = (historyGenerationResult.results ?? []).map((row) => row.generation_id);
+    if (historyGenerationIds.length > 0) {
+      const historyGenerationIdsJson = JSON.stringify(historyGenerationIds);
+      const historicalTargetResult = await runWithOverloadRetry(
+        () =>
+          db
+            .prepare(
+              `SELECT DISTINCT target_id
+         FROM dex_measured_execution_quotes
+         WHERE generation_id IN (SELECT value FROM json_each(?))
+         ORDER BY target_id`,
+            )
+            .bind(historyGenerationIdsJson)
+            .all<{ target_id: string }>(),
+        3,
+        signal,
+      );
+      const historicalTargetIds = (historicalTargetResult.results ?? []).map((row) => row.target_id);
+      for (let offset = 0; offset < historicalTargetIds.length; offset += DEX_MEASURED_HISTORY_TARGET_BATCH_SIZE) {
+        const targetIdBatch = historicalTargetIds.slice(offset, offset + DEX_MEASURED_HISTORY_TARGET_BATCH_SIZE);
+        const lkgBlockedTargetIds = new Set<string>();
+        const historicalResult = await runWithOverloadRetry(
+          () =>
+            db
+              .prepare(
+                `SELECT q.generation_id, q.target_generation_id, q.target_id, q.status, q.failure_reason,
+                  q.quote_profile_json, g.published_at AS quote_published_at, t.target_json
+           FROM dex_measured_execution_quotes q
+           JOIN surface_publication_generations g ON g.surface = ? AND g.generation_id = q.generation_id
+           JOIN dex_measured_execution_targets t
+             ON t.generation_id = q.target_generation_id AND t.target_id = q.target_id
+           WHERE q.generation_id IN (SELECT value FROM json_each(?))
+             AND q.target_id IN (SELECT value FROM json_each(?))
+           ORDER BY q.target_id, g.published_at DESC, q.generation_id DESC`,
+              )
+              .bind(
+                DEX_MEASURED_QUOTE_SURFACE,
+                historyGenerationIdsJson,
+                JSON.stringify(targetIdBatch),
+              )
+              .all<HistoricalQuoteRow>(),
+          3,
+          signal,
+        );
+        const historicalRows = historicalResult.results ?? [];
+        for (const row of historicalRows) {
+          const currentTarget = targets.get(row.target_id);
+          if (
+            currentTarget &&
+            latestPublishedAt - row.quote_published_at >
+              getDexMeasuredHistoryFreshnessSec(currentTarget.adapterProfileId)
+          ) {
+            continue;
+          }
+          const recordCycle = (cycle: DexMeasuredExecutionHistoryCycle) => {
+            const cycles = historyCyclesByTargetId.get(row.target_id) ?? [];
+            cycles.push(cycle);
+            historyCyclesByTargetId.set(row.target_id, cycles);
+          };
+          const recordIntegrityBarrier = () => {
+            recordCycle({
+              generationId: row.generation_id,
+              publishedAt: row.quote_published_at,
+              status: "failed",
+              operationalFailure: false,
+              profile: null,
+            });
+            lkgBlockedTargetIds.add(row.target_id);
+          };
+          const targetJson = parseJson(row.target_json, { onFailure: () => undefined });
+          const profileJson = row.quote_profile_json
+            ? parseJson(row.quote_profile_json, { onFailure: () => undefined })
+            : null;
+          if (!targetJson.ok || (row.quote_profile_json != null && !profileJson?.ok)) {
+            recordIntegrityBarrier();
+            continue;
+          }
+          const targetResult = DexMeasuredExecutionTargetSchema.safeParse(targetJson.value);
+          const profileResult = profileJson?.ok
+            ? DexMeasuredExecutionProfileSchema.safeParse(profileJson.value)
+            : null;
+          const profile = profileResult?.success ? profileResult.data : null;
+          if (
+            !targetResult.success ||
+            targetResult.data.targetId !== row.target_id ||
+            (row.status === "measured" &&
+              (profile === null ||
+                row.failure_reason !== null ||
+                profile.targetId !== row.target_id ||
+                profile.targetGenerationId !== row.target_generation_id ||
+                profile.quoteGenerationId !== row.generation_id)) ||
+            (row.status === "failed" && (profile !== null || !row.failure_reason?.trim()))
+          ) {
+            recordIntegrityBarrier();
+            continue;
+          }
+          recordCycle({
+            generationId: row.generation_id,
+            publishedAt: row.quote_published_at,
+            status: row.status,
+            operationalFailure: row.status === "failed" && isOperationalDexMeasuredFailure(row.failure_reason),
+            profile,
+          });
+          if (row.status === "failed" && !isOperationalDexMeasuredFailure(row.failure_reason)) {
+            lkgBlockedTargetIds.add(row.target_id);
+          }
 
-      const latest = byTargetId.get(row.target_id);
-      if (
-        row.status !== "measured" ||
-        profile === null ||
-        lkgBlockedTargetIds.has(row.target_id) ||
-        latest?.resolution === "last-known-good" ||
-        (latest != null && (latest.status === "measured" || !isOperationalDexMeasuredFailure(latest.failureReason)))
-      ) {
-        continue;
+          const latest = byTargetId.get(row.target_id);
+          if (
+            row.status !== "measured" ||
+            profile === null ||
+            lkgBlockedTargetIds.has(row.target_id) ||
+            latest?.resolution === "last-known-good" ||
+            (latest != null && (latest.status === "measured" || !isOperationalDexMeasuredFailure(latest.failureReason)))
+          ) {
+            continue;
+          }
+          byTargetId.set(row.target_id, {
+            quotedTarget: targetResult.data,
+            status: "measured",
+            failureReason: null,
+            profile,
+            quoteGenerationId: row.generation_id,
+            targetGenerationId: row.target_generation_id,
+            resolution: "last-known-good",
+            latestFailureReason: latest?.failureReason ?? "quote-missing",
+          });
+        }
+        historicalRows.length = 0;
+        for (const targetId of targetIdBatch) {
+          const entry = byTargetId.get(targetId);
+          if (entry?.status === "measured" && entry.profile !== null) {
+            const observationHistory = summarizeDexMeasuredExecutionHistory({
+              cycles: historyCyclesByTargetId.get(targetId) ?? [],
+              nowSec: latestPublishedAt,
+              freshnessMaxSec: getDexMeasuredHistoryFreshnessSec(entry.profile.adapterProfileId),
+            });
+            if (observationHistory) {
+              byTargetId.set(targetId, { ...entry, observationHistory });
+            }
+          }
+          historyCyclesByTargetId.delete(targetId);
+        }
       }
-      byTargetId.set(row.target_id, {
-        quotedTarget: targetResult.data,
-        status: "measured",
-        failureReason: null,
-        profile,
-        quoteGenerationId: row.generation_id,
-        targetGenerationId: row.target_generation_id,
-        resolution: "last-known-good",
-        latestFailureReason: latest?.failureReason ?? "quote-missing",
-      });
     }
   } catch {
     // Current-generation evidence remains usable if the optional LKG read fails.


### PR DESCRIPTION
## Summary
- discover complete measured-quote history generations once per scoring pass
- load and summarize historical quote evidence in bounded 64-target batches
- preserve last-known-good selection, exact historical identities, and Curve maturity windows
- clear raw D1 result arrays after schema validation to reduce peak Worker memory

## Validation
- 100 focused measured-execution, DEX scoring, route selection, and P4 tests
- Worker typecheck and typed lint
- Worker import/shared type boundary checks
- cron schedule and connection-budget checks
- 29 scheduled-dispatch smoke tests
- commit-derived artifact check
- production D1 query-shape probe (4 generations; 256 rows / ~1.06 MB in a 64-target batch)

## Scope
Shadow V9/DEX scoring reliability only. This does not activate Safety Score V9 or change the public V8 rating path.