### PR TITLE
Fail-closed for curated-fallback reserves with unresolved known-unknown exposure

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ReserveSlice } from "@shared/types/reserves";
-import { buildReviewedReserveClassifications, type V9ExtensionRegistryMeta } from "../safety-score-v9-extension";
+import {
+  buildReviewedReserveClassifications,
+  buildSafetyScoreV9ReviewedCuratedFallbackReserveRows,
+  type V9ExtensionRegistryMeta,
+} from "../safety-score-v9-extension";
 import { buildSafetyScoreV9ReserveClassifications } from "../safety-score-v9-extension-reserves";
 
 const CLOCK_SEC = Date.UTC(2026, 6, 14) / 1_000;
@@ -27,6 +31,46 @@ function reviewedMeta(
     },
   };
 }
+
+describe("buildSafetyScoreV9ReviewedCuratedFallbackReserveRows", () => {
+  it("rejects fallback reserve evidence with known-unknown exposure", () => {
+    const rows: ReserveSlice[] = [
+      { name: "Opaque basket", pct: 40, risk: "medium" },
+      { name: "Treasury bills", pct: 60, risk: "very-low" },
+    ];
+    const admitted = buildSafetyScoreV9ReviewedCuratedFallbackReserveRows(
+      reviewedMeta(rows, {
+        knownUnknownExposure: "Opaque basket constituents are not fully split.",
+        knownUnknownExposurePct: 40,
+        nonLinkDispositions: [
+          {
+            reserveIndex: 0,
+            reserveName: "Opaque basket",
+            pct: 40,
+            disposition: "basket-needs-split",
+            rationale: "The basket weights are unresolved.",
+          },
+        ],
+      }),
+      CLOCK_SEC,
+    );
+
+    expect(admitted).toBeNull();
+  });
+
+  it("admits complete current verified fallback reserve evidence", () => {
+    const admitted = buildSafetyScoreV9ReviewedCuratedFallbackReserveRows(
+      reviewedMeta([{ name: "Treasury bills", pct: 100, risk: "very-low" }]),
+      CLOCK_SEC,
+    );
+
+    expect(admitted).toMatchObject({
+      evidenceClass: "static-validated",
+      provenance: "curated-fallback",
+      rows: [{ name: "Treasury bills", pct: 100, risk: "very-low" }],
+    });
+  });
+});
 
 describe("buildReviewedReserveClassifications", () => {
   it("classifies exact tracked-asset slices without guessing from vague labels", () => {

--- a/worker/src/lib/safety-score-v9-extension.ts
+++ b/worker/src/lib/safety-score-v9-extension.ts
@@ -431,6 +431,7 @@ const CORROBORATING_ASSURANCE_METHODS = new Set([
 const DIRECT_RESERVE_ASSURANCE_METHODS = new Set(["audit", "examination"]);
 const ISSUER_ATTESTED_RESERVE_MAX_AGE_SEC = 31_536_000;
 const REVIEWED_CURATED_FALLBACK_RESERVE_MAX_AGE_SEC = 31 * 86_400;
+const UNRESOLVED_RESERVE_FALLBACK_DISPOSITIONS = new Set(["basket-needs-split", "insufficient-evidence"]);
 
 function normalizeReviewedStaticReserveRows(rows: readonly ReserveSlice[]): ReserveSlice[] {
   const sorted = [...rows].sort(
@@ -542,6 +543,10 @@ export function buildSafetyScoreV9ReviewedCuratedFallbackReserveRows(
     rows.length === 0 ||
     review?.scope !== "full-composition" ||
     review.confidence !== "verified" ||
+    review.knownUnknownExposurePct !== 0 ||
+    review.nonLinkDispositions?.some((disposition) =>
+      UNRESOLVED_RESERVE_FALLBACK_DISPOSITIONS.has(disposition.disposition),
+    ) === true ||
     review.sources.length === 0 ||
     reviewedAtSec === null ||
     compositionAtSec === null ||


### PR DESCRIPTION
### Motivation
- Prevent admitting registry fallback reserve rows as score-bearing evidence when the registry review records any known-unknown exposure or unresolved reserve dispositions, which could otherwise inflate safety scores during live-reserve outages.

### Description
- Add a guard in `buildSafetyScoreV9ReviewedCuratedFallbackReserveRows` to reject reviews where `reserveReview.knownUnknownExposurePct !== 0` or any `nonLinkDispositions` use unresolved dispositions (`basket-needs-split` / `insufficient-evidence`).
- Introduce `UNRESOLVED_RESERVE_FALLBACK_DISPOSITIONS` to centralize the unresolved-disposition checks used by the fallback admission path.
- Add focused regression tests in `worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts` asserting that incomplete fallback evidence is rejected and that complete verified fallback compositions are still admitted.
- Files changed: `worker/src/lib/safety-score-v9-extension.ts` and `worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts`.

### Testing
- Ran the focused Vitest suite for the modified tests: `npx vitest run worker/src/lib/__tests__/safety-score-v9-extension-reserves.test.ts` and all tests passed.
- Type-checked the worker package with `cd worker && npx tsc --noEmit` and the build passed with no type errors.
- Ran `git diff --check` for whitespace/format checks and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6377b0e4648332a4780ec9d08dafc2)