### PR TITLE
Fix V9 redemption eligibility gate

### DIFF
--- a/shared/lib/__tests__/safety-score-v9-exit.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-exit.test.ts
@@ -549,8 +549,10 @@ describe("reliable non-atomic redemption credit", () => {
 // Lever 3 (V9 scoring reshape): the exit pillar now credits documented,
 // reliable issuer- and protocol-redemption channels — not only the derived
 // eventual-redemption family — while every reliability gate and the
-// all-zero-capacity floor stay in force. Impaired/frozen routes are excluded by
-// reporting zero capacity, so relaxing the family gate cannot lift them.
+// all-zero-capacity floor stay in force. Native issuer/protocol observations
+// must still carry producer-side score eligibility, which is the scorer's only
+// downstream representation of open route status, resolution, immediacy,
+// evidence support, and bounded costs.
 describe("Lever 3 issuer/protocol redemption credit", () => {
   const floor = V9_CANDIDATE_POLICY_V1.policy.semantic.exit.boundedUnknownScore;
 
@@ -558,9 +560,7 @@ describe("Lever 3 issuer/protocol redemption credit", () => {
     return route({
       routeKey: "redemption:issuer-documented",
       routeFamily: "issuer-redemption",
-      // A native issuer observation fails the atomic-only score gate; credit now
-      // comes from the reliability gate, not scoreEligible.
-      scoreEligible: false,
+      scoreEligible: true,
       coverageClass: "exact-lower-bound",
       evidenceKind: "documented-terms",
       access: "issuer-api",
@@ -586,6 +586,17 @@ describe("Lever 3 issuer/protocol redemption credit", () => {
     // its evidence with only the T+1 settlement haircut.
     expect(result.score!).toBeGreaterThan(floor);
     expect(result.score!).toBeGreaterThan(55);
+  });
+
+  it("does not credit a native issuer redemption when producer-side score eligibility fails", () => {
+    const result = evaluateV9Exit(
+      { circulatingUsd: 20_000_000, routes: [documentedRedemption({ scoreEligible: false })] },
+      V9_CANDIDATE_POLICY_V1,
+    );
+
+    expect(result.primaryRouteKey).toBeNull();
+    expect(result.score).toBe(floor);
+    expect(result.reasons).toContain("unsupported-same-notional-route");
   });
 
   it("credits a documented, nonzero-capacity protocol redemption above the bounded floor", () => {

--- a/shared/lib/safety-score-v9/exit.ts
+++ b/shared/lib/safety-score-v9/exit.ts
@@ -265,13 +265,10 @@ const CREDITABLE_NON_ATOMIC_REDEMPTION_FAMILIES: readonly V9ExitEvaluationRoute[
  * issuer-, protocol-, and eventual-redemption families and admitted only after
  * hard-gating on a known observation, a resolved output, non-diagnostic
  * coverage, at least one enumerated failure domain, and a documented,
- * live-reserve, or on-chain redemption evidence kind. This gate decides only
- * *eligibility* for the discounted credit; whether the route actually clears
- * notional is settled downstream by its measured capacity curve. An impaired,
- * frozen, or discretionary route does not survive as a viable exit because a
- * redemption that cannot clear reports a zero (or immaterial) capacity curve, so
- * the zero-capacity floor drops it exactly as before this relaxation — the pin
- * safety here is that data invariant, not the family membership.
+ * live-reserve, or on-chain redemption evidence kind. Native issuer/protocol
+ * observations must also pass the producer-side scoreEligible gate because that
+ * aggregate is the scorer's only downstream representation of open route
+ * status, resolution, immediacy, evidence support, and cost bounds.
  */
 function isCreditableNonAtomicRedemption(
   route: V9ExitEvaluationRoute,
@@ -279,6 +276,7 @@ function isCreditableNonAtomicRedemption(
 ): boolean {
   if (route.lane !== "redemption") return false;
   if (!CREDITABLE_NON_ATOMIC_REDEMPTION_FAMILIES.includes(route.routeFamily)) return false;
+  if (route.routeFamily !== "eventual-redemption" && !route.scoreEligible) return false;
   if (route.observationState !== "known") return false;
   if (route.outputResolved !== true) return false;
   if (route.coverageClass === "diagnostic") return false;


### PR DESCRIPTION
### Motivation
- Fix a scoring-integrity bug where native `issuer-redemption` and `protocol-redemption` observations could receive discounted non-atomic V9 exit credit even when the producer-side `scoreEligible` gate (which encodes resolved/open/immediacy/evidence/cost predicates) was false.

### Description
- Require producer-side eligibility by updating `isCreditableNonAtomicRedemption()` in `shared/lib/safety-score-v9/exit.ts` to early-return false for native `issuer-redemption` and `protocol-redemption` when `route.scoreEligible` is false while preserving `eventual-redemption` behavior.
- Clarify the reliability-gate comment to document that `scoreEligible` is the scorer's only downstream representation of route open-ness, resolution, immediacy, evidence support, and bounded costs.
- Update tests in `shared/lib/__tests__/safety-score-v9-exit.test.ts` to make documented native redemption fixtures `scoreEligible: true` by default and add a regression test proving a native issuer route with `scoreEligible: false` remains excluded at the bounded-unknown floor.

### Testing
- Ran `npm test -- --run shared/lib/__tests__/safety-score-v9-exit.test.ts` and observed all tests in that file pass (25 passed / 0 failed).
- Ran `npm run typecheck -- --pretty false` and the TypeScript typecheck completed without errors.
- Ran `npm run check:worker-boundary` and `npm run check:shared-cycles` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a609b81583c8332889a397fd66fc67c)