### PR TITLE
fix(data): update kUSD (Kerne) skUSD address to live vault

### DIFF
--- a/shared/data/stablecoins/coins/kusd-kerne.json
+++ b/shared/data/stablecoins/coins/kusd-kerne.json
@@ -169,7 +169,7 @@
   "status": "pre-launch",
   "announcedDate": "2026-04",
   "launchPhase": "beta",
-  "launchPhaseDetail": "kUSD v2 is live on Base (first PSM mint 2026-05-14), but Pharos treats it as pre-active until a usable runtime price path exists. The protocol is in a genesis, capacity-capped phase: supply is about 1,113 USD, DefiLlama stablecoin id 402 exposes supply with price=null, CoinGecko does not resolve a Kerne USD coin, and the v1 WETH/Hyperliquid hedge vault leg is disclosed-degraded and excluded from reserves so kUSD is currently 100% USDC-backed through three PSM reserves. Staking wrapper skUSD (ERC-4626, 0xdEd74F7E) is deployed with a published live APY but near-zero third-party stake. Admin is a 2-of-3 Gnosis Safe; hourly signed proof of reserves is published at kerne.fi/verify.",
+  "launchPhaseDetail": "kUSD v2 is live on Base (first PSM mint 2026-05-14), but Pharos treats it as pre-active until a usable runtime price path exists. The protocol is in a genesis, capacity-capped phase: supply is about 1,113 USD, DefiLlama stablecoin id 402 exposes supply with price=null, CoinGecko does not resolve a Kerne USD coin, and the v1 WETH/Hyperliquid hedge vault leg is disclosed-degraded and excluded from reserves so kUSD is currently 100% USDC-backed through three PSM reserves. Staking wrapper skUSD (ERC-4626, 0x96F5102C15b839757f811A98CEc3725Ac21DfA14) is deployed with a published live APY but near-zero third-party stake. The previous skUSD (0xdEd74F7E) is retired. Admin is a 2-of-3 Gnosis Safe; hourly signed proof of reserves is published at kerne.fi/verify.",
   "featuredContent": [
     {
       "type": "article",

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -231,7 +231,7 @@
   "/stablecoin/krw-imbank/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/krw1-bdacs/": "2026-07-15T17:09:51+02:00",
   "/stablecoin/krwq-iq/": "2026-07-22T22:28:24+02:00",
-  "/stablecoin/kusd-kerne/": "2026-07-23T10:44:38+02:00",
+  "/stablecoin/kusd-kerne/": "2026-07-24T22:53:16-08:00",
   "/stablecoin/lisusd-lista/": "2026-07-22T22:30:49+02:00",
   "/stablecoin/luausd-lumi-finance/": "2026-07-21T12:33:09+02:00",
   "/stablecoin/lusd-liquity/": "2026-07-20T10:02:25+02:00",


### PR DESCRIPTION
**Fixes #650**

### Problem
The skUSD (staking wrapper) address recorded for kUSD (Kerne) was the retired v1 contract (`0xdEd74F7E`).

### Solution
Updated to the live vault address:
`0x96F5102C15b839757f811A98CEc3725Ac21DfA14`

Source: Kerne Protocol deployments + kerne.fi transparency page.

**Reference**
- Live skUSD: [`0x96F5102C15b839757f811A98CEc3725Ac21DfA14`](https://basescan.org/address/0x96F5102C15b839757f811A98CEc3725Ac21DfA14)
- Retired v1: `0xdEd74F7E...`