### PR TITLE
Normalize DEX challenger cleanup timestamps

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/challenger-publish.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/challenger-publish.test.ts
@@ -184,7 +184,7 @@ describe("challenger publish", () => {
     const { db, batches, maxConstructedStatements } = makePublishDb();
 
     const result = await publishDexPriceChallengerSnapshots(db, {
-      snapshotAt: 1_700_000_000,
+      snapshotAt: 1_700_000_000.9,
       retainedPoolsByStablecoin: new Map([["usdt-tether", challengerPools(60)]]),
       sourceCoverageCompleteByStablecoin: new Map([["usdt-tether", true]]),
       minPoolTvlUsd: 20_000,
@@ -201,6 +201,9 @@ describe("challenger publish", () => {
       .toBe(true);
     expect(statements[5]?.sql).toContain("INSERT INTO dex_price_challenger_snapshots");
     expect(statements[6]?.sql).toContain("DELETE FROM dex_price_challengers");
+    expect(statements.slice(0, 5).every((statement) => statement.binds[1] === 1_700_000_000)).toBe(true);
+    expect(statements[5]?.binds[1]).toBe(1_700_000_000);
+    expect(statements[6]?.binds[0]).toBe(1_700_000_000);
     expect(
       statements.slice(0, 5).flatMap((statement) =>
         statement.binds.filter((_, bindIndex) => bindIndex % 8 === 2)

--- a/worker/src/cron/dex-liquidity/challenger-publish.ts
+++ b/worker/src/cron/dex-liquidity/challenger-publish.ts
@@ -268,6 +268,7 @@ export async function publishDexPriceChallengerSnapshots(
   skippedStablecoins: number;
   missingTables: boolean;
 }> {
+  const snapshotAt = Math.floor(requireFiniteNumber(input.snapshotAt, "dex-price-challengers: snapshotAt"));
   const state = await detectDexPriceChallengerTableState(db);
   if (!state.challengersTable || !state.snapshotsTable) {
     return {
@@ -314,7 +315,7 @@ export async function publishDexPriceChallengerSnapshots(
     );
     const plan = buildDexPriceChallengerPublicationPlan({
       stablecoinId,
-      snapshotAt: input.snapshotAt,
+      snapshotAt,
       rows,
       sourceCoverageComplete: input.sourceCoverageCompleteByStablecoin.get(stablecoinId) ?? false,
     });
@@ -380,7 +381,7 @@ export async function publishDexPriceChallengerSnapshots(
          WHERE snapshot_at < ?
            AND stablecoin_id IN (${new Array(idChunk.length).fill("?").join(", ")})`,
       )
-      .bind(input.snapshotAt, ...idChunk)
+      .bind(snapshotAt, ...idChunk)
   );
   await batchExecute(db, cleanupStatements, {
     chunkSize: DEX_PRICE_CHALLENGER_BATCH_SIZE,


### PR DESCRIPTION
### Motivation
- The grouped cleanup previously bound the raw `input.snapshotAt` while payload and snapshot rows used a floored timestamp, which could cause freshly published payload rows to be deleted when `snapshotAt` is fractional.
- This is a data-integrity/availability edge-case introduced by batching and grouped cleanup logic and must be fixed without changing publication semantics.

### Description
- Normalize and validate the publication `snapshotAt` once inside `publishDexPriceChallengerSnapshots` using `Math.floor(requireFiniteNumber(...))` and reuse the normalized value throughout the function.
- Pass the normalized `snapshotAt` into `buildDexPriceChallengerPublicationPlan` so payload binds and snapshot pointer binds match the same normalized value.
- Use the normalized `snapshotAt` when binding the grouped cleanup `DELETE` statements so stale-row cleanup cannot remove rows just published.
- Updated test coverage to pass a fractional `snapshotAt` into `publishDexPriceChallengerSnapshots` and assert that payload, snapshot, and cleanup statements all bind the same floored timestamp; files changed: `worker/src/cron/dex-liquidity/challenger-publish.ts` and `worker/src/cron/dex-liquidity/__tests__/challenger-publish.test.ts`.

### Testing
- Ran the focused test suite with `npm test -- --run worker/src/cron/dex-liquidity/__tests__/challenger-publish.test.ts` and all tests passed (5 tests passed).
- Ran typecheck with `npm run typecheck:worker` which succeeded.
- Ran cron checks `npm run check:cron-sync` and `npm run check:cron-connections`, both of which passed.
- Ran `git diff --check` for whitespace/formatting issues and no problems were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64f64bc8bc8332b6b5f5bc16d5efce)