### PR TITLE
Fix Aerodrome exact-route scoring eligibility

### DIFF
--- a/shared/lib/__tests__/p4-exit-route-capacity.test.ts
+++ b/shared/lib/__tests__/p4-exit-route-capacity.test.ts
@@ -79,6 +79,17 @@ describe("P4 DEX exit route observations", () => {
     };
   }
 
+  function aerodromeMeasuredProfile(quotedAt: number): DexMeasuredExecutionPublicProfile {
+    const profile = measuredProfile(quotedAt);
+    return {
+      ...profile,
+      adapterProfileId: "aerodrome-slipstream-quoter-v2",
+      protocol: "aerodrome-slipstream",
+      chain: "base",
+      poolId: `base:${profile.poolProvenance.resolvedPoolAddress}`,
+    };
+  }
+
   function nativeCapacityCurve() {
     return DEX_MEASURED_CAPACITY_NOTIONALS_USD.map((requestedNotionalUsd) => {
       const executableUsd = Math.min(requestedNotionalUsd, 1_000_000);
@@ -725,6 +736,40 @@ describe("P4 DEX exit route observations", () => {
       evidenceKind: "measured-executable-depth",
       scoreEligible: true,
     });
+  });
+
+  it("accepts the active Base Aerodrome Slipstream adapter as exact measured evidence", () => {
+    const observedAt = 1_752_560_000;
+    const profile = aerodromeMeasuredProfile(observedAt - 60);
+    const result = buildP4DexExitRouteObservations({
+      stablecoinId: "usdc-circle",
+      observedAt,
+      retainedPools: [{
+        poolId: "defillama-yields-uuid",
+        project: "aerodrome-slipstream",
+        chain: "base",
+        tvlUsd: 2_000_000,
+        symbol: "USDC-USDT",
+        poolType: "aerodrome-slipstream",
+        source: "dl",
+        extra: {
+          measuredExecution: profile,
+          measuredExecutionPhysicalPoolId: profile.poolId,
+        },
+      }],
+    });
+
+    expect(result.observations[0]).toMatchObject({
+      adapterProfileId: "aerodrome-slipstream-quoter-v2",
+      evidenceKind: "measured-executable-depth",
+      scoreEligible: true,
+    });
+    expect(result.coverage).toMatchObject({
+      scoreEligibleCapabilityPoolCount: 1,
+      scoreEligiblePoolCount: 1,
+      unsupportedPoolCount: 0,
+    });
+    expect(isDexExitRouteCoverageComplete(result.coverage)).toBe(true);
   });
 
   it("keeps the 3pool reserve model score-facing until the atomic packet matures", () => {

--- a/shared/lib/p4-exit-route-capacity.ts
+++ b/shared/lib/p4-exit-route-capacity.ts
@@ -559,6 +559,14 @@ function isNativeMeasuredExecutionAdapter(adapterProfileId: string): boolean {
   );
 }
 
+function isQuoterV2MeasuredExecutionAdapter(adapterProfileId: string): boolean {
+  return (
+    adapterProfileId === "uniswap-v3-quoter-v2" ||
+    adapterProfileId === "pancakeswap-v3-quoter-v2" ||
+    adapterProfileId === "aerodrome-slipstream-quoter-v2"
+  );
+}
+
 function capabilityForPool(
   pool: P4DexRoutePoolInput,
   options: { ignoreMeasured?: boolean } = {},
@@ -570,8 +578,7 @@ function capabilityForPool(
     return capabilityById(
       isNativeMeasuredExecutionAdapter(measuredProfile.adapterProfileId)
         ? "native-measured-exact"
-        : measuredProfile.adapterProfileId === "uniswap-v3-quoter-v2" ||
-        measuredProfile.adapterProfileId === "pancakeswap-v3-quoter-v2"
+        : isQuoterV2MeasuredExecutionAdapter(measuredProfile.adapterProfileId)
         ? "quoter-v2-measured-exact"
         : measuredProfile.adapterProfileId === "curve-cryptoswap-get-dy-v1"
           ? "curve-cryptoswap-measured-exact"
@@ -672,8 +679,7 @@ function validateMeasuredExecutionProfile(
   if (!schemaValid) issues.push("invalid-profile-schema");
   if (!isNative) {
     if (
-      profile.adapterProfileId !== "uniswap-v3-quoter-v2" &&
-      profile.adapterProfileId !== "pancakeswap-v3-quoter-v2" &&
+      !isQuoterV2MeasuredExecutionAdapter(profile.adapterProfileId) &&
       profile.adapterProfileId !== "curve-cryptoswap-get-dy-v1" &&
       profile.adapterProfileId !== CURVE_STABLESWAP_ADAPTER_PROFILE_ID &&
       profile.adapterProfileId !== CURVE_STABLESWAP_NG_ADAPTER_PROFILE_ID


### PR DESCRIPTION
### Motivation

- Aerodrome Slipstream was added to the measured-execution registry but downstream P4 exit-route scoring and profile validation still treated only `uniswap-v3-quoter-v2` and `pancakeswap-v3-quoter-v2` as score-eligible, causing newly ungated Aerodrome profiles to be rejected and fail closed. 
- The intent of this change is to classify the activated Aerodrome Slipstream quoter as an exact measured V2 quoter capability so its measuredExecution profiles can produce score-eligible exact-route observations. 

### Description

- Add a shared predicate `isQuoterV2MeasuredExecutionAdapter()` that includes `aerodrome-slipstream-quoter-v2` alongside the existing V2 quoter adapters and use it when selecting capability IDs in `capabilityForPool`. 
- Update `validateMeasuredExecutionProfile()` to accept `aerodrome-slipstream-quoter-v2` as a score-eligible non-native quoter by using the new predicate. 
- Add a regression fixture `aerodromeMeasuredProfile()` and a test that asserts a Base Aerodrome Slipstream measured profile produces a `measured-executable-depth` observation that is `scoreEligible` and completes P4 coverage in `shared/lib/__tests__/p4-exit-route-capacity.test.ts`. 

### Testing

- Ran `npx vitest run shared/lib/__tests__/p4-exit-route-capacity.test.ts` and the suite passed (31 tests passed). 
- Ran `npm run check:worker-boundary` and `npm run check:shared-cycles` and both checks passed. 
- Ran `git diff --check` to verify no whitespace/tooling defects and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64f64b85a883328a04897fbea774b9)