### PR TITLE
Bound measured EVM RPC outage tails

### DIFF
--- a/worker/src/cron/measured-execution/__tests__/quoter-v2.test.ts
+++ b/worker/src/cron/measured-execution/__tests__/quoter-v2.test.ts
@@ -24,7 +24,10 @@ import {
   validateQuoterV2ProfileProof,
 } from "../quoter-v2";
 import { getDexMeasuredExecutionDeployment } from "../registry";
-import { createDexMeasuredExecutionRpcBudget } from "../profiles";
+import {
+  createDexMeasuredExecutionRpcBudget,
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+} from "../profiles";
 
 interface ReplayFixture {
   name: string;
@@ -315,6 +318,9 @@ describe("QuoterV2 pinned-block replay proofs", () => {
     expect(rpcMocks.fetchEvmMulticall3Aggregate3AtBlock.mock.calls.map((call) => call[1].length)).toEqual([
       8, 4, 2, 2, 4, 2, 2,
     ]);
+    expect(rpcMocks.fetchEvmMulticall3Aggregate3AtBlock.mock.calls.every(
+      (call) => call[3]?.timeoutMs === DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+    )).toBe(true);
   });
 
   it("attributes a request rejected by the hard RPC budget to that budget", async () => {

--- a/worker/src/cron/measured-execution/curve-cryptoswap.ts
+++ b/worker/src/cron/measured-execution/curve-cryptoswap.ts
@@ -15,11 +15,12 @@ import {
   type EvmMulticall3Call,
   type EvmMulticall3Result,
 } from "../../lib/evm-rpc";
-import type {
-  DexMeasuredExecutionAdapter,
-  DexMeasuredExecutionBudgetStopReason,
-  DexMeasuredExecutionRpcBudget,
-  DexMeasuredRawQuotePoint,
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionAdapter,
+  type DexMeasuredExecutionBudgetStopReason,
+  type DexMeasuredExecutionRpcBudget,
+  type DexMeasuredRawQuotePoint,
 } from "./profiles";
 
 const CURVE_CRYPTOSWAP_ABI = parseAbi(["function get_dy(uint256 i,uint256 j,uint256 dx) view returns (uint256)"]);
@@ -307,7 +308,7 @@ export async function verifyCurveCryptoSwapDeployment(input: {
   const requestOptions = {
     chainRpcs: input.chainRpcs,
     signal: input.signal,
-    timeoutMs: 15_000,
+    timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
     ...(rpcBudget ? { deadlineMs: rpcBudget.deadlineMs } : {}),
     ...(rpcBudget ? { beforeRequest: () => rpcBudget.tryConsume() } : {}),
     maxRetries: 0,
@@ -841,7 +842,7 @@ export const quoteCurveCryptoSwapRequests = createCurveCryptoSwapQuoteExecutor({
     fetchEvmMulticall3Aggregate3AtBlock(input.chain, input.calls, input.blockNumber, {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 30_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       maxRetries: 1,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget

--- a/worker/src/cron/measured-execution/curve-stableswap-ng.ts
+++ b/worker/src/cron/measured-execution/curve-stableswap-ng.ts
@@ -26,11 +26,12 @@ import {
   type EvmMulticall3Call,
   type EvmMulticall3Result,
 } from "../../lib/evm-rpc";
-import type {
-  DexMeasuredExecutionAdapter,
-  DexMeasuredExecutionBudgetStopReason,
-  DexMeasuredExecutionRpcBudget,
-  DexMeasuredRawQuotePoint,
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionAdapter,
+  type DexMeasuredExecutionBudgetStopReason,
+  type DexMeasuredExecutionRpcBudget,
+  type DexMeasuredRawQuotePoint,
 } from "./profiles";
 
 const CURVE_STABLESWAP_NG_POOL_ABI = parseAbi([
@@ -279,7 +280,7 @@ export function createCurveStableSwapNgDeploymentVerifier(
     const requestOptions = {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 15_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       maxRetries: 0,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),
@@ -402,6 +403,7 @@ export function createCurveStableSwapNgDeploymentVerifier(
     const tokenDecimalsProof:
       DexMeasuredExecutionStableSwapNgFactoryBindingProof["tokenDecimalsProof"] = [];
     for (let index = 0; index < policy.poolTokens.length; index += 1) {
+      throwIfAborted(input.signal);
       const token = policy.poolTokens[index]!;
       const coinCallData = encodeFunctionData({
         abi: CURVE_STABLESWAP_NG_POOL_ABI,
@@ -846,7 +848,7 @@ export const quoteCurveStableSwapNgRequests = createCurveStableSwapNgQuoteExecut
     fetchEvmMulticall3Aggregate3AtBlock(input.chain, input.calls, input.blockNumber, {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 30_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       maxRetries: 1,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),

--- a/worker/src/cron/measured-execution/curve-stableswap.ts
+++ b/worker/src/cron/measured-execution/curve-stableswap.ts
@@ -25,11 +25,12 @@ import {
   type EvmMulticall3Call,
   type EvmMulticall3Result,
 } from "../../lib/evm-rpc";
-import type {
-  DexMeasuredExecutionAdapter,
-  DexMeasuredExecutionBudgetStopReason,
-  DexMeasuredExecutionRpcBudget,
-  DexMeasuredRawQuotePoint,
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionAdapter,
+  type DexMeasuredExecutionBudgetStopReason,
+  type DexMeasuredExecutionRpcBudget,
+  type DexMeasuredRawQuotePoint,
 } from "./profiles";
 
 const CURVE_STABLESWAP_ABI = parseAbi([
@@ -253,7 +254,7 @@ export function createCurveStableSwapDeploymentVerifier(
     const requestOptions = {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 15_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       maxRetries: 0,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),
@@ -372,6 +373,7 @@ export function createCurveStableSwapDeploymentVerifier(
     const poolCoinsProof: DexMeasuredExecutionRegistryBindingProof["poolCoinsProof"] = [];
     const tokenDecimalsProof: DexMeasuredExecutionRegistryBindingProof["tokenDecimalsProof"] = [];
     for (let index = 0; index < policy.poolTokens.length; index += 1) {
+      throwIfAborted(input.signal);
       const token = policy.poolTokens[index]!;
       const coinCallData = encodeFunctionData({
         abi: CURVE_STABLESWAP_ABI,
@@ -780,7 +782,7 @@ export const quoteCurveStableSwapRequests = createCurveStableSwapQuoteExecutor({
     fetchEvmMulticall3Aggregate3AtBlock(input.chain, input.calls, input.blockNumber, {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 30_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       maxRetries: 1,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),

--- a/worker/src/cron/measured-execution/fluid-resolver.ts
+++ b/worker/src/cron/measured-execution/fluid-resolver.ts
@@ -14,10 +14,11 @@ import {
   type EvmMulticall3Call,
   type EvmMulticall3Result,
 } from "../../lib/evm-rpc";
-import type {
-  DexMeasuredExecutionBudgetStopReason,
-  DexMeasuredExecutionRpcBudget,
-  DexMeasuredRawQuotePoint,
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionBudgetStopReason,
+  type DexMeasuredExecutionRpcBudget,
+  type DexMeasuredRawQuotePoint,
 } from "./profiles";
 
 const FLUID_RESOLVER_ABI = parseAbi([
@@ -182,7 +183,7 @@ export async function verifyFluidResolverDeployment(input: {
   const code = await fetchEvmCodeAtBlock(input.deployment.chain, input.deployment.endpointAddress, input.blockNumber, {
     chainRpcs: input.chainRpcs,
     signal: input.signal,
-    timeoutMs: 15_000,
+    timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
     ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
     ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),
     maxRetries: 0,
@@ -550,7 +551,7 @@ export const quoteFluidResolverRequests = createFluidResolverQuoteExecutor({
     fetchEvmMulticall3Aggregate3AtBlock(input.chain, input.calls, input.blockNumber, {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 30_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget
         ? {

--- a/worker/src/cron/measured-execution/profiles.ts
+++ b/worker/src/cron/measured-execution/profiles.ts
@@ -10,6 +10,8 @@ import {
   type DexMeasuredExecutionTarget,
 } from "@shared/types/measured-execution";
 
+export const DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS = 15_000;
+
 export interface DexMeasuredRawQuotePoint extends DexMeasuredExecutionQuotePointProof {
   adapterMetadata?: Record<string, string | number | boolean>;
 }

--- a/worker/src/cron/measured-execution/quoter-v2.ts
+++ b/worker/src/cron/measured-execution/quoter-v2.ts
@@ -13,10 +13,11 @@ import {
   type EvmMulticall3Call,
   type EvmMulticall3Result,
 } from "../../lib/evm-rpc";
-import type {
-  DexMeasuredExecutionBudgetStopReason,
-  DexMeasuredExecutionRpcBudget,
-  DexMeasuredRawQuotePoint,
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionBudgetStopReason,
+  type DexMeasuredExecutionRpcBudget,
+  type DexMeasuredRawQuotePoint,
 } from "./profiles";
 import { getDexMeasuredExecutionDeployment } from "./registry";
 
@@ -186,7 +187,7 @@ async function executeAdaptiveChunk(input: {
   const result = await fetchEvmMulticall3Aggregate3AtBlock(input.chain, input.calls, input.blockNumber, {
     chainRpcs: input.chainRpcs,
     signal: input.signal,
-    timeoutMs: 30_000,
+    timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
     ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
     ...(input.rpcBudget
       ? {

--- a/worker/src/cron/measured-execution/registry.ts
+++ b/worker/src/cron/measured-execution/registry.ts
@@ -2,7 +2,10 @@ import { keccak256 } from "viem/utils";
 
 import type { ChainRpcConfig } from "../../lib/chain-registry";
 import { fetchEvmCodeAtBlock } from "../../lib/evm-rpc";
-import type { DexMeasuredExecutionRpcBudget } from "./profiles";
+import {
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
+  type DexMeasuredExecutionRpcBudget,
+} from "./profiles";
 
 export interface DexMeasuredExecutionDeployment {
   adapterProfileId:
@@ -167,7 +170,7 @@ export async function verifyDexMeasuredExecutionDeployment(input: {
   const code = await fetchEvmCodeAtBlock(input.deployment.chain, input.deployment.endpointAddress, input.blockNumber, {
     chainRpcs: input.chainRpcs,
     signal: input.signal,
-    timeoutMs: 15_000,
+    timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
     ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
     ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),
     maxRetries: 0,
@@ -186,7 +189,7 @@ export async function verifyDexMeasuredExecutionDeployment(input: {
     {
       chainRpcs: input.chainRpcs,
       signal: input.signal,
-      timeoutMs: 15_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       ...(input.rpcBudget ? { deadlineMs: input.rpcBudget.deadlineMs } : {}),
       ...(input.rpcBudget ? { beforeRequest: () => input.rpcBudget!.tryConsume() } : {}),
       maxRetries: 0,

--- a/worker/src/cron/measured-execution/sync.ts
+++ b/worker/src/cron/measured-execution/sync.ts
@@ -23,6 +23,7 @@ import {
 import {
   buildDexMeasuredExecutionProfile,
   createDexMeasuredExecutionRpcBudget,
+  DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
   type DexMeasuredRawQuotePoint,
 } from "./profiles";
 import { quoteQuoterV2Requests, resolveQuoterV2PoolBindings, validateQuoterV2ProfileProof } from "./quoter-v2";
@@ -449,7 +450,7 @@ export async function syncDexMeasuredExecution(
     const blockNumber = await fetchEvmBlockNumber(chain, {
       chainRpcs,
       signal,
-      timeoutMs: 15_000,
+      timeoutMs: DEX_MEASURED_EVM_REQUEST_TIMEOUT_MS,
       deadlineMs: rpcBudget.deadlineMs,
       beforeRequest: () => rpcBudget.tryConsume(),
       maxRetries: 0,


### PR DESCRIPTION
## Summary
- centralize and apply the documented 15-second EVM request timeout across measured-execution block, identity, quote, and Curve calls
- keep Curve token verification cooperative with cron aborts
- add adaptive QuoterV2 timeout-policy regression coverage

## Validation
- `npm run test:merge-gate:discover -- --target=pr` (Node 24.16.0; 21 selected nodes passed)
- measured-execution tests: 16 files, 146 tests passed
- generated artifacts, cron sync, cron connections, worker typecheck, and gitleaks passed

The repository-wide cron-abort checker reports two pre-existing advisory violations in unchanged safety-score observer files.