### PR TITLE
Move CEX depth parsing off the DEX memory peak

### DIFF
--- a/worker/src/cron/__tests__/sync-dex-liquidity.test.ts
+++ b/worker/src/cron/__tests__/sync-dex-liquidity.test.ts
@@ -395,7 +395,7 @@ describe("syncDexLiquidity", () => {
     expect(fetchCgTickersFallback).not.toHaveBeenCalled();
   });
 
-  it("releases identity and staged-observation graphs before bounded market telemetry", async () => {
+  it("fetches bounded market telemetry before pool graphs accumulate", async () => {
     const knownPoolIndex = {
       exactKeys: new Set(["ethereum:0xpool"]),
       derivedKeyCounts: new Map([["derived", 1]]),
@@ -419,13 +419,10 @@ describe("syncDexLiquidity", () => {
       priceObservations: stagedPriceObservations,
     });
     vi.mocked(fetchMajorStablecoinOrderbookDepthSummary).mockImplementationOnce(async () => {
-      expect(knownPoolIndex.exactKeys.size).toBe(0);
-      expect(knownPoolIndex.derivedKeyCounts.size).toBe(0);
-      expect(knownPoolIndex.derivedToExactKeys.size).toBe(0);
-      expect(knownPoolIndex.wildcardKeyCounts.size).toBe(0);
-      expect(knownPoolIndex.wildcardToExactKeys.size).toBe(0);
-      expect(knownPoolIndex.concreteFeeVariantKeys.size).toBe(0);
-      expect(stagedPriceObservations.size).toBe(0);
+      expect(fetchDataSources).not.toHaveBeenCalled();
+      expect(buildKnownPoolAddresses).not.toHaveBeenCalled();
+      expect(processPoolMetrics).not.toHaveBeenCalled();
+      expect(mergeStagedPools).not.toHaveBeenCalled();
       return {
         checkedSymbols: 0,
         venueCount: 0,

--- a/worker/src/cron/dex-liquidity/orchestrator-phases.ts
+++ b/worker/src/cron/dex-liquidity/orchestrator-phases.ts
@@ -13,7 +13,10 @@ export type { SubgraphEnrichmentPhaseResult } from "./orchestrator-phases/subgra
 export { fetchSubgraphEnrichmentPhase } from "./orchestrator-phases/subgraph-enrichment";
 
 export type { FallbackCrawlerPhaseResult } from "./orchestrator-phases/fallback";
-export { runFallbackCrawlerPhase } from "./orchestrator-phases/fallback";
+export {
+  fetchDirectCexOrderbookDepthTelemetry,
+  runFallbackCrawlerPhase,
+} from "./orchestrator-phases/fallback";
 
 export type { AuthoritativeStagedPoolConfirmationIndex } from "./orchestrator-phases/authoritative";
 export { buildAuthoritativeStagedPoolConfirmationIndex } from "./orchestrator-phases/authoritative";

--- a/worker/src/cron/dex-liquidity/orchestrator-phases/fallback.ts
+++ b/worker/src/cron/dex-liquidity/orchestrator-phases/fallback.ts
@@ -14,31 +14,34 @@ export interface FallbackCrawlerPhaseResult {
   directCexOrderbookDepth: DirectCexOrderbookDepthSummary | null;
 }
 
+export async function fetchDirectCexOrderbookDepthTelemetry(params: {
+  signal?: AbortSignal;
+  failedSources: string[];
+}): Promise<DirectCexOrderbookDepthSummary | null> {
+  try {
+    return await fetchMajorStablecoinOrderbookDepthSummary(params.signal);
+  } catch (err) {
+    rethrowIfAborted(err, params.signal);
+    console.warn("[dex-liquidity] Direct CEX orderbook depth telemetry failed (non-fatal):", err);
+    params.failedSources.push("direct-cex-orderbook-depth");
+    return null;
+  }
+}
+
 export async function runFallbackCrawlerPhase(params: {
   metrics: Map<string, LiquidityMetrics>;
   priceObservations: Map<string, DexPriceObs[]>;
-  signal?: AbortSignal;
-  failedSources: string[];
+  directCexOrderbookDepth: DirectCexOrderbookDepthSummary | null;
 }): Promise<FallbackCrawlerPhaseResult> {
   const weakCoverageTargetIdsBeforeFallback = new Set(
     getFallbackTargets(params.metrics, params.priceObservations, { requireTrackedContracts: true }).map(
       (meta) => meta.id,
     ),
   );
-  let directCexOrderbookDepth: DirectCexOrderbookDepthSummary | null = null;
-
   console.log(
     `[dex-liquidity] Discovery staging supplied ${params.priceObservations.size} coins with price observations; ` +
       "inline discovery is disabled in the scoring lane",
   );
-
-  try {
-    directCexOrderbookDepth = await fetchMajorStablecoinOrderbookDepthSummary(params.signal);
-  } catch (err) {
-    rethrowIfAborted(err, params.signal);
-    console.warn("[dex-liquidity] Direct CEX orderbook depth telemetry failed (non-fatal):", err);
-    params.failedSources.push("direct-cex-orderbook-depth");
-  }
 
   const weakCoverageTargetIdsAfterFallback = new Set(
     getFallbackTargets(params.metrics, params.priceObservations, { requireTrackedContracts: true }).map(
@@ -57,6 +60,6 @@ export async function runFallbackCrawlerPhase(params: {
     cgTickerFallbackCoins: 0,
     coverageRecoveredCoins,
     weakCoverageCoinsBeforeFallback: weakCoverageTargetIdsBeforeFallback.size,
-    directCexOrderbookDepth,
+    directCexOrderbookDepth: params.directCexOrderbookDepth,
   };
 }

--- a/worker/src/cron/dex-liquidity/orchestrator.ts
+++ b/worker/src/cron/dex-liquidity/orchestrator.ts
@@ -26,6 +26,7 @@ import {
   buildAuthoritativeStagedPoolConfirmationIndex,
   buildDexDirectApiFetchers,
   fetchSubgraphEnrichmentPhase,
+  fetchDirectCexOrderbookDepthTelemetry,
   integrateDirectApiLiquidityPhase,
   loadTrackedStablecoinMaps,
   mergeDexPriceObservationMap,
@@ -212,6 +213,7 @@ interface DexLiquiditySourceState {
   failedSources: string[];
   criticalSourceFailures: string[];
   fallbackSignals: string[];
+  directCexOrderbookDepth: DexLiquidityFallbackPhase["directCexOrderbookDepth"];
 }
 
 interface DexLiquidityPoolState {
@@ -324,6 +326,13 @@ async function loadDexLiquiditySourceState(ctx: DexLiquidityRunContext): Promise
   const validationReferences = await loadPriceValidationReferences(ctx.db);
   const { stablecoinPriceById, stablecoinMcapById } = await loadTrackedStablecoinMaps(ctx.db, ctx.syncStartSec);
   const lookups = buildSymbolLookups();
+  // Coinbase level-2 books can be large even though only a compact summary is
+  // retained. Fetch them before any DEX pool graph exists so transient response
+  // parsing cannot collide with the scoring lane's memory peak.
+  const directCexOrderbookDepth = await fetchDirectCexOrderbookDepthTelemetry({
+    signal: ctx.signal,
+    failedSources,
+  });
 
   const directApiFetchers = buildDexDirectApiFetchers({
     db: ctx.db,
@@ -541,6 +550,7 @@ async function loadDexLiquiditySourceState(ctx: DexLiquidityRunContext): Promise
     failedSources,
     criticalSourceFailures,
     fallbackSignals,
+    directCexOrderbookDepth,
   };
 }
 
@@ -713,8 +723,7 @@ async function buildDexLiquidityPoolState(
   const fallback = await runFallbackCrawlerPhase({
     metrics,
     priceObservations: sourceState.priceObservations,
-    signal: ctx.signal,
-    failedSources: sourceState.failedSources,
+    directCexOrderbookDepth: sourceState.directCexOrderbookDepth,
   });
   await reportDexLiquidityProgress(ctx, {
     stage: "pool-processing-complete",


### PR DESCRIPTION
## Summary
- fetch major-stablecoin CEX orderbook telemetry before loading DEX pool graphs
- carry only the compact depth aggregate into the later analysis phase
- preserve all scoring, weak-coverage, and diagnostic semantics
- lock the low-memory ordering in the orchestration regression

## Production evidence
The 20:40 UTC run under Worker version 01c30bbd-fbca-4f5c-87e2-bac42dbe183f still exceeded memory immediately after fallback orderbook requests and before scoring. At that point the job held the fully assembled 16k-primary/8k-direct pool graph while parsing Coinbase level-2 JSON.

## Validation
- 49 focused orchestration, CEX depth, analysis, and measured-history tests
- Worker typecheck
- typed lint and Worker boundary check
- cron connection-budget check
- commit-derived artifact check

## Scope
Shadow V9/DEX scoring reliability only. No V9 activation or public V8 behavior changes.