### PR TITLE
Preserve mint/burn aggregation evidence during retention

### DIFF
--- a/worker/src/cron/__tests__/mint-burn-retention.test.ts
+++ b/worker/src/cron/__tests__/mint-burn-retention.test.ts
@@ -228,6 +228,55 @@ describe("mint/burn retention", () => {
     expect(eventIds(sqlite)).toEqual([]);
   });
 
+  it("keeps old hourly evidence until a capped raw-event backlog drains", async () => {
+    const { sqlite, db } = setupDb();
+    openDb = sqlite;
+    const oldTimestamp = NOW_SEC - MINT_BURN_HOURLY_RETENTION_SEC - HOUR_SEC;
+    const oldHour = hourFor(oldTimestamp);
+    for (let index = 0; index < 5; index += 1) {
+      insertEvent(sqlite, {
+        id: `old-eligible-${index}`,
+        timestamp: oldTimestamp + index,
+      });
+    }
+
+    const first = await pruneMintBurnRetention(db, NOW_SEC, undefined, {
+      eventBatchLimit: 2,
+      eventRunLimit: 3,
+      hourlyBatchLimit: 2,
+      hourlyRunLimit: 2,
+    });
+
+    expect(first.eventRows.deletedRows).toBe(3);
+    expect(first.eventRows.cappedAtLimit).toBe(true);
+    expect(first.hourlyRows.deletedRows).toBe(0);
+    expect(first.hourlyRows.oldestEligibleAt).toBeNull();
+    expect(eventIds(sqlite)).toHaveLength(2);
+    expect(
+      sqlite
+        .prepare("SELECT COUNT(*) AS count FROM mint_burn_hourly WHERE hour_ts = ?")
+        .get(oldHour),
+    ).toEqual({ count: 1 });
+
+    const second = await pruneMintBurnRetention(db, NOW_SEC, undefined, {
+      eventBatchLimit: 2,
+      eventRunLimit: 3,
+      hourlyBatchLimit: 2,
+      hourlyRunLimit: 2,
+    });
+
+    expect(second.eventRows.deletedRows).toBe(2);
+    expect(second.eventRows.cappedAtLimit).toBe(false);
+    expect(second.hourlyRows.deletedRows).toBe(1);
+    expect(second.hourlyRows.oldestEligibleAt).toBeNull();
+    expect(eventIds(sqlite)).toEqual([]);
+    expect(
+      sqlite
+        .prepare("SELECT COUNT(*) AS count FROM mint_burn_hourly WHERE hour_ts = ?")
+        .get(oldHour),
+    ).toEqual({ count: 0 });
+  });
+
   it("reports a family cleanup error without preventing the other family", async () => {
     const { sqlite, db } = setupDb();
     openDb = sqlite;

--- a/worker/src/cron/mint-burn/retention.ts
+++ b/worker/src/cron/mint-burn/retention.ts
@@ -201,10 +201,18 @@ async function pruneHourlyRows(
       `/* pharos:mint-burn:hourly-retention-delete */
        DELETE FROM mint_burn_hourly
         WHERE rowid IN (
-          SELECT rowid
-            FROM mint_burn_hourly
-           WHERE hour_ts < ?
-           ORDER BY hour_ts ASC
+          SELECT hourly.rowid
+            FROM mint_burn_hourly hourly
+           WHERE hourly.hour_ts < ?
+             AND NOT EXISTS (
+               SELECT 1
+                 FROM mint_burn_events event
+                WHERE event.stablecoin_id = hourly.stablecoin_id
+                  AND event.chain_id = hourly.chain_id
+                  AND event.timestamp >= hourly.hour_ts
+                  AND event.timestamp < hourly.hour_ts + 3600
+             )
+           ORDER BY hourly.hour_ts ASC
            LIMIT ?
         )`,
       (limit) => [cutoff, limit],
@@ -227,10 +235,18 @@ async function pruneHourlyRows(
     const oldestEligible = await runWithOverloadRetry(
       () => db
         .prepare(
-          `SELECT hour_ts AS oldest_eligible_at
-             FROM mint_burn_hourly
-            WHERE hour_ts < ?
-            ORDER BY hour_ts ASC
+          `SELECT hourly.hour_ts AS oldest_eligible_at
+             FROM mint_burn_hourly hourly
+            WHERE hourly.hour_ts < ?
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM mint_burn_events event
+                 WHERE event.stablecoin_id = hourly.stablecoin_id
+                   AND event.chain_id = hourly.chain_id
+                   AND event.timestamp >= hourly.hour_ts
+                   AND event.timestamp < hourly.hour_ts + 3600
+              )
+            ORDER BY hourly.hour_ts ASC
             LIMIT 1`,
         )
         .bind(cutoff)


### PR DESCRIPTION
## Summary
- keep an hourly mint/burn aggregate while any raw event still depends on it as deletion evidence
- make hourly backlog telemetry use the same dependency-safe predicate
- cover capped multi-run raw drains with a SQLite-backed regression

## Production defect
The first two bounded cleanup passes deleted old hourly rows after each raw-event batch. Remaining raw rows in those hours then lost their aggregation evidence and became permanently ineligible. This forward guard stops that dependency inversion before recovering the already-stranded backlog.

## Checks
- `npx vitest run worker/src/cron/__tests__/mint-burn-retention.test.ts`
- `npm run typecheck:worker`
- `npm run check:env-contract`
- production `EXPLAIN QUERY PLAN` confirms `idx_mbh_ts` and covering `idx_mbe_coin_chain_ts`
- `git diff --check`
- pre-push commit-derived artifact check