### PR TITLE
Scope implementation history to measured resilience depth

### DIFF
--- a/shared/lib/__tests__/safety-score-v9-operational-resilience-integration.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-operational-resilience-integration.test.ts
@@ -446,6 +446,19 @@ describe("Safety Score v9 operational-resilience full-pipeline integration", () 
     });
   });
 
+  it("does not let implementation history qualify an immature operational overlay", () => {
+    const factSet = mutateFactSet(compiledFactSet([]), (asset) => {
+      asset.operationalResilience!.liveHistoryEligibility.minimumLiveHistoryMonths = 12;
+    });
+    const evaluated = evaluatedAsset(factSet);
+
+    expect(evaluated.operationalResilience).toMatchObject({
+      eligible: false,
+      pillarCredits: { backing: 0, exit: 0, control: 0 },
+      contributions: [],
+    });
+  });
+
   it("uses distinct physical capacity instead of summing shared resources twice", () => {
     const request = selectV9ExitStressRequest(SUPPLY_USD, V9_CANDIDATE_POLICY_V1)!;
     const first = measuredRoute({

--- a/shared/lib/__tests__/safety-score-v9-operational-resilience.test.ts
+++ b/shared/lib/__tests__/safety-score-v9-operational-resilience.test.ts
@@ -254,6 +254,37 @@ describe("Safety Score v9 operational resilience", () => {
     ).toBe(false);
   });
 
+  it("does not use implementation history to qualify editorial resilience claims", () => {
+    const input = facts();
+    input.liveHistoryEligibility.minimumLiveHistoryMonths = 12;
+    const implementationHistory = {
+      minimumLiveHistoryMonths: 120,
+      evidenceRefIds: ["implementation-launch"],
+    };
+
+    const withoutDepth = evaluateV9OperationalResilience(
+      input,
+      null,
+      POLICY,
+      NO_BLOCKERS,
+      implementationHistory,
+    );
+    expect(withoutDepth.eligible).toBe(false);
+    expect(withoutDepth.contributions).toEqual([]);
+
+    const withDepth = evaluateV9OperationalResilience(
+      input,
+      MEASURED_DEPTH,
+      POLICY,
+      NO_BLOCKERS,
+      implementationHistory,
+    );
+    expect(withDepth.eligible).toBe(true);
+    expect(withDepth.contributions).toEqual([
+      expect.objectContaining({ component: "persistent-market-depth", points: 2 }),
+    ]);
+  });
+
   it("evaluates cumulative and stress redemption claims independently", () => {
     const input = facts();
     input.stressEpisodes = [];

--- a/shared/lib/safety-score-v9/operational-resilience.ts
+++ b/shared/lib/safety-score-v9/operational-resilience.ts
@@ -170,7 +170,6 @@ function activeBlockerCodes(
 
 function eligibilityTrace(
   fact: V9OperationalResilienceFact | null,
-  implementationHistory: V9OperationalResilienceImplementationHistory | null,
   policy: V9OperationalResiliencePolicy,
 ): V9OperationalResilienceEligibilityTrace {
   const history = fact?.liveHistoryEligibility ?? null;
@@ -188,6 +187,19 @@ function eligibilityTrace(
       satisfied: true,
     };
   }
+  return {
+    requiredLiveHistoryMonths: policy.minimumLiveHistoryMonths,
+    documentedLiveHistoryMonths: history?.minimumLiveHistoryMonths ?? null,
+    confidence: history?.confidence ?? null,
+    evidenceRefIds: canonicalEvidence(history?.evidenceRefIds ?? []),
+    satisfied: false,
+  };
+}
+
+function implementationEligibilityTrace(
+  implementationHistory: V9OperationalResilienceImplementationHistory | null,
+  policy: V9OperationalResiliencePolicy,
+): V9OperationalResilienceEligibilityTrace {
   if (implementationHistory !== null) {
     nonNegativeInteger(
       implementationHistory.minimumLiveHistoryMonths,
@@ -206,9 +218,9 @@ function eligibilityTrace(
   }
   return {
     requiredLiveHistoryMonths: policy.minimumLiveHistoryMonths,
-    documentedLiveHistoryMonths: history?.minimumLiveHistoryMonths ?? null,
-    confidence: history?.confidence ?? null,
-    evidenceRefIds: canonicalEvidence(history?.evidenceRefIds ?? []),
+    documentedLiveHistoryMonths: null,
+    confidence: null,
+    evidenceRefIds: [],
     satisfied: false,
   };
 }
@@ -226,9 +238,18 @@ export function evaluateV9OperationalResilience(
   blockers: V9OperationalResilienceBlockers,
   implementationHistory: V9OperationalResilienceImplementationHistory | null = null,
 ): V9OperationalResilienceResult {
-  const eligibility = eligibilityTrace(fact, implementationHistory, policy);
+  const overlayEligibility = eligibilityTrace(fact, policy);
+  const depthEligibility = implementationEligibilityTrace(implementationHistory, policy);
+  const eligibility =
+    !overlayEligibility.satisfied && measuredMarketDepth !== null && depthEligibility.satisfied
+      ? depthEligibility
+      : overlayEligibility;
   const blockerCodes = activeBlockerCodes(fact, blockers);
-  if (!eligibility.satisfied || blockerCodes.length > 0) {
+  if (
+    (!overlayEligibility.satisfied &&
+      !(measuredMarketDepth !== null && depthEligibility.satisfied)) ||
+    blockerCodes.length > 0
+  ) {
     return {
       eligible: false,
       eligibility,
@@ -262,8 +283,9 @@ export function evaluateV9OperationalResilience(
     });
   };
 
-  const cumulativeRatio =
-    fact?.redemptionThroughput?.cumulativeLifetimeRedeemedSupplyRatio ?? null;
+  const cumulativeRatio = overlayEligibility.satisfied
+    ? fact?.redemptionThroughput?.cumulativeLifetimeRedeemedSupplyRatio ?? null
+    : null;
   if (cumulativeRatio !== null) {
     finiteNonNegative(cumulativeRatio.value, "cumulative redeemed supply ratio");
     if (cumulativeRatio.value >= policy.redemption.minimumCumulativeSupplyRatio) {
@@ -277,7 +299,9 @@ export function evaluateV9OperationalResilience(
     }
   }
 
-  const qualifyingStressWindows = (fact?.redemptionThroughput?.stressWindows ?? [])
+  const qualifyingStressWindows = (
+    overlayEligibility.satisfied ? fact?.redemptionThroughput?.stressWindows ?? [] : []
+  )
     .filter((window) => {
       finiteNonNegative(
         window.redeemedSupplyRatioLowerBound,
@@ -341,7 +365,7 @@ export function evaluateV9OperationalResilience(
     }
   }
 
-  const qualifyingEpisodes = (fact?.stressEpisodes ?? [])
+  const qualifyingEpisodes = (overlayEligibility.satisfied ? fact?.stressEpisodes ?? [] : [])
     .filter((episode) => {
       if (episode.recoveredWithinSec !== null) {
         finiteNonNegative(
@@ -381,7 +405,7 @@ export function evaluateV9OperationalResilience(
     );
   }
 
-  const reconciliation = fact?.reserveReconciliation ?? null;
+  const reconciliation = overlayEligibility.satisfied ? fact?.reserveReconciliation ?? null : null;
   if (reconciliation !== null) {
     nonNegativeInteger(
       reconciliation.reportHistory.observedReportHistoryMonths,


### PR DESCRIPTION
### Motivation
- Fix a logic regression where canonical `implementationHistory` could satisfy the global operational-resilience eligibility gate and thereby allow editorial fact-backed contributions to be scored even when the editorial overlay was too young, contrary to the v9 methodology docs. 
- Preserve the documented intent that canonical implementation history should only satisfy the maturity gate for producer-measured persistent market depth and not create independent credit for editorial resilience claims.

### Description
- Split eligibility into two traces by introducing `implementationEligibilityTrace()` and keeping the existing `eligibilityTrace()` as the editorial-overlay eligibility check, and stop passing `implementationHistory` into the overlay trace. 
- Use `implementationHistory` only to qualify `measuredMarketDepth` when `overlayEligibility` is not satisfied and `measuredMarketDepth` is present, while keeping redemption, stress-recovery, and reserve-reconciliation contributions gated by the editorial `overlayEligibility`. 
- Ensure contributions derived from the editorial `fact` (cumulative redemption, stress windows, stress episodes, reserve reconciliation) are evaluated only when the editorial overlay eligibility is satisfied. 
- Add unit and integration regressions that assert implementation history can qualify measured depth but cannot qualify immature editorial overlays, and commit the fixes in `shared/lib/safety-score-v9/operational-resilience.ts` and tests in `shared/lib/__tests__/safety-score-v9-operational-resilience.test.ts` and `shared/lib/__tests__/safety-score-v9-operational-resilience-integration.test.ts`.

### Testing
- Ran the focused test suite with `npx vitest run shared/lib/__tests__/safety-score-v9-operational-resilience.test.ts shared/lib/__tests__/safety-score-v9-operational-resilience-integration.test.ts`, and all tests passed (23 tests passed). 
- Ran type checks with `npm run typecheck:tests` and it succeeded. 
- Ran project checks `npm run check:worker-boundary`, `npm run check:shared-cycles`, and `npm run check:doc-sync`, all of which passed (no circular dependencies and doc-sync OK). 
- Ran `git diff --check` and repository checks used by the change contract with no outstanding issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64f64bda248332a901dab07fabb54a)