### PR TITLE
Honor default roles in variant validation

### DIFF
--- a/shared/lib/stablecoins/__tests__/validate-variants.test.ts
+++ b/shared/lib/stablecoins/__tests__/validate-variants.test.ts
@@ -266,6 +266,33 @@ describe("validateVariantRelationships", () => {
     expect(errors[0]).toContain("does not declare variantOf / variantKind");
   });
 
+  it("applies the default serial-claim role to reviewed wrapper relationships", () => {
+    const parent = makeParent("parent-a", "fiat-cash");
+    const child = makeCoin({
+      id: "missing-default-role-variant",
+      dependencyReview: {
+        reviewedAt: "2026-07-21",
+        reviewer: "test",
+        confidence: "verified",
+        sources: [{ label: "Wrapper evidence", url: "https://example.com/wrapper" }],
+        rationale: "The reviewed relationship is a direct 1:1 wrapper claim.",
+        relationships: [
+          {
+            id: "parent-a",
+            weight: 1,
+            type: "wrapper",
+            reason: "Every child unit is a direct claim on one parent unit.",
+          },
+        ],
+      },
+    });
+
+    const errors = validateVariantRelationships([parent, child]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("active USD asset with a reviewed serial wrapper");
+    expect(errors[0]).toContain("does not declare variantOf / variantKind");
+  });
+
   it("does not infer a missing variant for mixed-strategy NAV tokens", () => {
     const parentA = makeParent("parent-a", "fiat-cash");
     const parentB = makeParent("parent-b", "fiat-cash");

--- a/shared/lib/stablecoins/validate-variants.ts
+++ b/shared/lib/stablecoins/validate-variants.ts
@@ -1,8 +1,18 @@
 import type { StablecoinMeta } from "../../types";
+import { defaultV9DependencyEconomicRole } from "../../types/dependency-types";
 import { isActiveStablecoinMeta, isReadableStablecoinMeta } from "./status";
 
 function hasVariantFields(meta: StablecoinMeta): boolean {
   return meta.variantOf != null || meta.variantKind != null;
+}
+
+function isReviewedSerialWrapper(
+  relationship: NonNullable<StablecoinMeta["dependencyReview"]>["relationships"][number],
+): boolean {
+  return (
+    relationship.type === "wrapper" &&
+    (relationship.economicRole ?? defaultV9DependencyEconomicRole(relationship.type)) === "serial-claim"
+  );
 }
 
 function collectDirectWrapperParentCandidates(meta: StablecoinMeta): string[] {
@@ -25,7 +35,7 @@ function collectDirectWrapperParentCandidates(meta: StablecoinMeta): string[] {
   }
 
   for (const relationship of meta.dependencyReview?.relationships ?? []) {
-    if (relationship.type === "wrapper" && relationship.economicRole === "serial-claim") {
+    if (isReviewedSerialWrapper(relationship)) {
       candidates.add(relationship.id);
     }
   }
@@ -34,9 +44,7 @@ function collectDirectWrapperParentCandidates(meta: StablecoinMeta): string[] {
 }
 
 function hasReviewedSerialWrapperRelationship(meta: StablecoinMeta): boolean {
-  return (meta.dependencyReview?.relationships ?? []).some(
-    (relationship) => relationship.type === "wrapper" && relationship.economicRole === "serial-claim",
-  );
+  return (meta.dependencyReview?.relationships ?? []).some(isReviewedSerialWrapper);
 }
 
 function hasOtherTrackedLinkedExposure(


### PR DESCRIPTION
### Motivation
- The variant validator only treated reviewed `wrapper` relationships as serial wrappers when `economicRole` was explicitly set to `"serial-claim"`, but the schema and runtime default an omitted role to `serial-claim` for non-collateral types, creating a validation gap.

### Description
- Import `defaultV9DependencyEconomicRole` and add `isReviewedSerialWrapper()` which treats `relationship.economicRole ?? defaultV9DependencyEconomicRole(relationship.type)` as the canonical role.
- Use the new `isReviewedSerialWrapper()` predicate in `collectDirectWrapperParentCandidates()` and `hasReviewedSerialWrapperRelationship()` to ensure omitted roles are interpreted consistently.
- Add a regression test proving that a reviewed `wrapper` relationship with an omitted `economicRole` still triggers the missing `variantOf`/`variantKind` guard.

### Testing
- Ran `npx vitest run shared/lib/stablecoins/__tests__/validate-variants.test.ts --reporter=dot` and all tests passed (18 tests).
- Ran `npm run check:stablecoin-data` and the stablecoin data validation reported OK and the generated aggregate was current.
- Ran `npm run check:worker-boundary` and `npm run check:shared-cycles` and both checks passed.
- Ran `git diff --check` and no diff/format issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64f64b8e0c8332a30cfb4f7171c551)