### PR TITLE
Fail closed on malformed Sky unknown debt

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/sky-makercore.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/sky-makercore.test.ts
@@ -392,6 +392,39 @@ describe("fetchSkyMakercoreReserves PSM attribution", () => {
     },
   );
 
+  it("degrades when an unknown module has malformed debt", async () => {
+    vi.mocked(fetchJsonWithRetry).mockResolvedValue({
+      count: 2,
+      results: [
+        {
+          group: "stablecoins",
+          group_name: "Stablecoins",
+          debt: "9000000000",
+          collateral: "9000000000",
+          datetime: "2026-04-05T17:33:24",
+        },
+        {
+          group: "new-module",
+          group_name: "New Module",
+          debt: "1,000,000,000",
+          collateral: "1000000000",
+          datetime: "2026-04-05T17:33:24",
+        },
+      ],
+    });
+
+    const result = await fetchSkyMakercoreReserves(coin, config, signal);
+
+    expect(result.metadata?.unknownExposurePct).toBe(0);
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        code: "unknown-asset",
+        effect: "degraded",
+        message: expect.stringContaining("new-module"),
+      }),
+    );
+  });
+
   it("propagates aborts from the optional LitePSM capacity read", async () => {
     vi.mocked(fetchJsonWithRetry).mockResolvedValue({
       count: 2,

--- a/worker/src/cron/reserve-adapters/sky-makercore.ts
+++ b/worker/src/cron/reserve-adapters/sky-makercore.ts
@@ -86,6 +86,12 @@ function parseNumericString(raw: string): number {
   return parsePositiveNumber(raw) ?? 0;
 }
 
+function hasMalformedDebt(raw: string): boolean {
+  if (raw.trim() === "") return true;
+  const debt = Number(raw);
+  return !Number.isFinite(debt) || debt < 0;
+}
+
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for tests)
 // ---------------------------------------------------------------------------
@@ -221,10 +227,16 @@ export async function fetchSkyMakercoreReserves(
     .filter((g) => !KNOWN_GROUPS.has(g.group))
     .reduce((sum, g) => sum + parseNumericString(g.debt), 0);
   const unknownExposurePct = totalDebt > 0 ? (unknownDebt / totalDebt) * 100 : 0;
-  const unknown = listUnknownGroups(groups.filter((group) => parseNumericString(group.debt) > 0));
+  const unknownGroups = groups.filter((group) => !KNOWN_GROUPS.has(group.group));
+  const unknown = listUnknownGroups(unknownGroups.filter((group) => parseNumericString(group.debt) > 0));
   const warnings: LiveReserveWarning[] = unknown.map((group) =>
     reserveInfoWarning("unknown-asset", `Sky module bucketed into other: ${group}`),
   );
+  for (const group of unknownGroups.filter((group) => hasMalformedDebt(group.debt))) {
+    warnings.push(
+      reserveDegradedWarning("unknown-asset", `Sky module has malformed debt and cannot be classified: ${group.group}`),
+    );
+  }
   if (timestampSummary && timestampSummary.sourceTimestampSpreadSec > SOURCE_TIMESTAMP_SPREAD_DEGRADE_SEC) {
     warnings.push(
       reserveDegradedWarning(


### PR DESCRIPTION
### Motivation
- The Sky MakerCore adapter normalized any unparsable or non-positive debt to zero, so malformed but semantically-material values (e.g. comma-formatted numbers) could be silently omitted from unknown-exposure math and bypass the materiality validator.
- The change ensures the adapter fails closed when an unknown module’s debt cannot be safely quantified so provider-malformed data cannot publish a clean reserve snapshot.

### Description
- Add `hasMalformedDebt()` to `worker/src/cron/reserve-adapters/sky-makercore.ts` to detect empty, non-finite, or negative debt encodings. 
- Separate unknown-group detection from positive-debt filtering and emit a degrading `unknown-asset` warning when an unrecognized group has malformed debt so the run degrades rather than appearing clean. 
- Add a regression test in `worker/src/cron/reserve-adapters/__tests__/sky-makercore.test.ts` that exercises a comma-formatted material unknown debt (`"1,000,000,000"`) and asserts the degrading warning is emitted. 
- Modified files: `worker/src/cron/reserve-adapters/sky-makercore.ts`, `worker/src/cron/reserve-adapters/__tests__/sky-makercore.test.ts`.

### Testing
- Ran the adapter unit tests with `npm test -- --run worker/src/cron/reserve-adapters/__tests__/sky-makercore.test.ts` and all tests passed (17 tests passed).
- Ran TypeScript checks with `cd worker && npx tsc --noEmit` and the typecheck succeeded.
- Ran repository focused checks (`node scripts/ci/pharos-change-contract.mjs --markdown` and `git diff --check`) and they reported no problems relevant to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64f64b6f00833285e97d59bfcac24a)