### PR TITLE
Recover stranded mint/burn aggregation evidence

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3227,7 +3227,7 @@ Returns per-chain breakdown and hourly timeseries for a single coin. Returns `40
 
 ### `GET /api/mint-burn-events`
 
-Paginated list of recent individual mint/burn events for a specific stablecoin. Events are sourced from on-chain logs via Alchemy JSON-RPC. Safely valued, aggregated, and Tape-projected event rows are retained for at least 8 days; protected repair or projection debt can remain longer. The 90-day aggregate flow history is served separately by `GET /api/mint-burn-flows`.
+Paginated list of recent individual mint/burn events for a specific stablecoin. Events are sourced from on-chain logs via Alchemy JSON-RPC. Safely valued, aggregated, and Tape-projected event rows are retained for at least 8 days; protected repair or projection debt can remain longer. Missing aggregation evidence is rebuilt in bounded batches only for terminal hours without unresolved price debt, and an hourly bucket remains protected while any raw event depends on it. The 90-day aggregate flow history is served separately by `GET /api/mint-burn-flows`.
 
 **Cache:** producer-backed
 

--- a/docs/mint-burn-flows.md
+++ b/docs/mint-burn-flows.md
@@ -395,12 +395,13 @@ Detects simultaneous outflows from risky stablecoins and inflows to safe havens.
 
 ## Retention
 
-The critical `sync-mint-burn` producer owns bounded cleanup after ingestion:
+The critical `sync-mint-burn` producer owns bounded cleanup and aggregation-evidence repair after ingestion:
 
-- Individual `mint_burn_events` rows are retained for at least **8 days**. An older row is eligible only after its USD valuation is settled (`amount_usd` is present or price repair is explicitly `recovered`/`irreducible`), its stablecoin/chain/hour aggregate exists, and the Tape projector cursor has passed its timestamp. Unpriced, pending-repair, unaggregated, and not-yet-projected rows remain protected regardless of age.
-- `mint_burn_hourly` buckets are retained for at least **95 days**, preserving the public 90-day aggregate window with a five-day operating margin.
-- Deletes run oldest-first in 10,000-row statements, capped at 50,000 event rows and 25,000 hourly rows per critical run. The extended lane does not run cleanup.
-- Cron metadata reports each family's cutoff, deleted count, oldest remaining and eligible timestamp, cap state, duration, and error. A cleanup error degrades an otherwise successful critical run without discarding successful ingestion; the other retention family still gets its bounded attempt.
+- Individual `mint_burn_events` rows are retained for at least **8 days**. An older row is eligible only after its USD valuation is settled (`amount_usd` is present or price repair is explicitly `recovered`/`irreducible`), its stablecoin/chain/hour aggregate exists, and the Tape projector cursor has passed its timestamp. Unpriced, pending-repair, and not-yet-projected rows remain protected regardless of age.
+- A missing hourly bucket for terminal, projected raw rows is rebuilt oldest-first from the still-retained events before deletion. A candidate hour containing unresolved or pending price-repair debt is not rebuilt or pruned. Historical price repair likewise recalculates and verifies only its affected hours, so raw turnover cannot erase unrelated aggregate history.
+- `mint_burn_hourly` buckets are retained for at least **95 days**, preserving the public 90-day aggregate window with a five-day operating margin. Cleanup never removes a bucket while any raw event still depends on it as aggregation evidence.
+- Repairs are capped at 5,000 hourly buckets per critical run. Deletes run oldest-first in 10,000-row statements, capped at 50,000 event rows and 25,000 hourly rows per critical run. The extended lane does not run cleanup.
+- Cron metadata reports aggregation repair cutoff, repaired count, oldest repairable timestamp, cap state, duration, and error, plus each deletion family's cutoff, deleted count, oldest remaining and eligible timestamp, cap state, duration, and error. A cleanup stage error degrades an otherwise successful critical run without discarding successful ingestion; the remaining stages still get their bounded attempts.
 
 The daily `mint-burn-growth-watchdog` cron remains a fail-safe rather than the retention owner. It reports degraded at **2.3M event rows**, the existing proxy for the agreed ~5 GB investigation point, so operators can detect cleanup that is not converging, an unexpectedly large protected backlog, or abnormal producer growth. D1 disallows `PRAGMA page_count`, hence the row-count proxy.
 

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -1,6 +1,6 @@
 {
   "api-reference": {
-    "dateModified": "2026-07-26T07:32:16+02:00",
+    "dateModified": "2026-07-26T09:23:42+02:00",
     "dateCreated": "2026-02-23T15:28:17+01:00"
   },
   "architecture": {
@@ -60,7 +60,7 @@
     "dateCreated": "2026-04-19T03:17:40+02:00"
   },
   "mint-burn-flows": {
-    "dateModified": "2026-07-26T07:32:16+02:00",
+    "dateModified": "2026-07-26T09:23:42+02:00",
     "dateCreated": "2026-03-01T16:21:41+01:00"
   },
   "yield-intelligence": {

--- a/worker/src/cron/__tests__/mint-burn-retention.test.ts
+++ b/worker/src/cron/__tests__/mint-burn-retention.test.ts
@@ -24,15 +24,26 @@ function setupDb(): { sqlite: DatabaseSync; db: D1Database } {
       id TEXT PRIMARY KEY,
       stablecoin_id TEXT NOT NULL,
       chain_id TEXT NOT NULL,
+      direction TEXT NOT NULL DEFAULT 'mint',
+      amount REAL NOT NULL DEFAULT 1,
       amount_usd REAL,
       timestamp INTEGER NOT NULL,
-      price_repair_status TEXT
+      price_repair_status TEXT,
+      burn_type TEXT,
+      flow_type TEXT NOT NULL DEFAULT 'standard'
     );
     CREATE INDEX idx_mbe2_ts ON mint_burn_events(timestamp DESC);
+    CREATE INDEX idx_mbe_coin_chain_ts
+      ON mint_burn_events(stablecoin_id, chain_id, timestamp DESC);
     CREATE TABLE mint_burn_hourly (
       stablecoin_id TEXT NOT NULL,
       chain_id TEXT NOT NULL,
       hour_ts INTEGER NOT NULL,
+      mint_count INTEGER NOT NULL DEFAULT 0,
+      burn_count INTEGER NOT NULL DEFAULT 0,
+      mint_volume_usd REAL NOT NULL DEFAULT 0,
+      burn_volume_usd REAL NOT NULL DEFAULT 0,
+      net_flow_usd REAL NOT NULL DEFAULT 0,
       PRIMARY KEY (stablecoin_id, chain_id, hour_ts)
     );
     CREATE INDEX idx_mbh_ts ON mint_burn_hourly(hour_ts DESC);
@@ -121,6 +132,7 @@ describe("mint/burn retention", () => {
     insertEvent(sqlite, {
       id: "protected-no-hourly",
       timestamp: noHourlyTimestamp,
+      amountUsd: null,
       withHourly: false,
     });
     insertEvent(sqlite, { id: "boundary", timestamp: eventCutoff });
@@ -148,6 +160,13 @@ describe("mint/burn retention", () => {
       deletedRows: 2,
       oldestRemainingAt: noHourlyTimestamp,
       oldestEligibleAt: null,
+      cappedAtLimit: false,
+      error: null,
+    });
+    expect(result.aggregationRepair).toMatchObject({
+      cutoff: eventCutoff,
+      repairedRows: 0,
+      oldestRepairableAt: null,
       cappedAtLimit: false,
       error: null,
     });
@@ -277,6 +296,109 @@ describe("mint/burn retention", () => {
     ).toEqual({ count: 0 });
   });
 
+  it("rebuilds missing terminal hourly evidence before pruning raw rows", async () => {
+    const { sqlite, db } = setupDb();
+    openDb = sqlite;
+    const oldTimestamp = NOW_SEC - MINT_BURN_HOURLY_RETENTION_SEC - HOUR_SEC;
+    insertEvent(sqlite, {
+      id: "stranded-terminal",
+      timestamp: oldTimestamp,
+      withHourly: false,
+    });
+
+    const result = await pruneMintBurnRetention(db, NOW_SEC, undefined, {
+      repairCandidateEventLimit: 2,
+      repairRunLimit: 1,
+      eventBatchLimit: 2,
+      eventRunLimit: 2,
+      hourlyBatchLimit: 2,
+      hourlyRunLimit: 2,
+    });
+
+    expect(result.aggregationRepair).toMatchObject({
+      repairedRows: 1,
+      oldestRepairableAt: null,
+      cappedAtLimit: false,
+      error: null,
+    });
+    expect(result.eventRows.deletedRows).toBe(1);
+    expect(result.hourlyRows.deletedRows).toBe(1);
+    expect(eventIds(sqlite)).toEqual([]);
+    expect(sqlite.prepare("SELECT COUNT(*) AS count FROM mint_burn_hourly").get()).toEqual({
+      count: 0,
+    });
+  });
+
+  it("does not rebuild or prune a missing hour with unresolved price debt", async () => {
+    const { sqlite, db } = setupDb();
+    openDb = sqlite;
+    const oldTimestamp = NOW_SEC - MINT_BURN_HOURLY_RETENTION_SEC - HOUR_SEC;
+    insertEvent(sqlite, {
+      id: "terminal-sibling",
+      timestamp: oldTimestamp,
+      withHourly: false,
+    });
+    insertEvent(sqlite, {
+      id: "unresolved-sibling",
+      timestamp: oldTimestamp + 1,
+      amountUsd: null,
+      withHourly: false,
+    });
+
+    const result = await pruneMintBurnRetention(db, NOW_SEC);
+
+    expect(result.aggregationRepair).toMatchObject({
+      repairedRows: 0,
+      oldestRepairableAt: null,
+      cappedAtLimit: false,
+      error: null,
+    });
+    expect(result.eventRows.deletedRows).toBe(0);
+    expect(result.hourlyRows.deletedRows).toBe(0);
+    expect(eventIds(sqlite)).toEqual(["terminal-sibling", "unresolved-sibling"]);
+  });
+
+  it("continues aggregation-evidence repair after its hourly limit is reached", async () => {
+    const { sqlite, db } = setupDb();
+    openDb = sqlite;
+    const oldTimestamp = NOW_SEC - MINT_BURN_HOURLY_RETENTION_SEC - 4 * HOUR_SEC;
+    for (let index = 0; index < 3; index += 1) {
+      insertEvent(sqlite, {
+        id: `stranded-hour-${index}`,
+        timestamp: oldTimestamp + index * HOUR_SEC,
+        withHourly: false,
+      });
+    }
+
+    const first = await pruneMintBurnRetention(db, NOW_SEC, undefined, {
+      repairCandidateEventLimit: 3,
+      repairRunLimit: 2,
+      eventBatchLimit: 3,
+      eventRunLimit: 3,
+      hourlyBatchLimit: 3,
+      hourlyRunLimit: 3,
+    });
+
+    expect(first.aggregationRepair.repairedRows).toBe(2);
+    expect(first.aggregationRepair.cappedAtLimit).toBe(true);
+    expect(first.aggregationRepair.oldestRepairableAt).not.toBeNull();
+    expect(eventIds(sqlite)).toEqual(["stranded-hour-2"]);
+
+    const second = await pruneMintBurnRetention(db, NOW_SEC, undefined, {
+      repairCandidateEventLimit: 3,
+      repairRunLimit: 2,
+      eventBatchLimit: 3,
+      eventRunLimit: 3,
+      hourlyBatchLimit: 3,
+      hourlyRunLimit: 3,
+    });
+
+    expect(second.aggregationRepair.repairedRows).toBe(1);
+    expect(second.aggregationRepair.cappedAtLimit).toBe(false);
+    expect(second.aggregationRepair.oldestRepairableAt).toBeNull();
+    expect(eventIds(sqlite)).toEqual([]);
+  });
+
   it("reports a family cleanup error without preventing the other family", async () => {
     const { sqlite, db } = setupDb();
     openDb = sqlite;
@@ -301,6 +423,36 @@ describe("mint/burn retention", () => {
     expect(result.eventRows.error).toBe("event retention unavailable");
     expect(result.hourlyRows.error).toBeNull();
     expect(result.error).toContain("eventRows: event retention unavailable");
+  });
+
+  it("reports aggregation repair failure without preventing bounded deletion", async () => {
+    const { sqlite, db } = setupDb();
+    openDb = sqlite;
+    const cutoff = NOW_SEC - MINT_BURN_EVENT_RETENTION_SEC;
+    insertEvent(sqlite, { id: "eligible-after-repair-error", timestamp: cutoff - 1 });
+    const failingDb = {
+      ...db,
+      prepare(sql: string) {
+        if (!sql.includes("pharos:mint-burn:aggregation-evidence-repair")) {
+          return db.prepare(sql);
+        }
+        const statement = {
+          bind: () => statement as unknown as D1PreparedStatement,
+          run: async () => {
+            throw new Error("aggregation repair unavailable");
+          },
+        };
+        return statement as unknown as D1PreparedStatement;
+      },
+    } as D1Database;
+
+    const result = await pruneMintBurnRetention(failingDb, NOW_SEC);
+
+    expect(result.aggregationRepair.error).toBe("aggregation repair unavailable");
+    expect(result.eventRows.deletedRows).toBe(1);
+    expect(result.eventRows.error).toBeNull();
+    expect(result.hourlyRows.error).toBeNull();
+    expect(result.error).toContain("aggregationRepair: aggregation repair unavailable");
   });
 
   it("throws before D1 work when already aborted", async () => {

--- a/worker/src/cron/mint-burn/retention.ts
+++ b/worker/src/cron/mint-burn/retention.ts
@@ -11,6 +11,8 @@ const MINT_BURN_TAPE_CURSOR_KEY = "tape-projector:cursor:mint_burn.large_flow";
 const DEFAULT_DELETE_BATCH_LIMIT = 10_000;
 const DEFAULT_EVENT_DELETE_RUN_LIMIT = 50_000;
 const DEFAULT_HOURLY_DELETE_RUN_LIMIT = 25_000;
+const DEFAULT_REPAIR_CANDIDATE_EVENT_LIMIT = 50_000;
+const DEFAULT_HOURLY_REPAIR_RUN_LIMIT = 5_000;
 
 export interface MintBurnRetentionFamilyResult {
   cutoff: number;
@@ -23,13 +25,25 @@ export interface MintBurnRetentionFamilyResult {
 }
 
 export interface MintBurnRetentionResult {
+  aggregationRepair: MintBurnAggregationRepairResult;
   eventRows: MintBurnRetentionFamilyResult;
   hourlyRows: MintBurnRetentionFamilyResult;
   durationMs: number;
   error: string | null;
 }
 
+export interface MintBurnAggregationRepairResult {
+  cutoff: number;
+  repairedRows: number;
+  oldestRepairableAt: number | null;
+  cappedAtLimit: boolean;
+  durationMs: number;
+  error: string | null;
+}
+
 interface MintBurnRetentionOptions {
+  repairCandidateEventLimit?: number;
+  repairRunLimit?: number;
   eventBatchLimit?: number;
   eventRunLimit?: number;
   hourlyBatchLimit?: number;
@@ -69,6 +83,168 @@ async function deleteCapped(
     deletedRows,
     cappedAtLimit: deletedRows >= runLimit,
   };
+}
+
+async function repairMissingHourlyRows(
+  db: D1Database,
+  nowSec: number,
+  candidateEventLimit: number,
+  runLimit: number,
+  signal?: AbortSignal,
+): Promise<MintBurnAggregationRepairResult> {
+  const startedAtMs = Date.now();
+  const cutoff = nowSec - MINT_BURN_EVENT_RETENTION_SEC;
+  const result: MintBurnAggregationRepairResult = {
+    cutoff,
+    repairedRows: 0,
+    oldestRepairableAt: null,
+    cappedAtLimit: false,
+    durationMs: 0,
+    error: null,
+  };
+
+  try {
+    throwIfAborted(signal);
+    const repaired = await runWithOverloadRetry(
+      () => db
+        .prepare(
+          `/* pharos:mint-burn:aggregation-evidence-repair */
+           WITH oldest_candidates AS MATERIALIZED (
+             SELECT
+               event.stablecoin_id,
+               event.chain_id,
+               (event.timestamp / 3600) * 3600 AS hour_ts,
+               event.timestamp
+             FROM mint_burn_events event INDEXED BY idx_mbe2_ts
+             WHERE event.timestamp < ?
+               AND (
+                 event.amount_usd IS NOT NULL
+                 OR event.price_repair_status IN ('recovered', 'irreducible')
+               )
+               AND COALESCE(event.price_repair_status, '') <> 'pending_aggregate'
+               AND event.timestamp <= COALESCE((
+                 SELECT CAST(value AS INTEGER)
+                   FROM cache
+                  WHERE key = ?
+               ), 0)
+               AND NOT EXISTS (
+                 SELECT 1
+                   FROM mint_burn_hourly hourly
+                  WHERE hourly.stablecoin_id = event.stablecoin_id
+                    AND hourly.chain_id = event.chain_id
+                    AND hourly.hour_ts = (event.timestamp / 3600) * 3600
+               )
+               AND NOT EXISTS (
+                 SELECT 1
+                   FROM mint_burn_events sibling
+                  WHERE sibling.stablecoin_id = event.stablecoin_id
+                    AND sibling.chain_id = event.chain_id
+                    AND sibling.timestamp >= (event.timestamp / 3600) * 3600
+                    AND sibling.timestamp < ((event.timestamp / 3600) * 3600) + 3600
+                    AND (
+                      (
+                        sibling.amount_usd IS NULL
+                        AND COALESCE(sibling.price_repair_status, '') NOT IN ('recovered', 'irreducible')
+                      )
+                      OR sibling.price_repair_status = 'pending_aggregate'
+                    )
+               )
+             ORDER BY event.timestamp ASC
+             LIMIT ?
+           ), candidate_hours AS MATERIALIZED (
+             SELECT stablecoin_id, chain_id, hour_ts, MIN(timestamp) AS oldest_at
+               FROM oldest_candidates
+              GROUP BY stablecoin_id, chain_id, hour_ts
+              ORDER BY oldest_at ASC
+              LIMIT ?
+           )
+           INSERT OR IGNORE INTO mint_burn_hourly
+             (stablecoin_id, chain_id, hour_ts, mint_count, burn_count,
+              mint_volume_usd, burn_volume_usd, net_flow_usd)
+           SELECT
+             event.stablecoin_id,
+             event.chain_id,
+             candidate.hour_ts,
+             SUM(CASE WHEN event.direction = 'mint' AND event.flow_type = 'standard' THEN 1 ELSE 0 END),
+             SUM(CASE WHEN event.direction = 'burn' AND event.burn_type = 'effective_burn' AND event.flow_type = 'standard' THEN 1 ELSE 0 END),
+             COALESCE(SUM(CASE WHEN event.direction = 'mint' AND event.flow_type = 'standard' THEN event.amount_usd ELSE 0 END), 0),
+             COALESCE(SUM(CASE WHEN event.direction = 'burn' AND event.burn_type = 'effective_burn' AND event.flow_type = 'standard' THEN event.amount_usd ELSE 0 END), 0),
+             COALESCE(SUM(CASE
+               WHEN event.direction = 'mint' AND event.flow_type = 'standard' THEN event.amount_usd
+               WHEN event.direction = 'burn' AND event.burn_type = 'effective_burn' AND event.flow_type = 'standard' THEN -event.amount_usd
+               ELSE 0
+             END), 0)
+             FROM candidate_hours candidate
+             JOIN mint_burn_events event
+               ON event.stablecoin_id = candidate.stablecoin_id
+              AND event.chain_id = candidate.chain_id
+              AND event.timestamp >= candidate.hour_ts
+              AND event.timestamp < candidate.hour_ts + 3600
+            GROUP BY event.stablecoin_id, event.chain_id, candidate.hour_ts`,
+        )
+        .bind(cutoff, MINT_BURN_TAPE_CURSOR_KEY, candidateEventLimit, runLimit)
+        .run(),
+      3,
+      signal,
+    );
+    result.repairedRows = Number(repaired.meta?.changes ?? 0);
+
+    const oldestRepairable = await runWithOverloadRetry(
+      () => db
+        .prepare(
+          `/* pharos:mint-burn:aggregation-evidence-oldest-repairable */
+           SELECT event.timestamp AS oldest_repairable_at
+             FROM mint_burn_events event INDEXED BY idx_mbe2_ts
+            WHERE event.timestamp < ?
+              AND (
+                event.amount_usd IS NOT NULL
+                OR event.price_repair_status IN ('recovered', 'irreducible')
+              )
+              AND COALESCE(event.price_repair_status, '') <> 'pending_aggregate'
+              AND event.timestamp <= COALESCE((
+                SELECT CAST(value AS INTEGER)
+                  FROM cache
+                 WHERE key = ?
+              ), 0)
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM mint_burn_hourly hourly
+                 WHERE hourly.stablecoin_id = event.stablecoin_id
+                   AND hourly.chain_id = event.chain_id
+                   AND hourly.hour_ts = (event.timestamp / 3600) * 3600
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM mint_burn_events sibling
+                 WHERE sibling.stablecoin_id = event.stablecoin_id
+                   AND sibling.chain_id = event.chain_id
+                   AND sibling.timestamp >= (event.timestamp / 3600) * 3600
+                   AND sibling.timestamp < ((event.timestamp / 3600) * 3600) + 3600
+                   AND (
+                     (
+                       sibling.amount_usd IS NULL
+                       AND COALESCE(sibling.price_repair_status, '') NOT IN ('recovered', 'irreducible')
+                     )
+                     OR sibling.price_repair_status = 'pending_aggregate'
+                   )
+              )
+            ORDER BY event.timestamp ASC
+            LIMIT 1`,
+        )
+        .bind(cutoff, MINT_BURN_TAPE_CURSOR_KEY)
+        .first<{ oldest_repairable_at: number | null }>(),
+      3,
+      signal,
+    );
+    result.oldestRepairableAt = oldestRepairable?.oldest_repairable_at ?? null;
+    result.cappedAtLimit = result.oldestRepairableAt !== null;
+  } catch (error) {
+    rethrowIfAborted(error, signal);
+    result.error = toErrorMessage(error).slice(0, 500);
+  }
+
+  result.durationMs = Math.max(0, Date.now() - startedAtMs);
+  return result;
 }
 
 async function pruneEventRows(
@@ -273,6 +449,16 @@ export async function pruneMintBurnRetention(
 ): Promise<MintBurnRetentionResult> {
   throwIfAborted(signal);
   const startedAtMs = Date.now();
+  const repairCandidateEventLimit = normalizeLimit(
+    options.repairCandidateEventLimit,
+    DEFAULT_REPAIR_CANDIDATE_EVENT_LIMIT,
+    "repairCandidateEventLimit",
+  );
+  const repairRunLimit = normalizeLimit(
+    options.repairRunLimit,
+    DEFAULT_HOURLY_REPAIR_RUN_LIMIT,
+    "repairRunLimit",
+  );
   const eventBatchLimit = normalizeLimit(
     options.eventBatchLimit,
     DEFAULT_DELETE_BATCH_LIMIT,
@@ -294,6 +480,14 @@ export async function pruneMintBurnRetention(
     "hourlyRunLimit",
   );
 
+  const aggregationRepair = await repairMissingHourlyRows(
+    db,
+    nowSec,
+    repairCandidateEventLimit,
+    repairRunLimit,
+    signal,
+  );
+  throwIfAborted(signal);
   const eventRows = await pruneEventRows(
     db,
     nowSec,
@@ -311,11 +505,13 @@ export async function pruneMintBurnRetention(
   );
 
   const errors = [
+    aggregationRepair.error ? `aggregationRepair: ${aggregationRepair.error}` : null,
     eventRows.error ? `eventRows: ${eventRows.error}` : null,
     hourlyRows.error ? `hourlyRows: ${hourlyRows.error}` : null,
   ].filter((error): error is string => error !== null);
 
   return {
+    aggregationRepair,
     eventRows,
     hourlyRows,
     durationMs: Math.max(0, Date.now() - startedAtMs),

--- a/worker/src/lib/__tests__/mint-burn-historical-price-repair.test.ts
+++ b/worker/src/lib/__tests__/mint-burn-historical-price-repair.test.ts
@@ -295,12 +295,16 @@ describe("historical mint/burn price repair", () => {
     const db = makeSqliteD1();
     try {
       const timestamp = 1_800_000_000;
+      const repairedHour = Math.floor(timestamp / 3600) * 3600;
+      const preservedHour = repairedHour - 30 * DAY;
       insertEvent(db, { id: "event-1", stablecoinId: "usdt-tether", timestamp });
       db.sqlite.exec(`
         INSERT INTO mint_burn_hourly
           (stablecoin_id, chain_id, hour_ts, mint_count, burn_count,
            mint_volume_usd, burn_volume_usd, net_flow_usd)
-        VALUES ('usdt-tether', 'ethereum', ${Math.floor(timestamp / 3600) * 3600}, 1, 0, 0, 0, 0);
+        VALUES
+          ('usdt-tether', 'ethereum', ${repairedHour}, 1, 0, 0, 0, 0),
+          ('usdt-tether', 'ethereum', ${preservedHour}, 7, 3, 700, 300, 400);
       `);
 
       const first = await repairHistoricalMintBurnPrices(db, {
@@ -335,10 +339,26 @@ describe("historical mint/burn price repair", () => {
         db.sqlite
           .prepare(
             `SELECT mint_count, mint_volume_usd, net_flow_usd
-             FROM mint_burn_hourly WHERE stablecoin_id = 'usdt-tether'`,
+             FROM mint_burn_hourly
+             WHERE stablecoin_id = 'usdt-tether' AND hour_ts = ${repairedHour}`,
           )
           .get(),
       ).toEqual({ mint_count: 1, mint_volume_usd: 99.7, net_flow_usd: 99.7 });
+      expect(
+        db.sqlite
+          .prepare(
+            `SELECT mint_count, burn_count, mint_volume_usd, burn_volume_usd, net_flow_usd
+             FROM mint_burn_hourly
+             WHERE stablecoin_id = 'usdt-tether' AND hour_ts = ${preservedHour}`,
+          )
+          .get(),
+      ).toEqual({
+        mint_count: 7,
+        burn_count: 3,
+        mint_volume_usd: 700,
+        burn_volume_usd: 300,
+        net_flow_usd: 400,
+      });
 
       const second = await repairHistoricalMintBurnPrices(db, {
         dryRun: false,

--- a/worker/src/lib/mint-burn-historical-price-repair.ts
+++ b/worker/src/lib/mint-burn-historical-price-repair.ts
@@ -6,7 +6,8 @@ import { cgHeaders, cgUrl } from "./coingecko";
 import { DEFILLAMA_COINS, USER_AGENT } from "./constants";
 import { fetchJsonWithRetry } from "./fetch-retry";
 import { buildPriceValidationContext, validatePriceCandidate } from "./price-validation";
-import { rebuildHourlyForStablecoinIds } from "./mint-burn-pipeline/persistence";
+import { recalcAffectedHours } from "./mint-burn-pipeline/persistence";
+import type { MintBurnAffectedHour } from "./mint-burn-pipeline/types";
 
 export const DEFAULT_HISTORICAL_MINT_PRICE_REPAIR_LIMIT = 100;
 export const MAX_HISTORICAL_MINT_PRICE_REPAIR_LIMIT = 500;
@@ -558,26 +559,43 @@ async function loadBacklog(db: D1Database): Promise<HistoricalMintPriceRepairBac
   };
 }
 
-async function loadPendingAggregateCoins(db: D1Database): Promise<string[]> {
+async function loadPendingAggregateHours(
+  db: D1Database,
+  stablecoinIds?: string[],
+): Promise<MintBurnAffectedHour[]> {
+  const ids = [...new Set(stablecoinIds ?? [])].sort();
+  if (stablecoinIds && ids.length === 0) return [];
+  const filter = ids.length > 0 ? buildInClause(ids) : null;
   const rows = await db
     .prepare(
-      `SELECT DISTINCT stablecoin_id
+      `SELECT
+         stablecoin_id,
+         chain_id,
+         (timestamp / 3600) * 3600 AS hour_ts
        FROM mint_burn_events
        WHERE price_repair_status = 'pending_aggregate'
-       ORDER BY stablecoin_id ASC
-       LIMIT 100`,
+         ${filter ? `AND stablecoin_id IN (${filter.sql})` : ""}
+       GROUP BY stablecoin_id, chain_id, hour_ts
+       ORDER BY stablecoin_id ASC, chain_id ASC, hour_ts ASC
+       LIMIT 500`,
     )
-    .all<{ stablecoin_id: string }>();
-  return (rows.results ?? []).map((row) => row.stablecoin_id);
+    .bind(...(filter?.binds ?? []))
+    .all<{ stablecoin_id: string; chain_id: string; hour_ts: number }>();
+  return (rows.results ?? []).map((row) => ({
+    stablecoinId: row.stablecoin_id,
+    chainId: row.chain_id,
+    hourTs: row.hour_ts,
+  }));
 }
 
-async function verifyHourlyAggregateForCoin(db: D1Database, stablecoinId: string): Promise<void> {
+async function verifyHourlyAggregateForHour(
+  db: D1Database,
+  hour: MintBurnAffectedHour,
+): Promise<void> {
   const row = await db
     .prepare(
       `WITH expected AS (
          SELECT
-           chain_id,
-           (timestamp / 3600) * 3600 AS hour_ts,
            SUM(CASE WHEN direction = 'mint' AND flow_type = 'standard' THEN 1 ELSE 0 END) AS mint_count,
            SUM(CASE WHEN direction = 'burn' AND burn_type = 'effective_burn' AND flow_type = 'standard' THEN 1 ELSE 0 END) AS burn_count,
            COALESCE(SUM(CASE WHEN direction = 'mint' AND flow_type = 'standard' THEN amount_usd ELSE 0 END), 0) AS mint_volume_usd,
@@ -589,55 +607,71 @@ async function verifyHourlyAggregateForCoin(db: D1Database, stablecoinId: string
            END), 0) AS net_flow_usd
          FROM mint_burn_events
          WHERE stablecoin_id = ?
-         GROUP BY chain_id, hour_ts
-       ), mismatches AS (
-         SELECT 1
+           AND chain_id = ?
+           AND timestamp >= ?
+           AND timestamp < ?
+       )
+       SELECT COUNT(*) AS mismatch_count
          FROM expected e
          LEFT JOIN mint_burn_hourly a
-           ON a.stablecoin_id = ? AND a.chain_id = e.chain_id AND a.hour_ts = e.hour_ts
-         WHERE a.stablecoin_id IS NULL
-            OR a.mint_count != e.mint_count
-            OR a.burn_count != e.burn_count
-            OR ABS(a.mint_volume_usd - e.mint_volume_usd) > MAX(0.000001, ABS(e.mint_volume_usd) * 0.000000001)
-            OR ABS(a.burn_volume_usd - e.burn_volume_usd) > MAX(0.000001, ABS(e.burn_volume_usd) * 0.000000001)
-            OR ABS(a.net_flow_usd - e.net_flow_usd) > MAX(0.000001, ABS(e.net_flow_usd) * 0.000000001)
-         UNION ALL
-         SELECT 1
-         FROM mint_burn_hourly a
-         LEFT JOIN expected e ON e.chain_id = a.chain_id AND e.hour_ts = a.hour_ts
-         WHERE a.stablecoin_id = ? AND e.chain_id IS NULL
-       )
-       SELECT COUNT(*) AS mismatch_count FROM mismatches`,
+           ON a.stablecoin_id = ?
+          AND a.chain_id = ?
+          AND a.hour_ts = ?
+        WHERE a.stablecoin_id IS NULL
+           OR a.mint_count != e.mint_count
+           OR a.burn_count != e.burn_count
+           OR ABS(a.mint_volume_usd - e.mint_volume_usd) > MAX(0.000001, ABS(e.mint_volume_usd) * 0.000000001)
+           OR ABS(a.burn_volume_usd - e.burn_volume_usd) > MAX(0.000001, ABS(e.burn_volume_usd) * 0.000000001)
+           OR ABS(a.net_flow_usd - e.net_flow_usd) > MAX(0.000001, ABS(e.net_flow_usd) * 0.000000001)`,
     )
-    .bind(stablecoinId, stablecoinId, stablecoinId)
+    .bind(
+      hour.stablecoinId,
+      hour.chainId,
+      hour.hourTs,
+      hour.hourTs + 3600,
+      hour.stablecoinId,
+      hour.chainId,
+      hour.hourTs,
+    )
     .first<{ mismatch_count: number }>();
   if ((row?.mismatch_count ?? 0) !== 0) {
-    throw new Error(`mint/burn aggregate verification failed for ${stablecoinId}`);
+    throw new Error(
+      `mint/burn aggregate verification failed for ${hour.stablecoinId}/${hour.chainId}/${hour.hourTs}`,
+    );
   }
 }
 
-async function rebuildAndFinalizeAggregates(db: D1Database, stablecoinIds: string[]): Promise<string[]> {
-  const ids = [...new Set(stablecoinIds)].sort();
-  if (ids.length === 0) return [];
-  await rebuildHourlyForStablecoinIds(db, ids);
-  for (const stablecoinId of ids) {
-    await verifyHourlyAggregateForCoin(db, stablecoinId);
+async function rebuildAndFinalizeAggregates(
+  db: D1Database,
+  hours: MintBurnAffectedHour[],
+): Promise<string[]> {
+  if (hours.length === 0) return [];
+  const affectedHours = new Map<string, MintBurnAffectedHour>();
+  for (const hour of hours) {
+    affectedHours.set(`${hour.stablecoinId}-${hour.chainId}-${hour.hourTs}`, hour);
+  }
+  await recalcAffectedHours(db, affectedHours);
+  for (const hour of affectedHours.values()) {
+    await verifyHourlyAggregateForHour(db, hour);
   }
   await batchExecute(
     db,
-    ids.map((stablecoinId) =>
+    [...affectedHours.values()].map((hour) =>
       db
         .prepare(
           `UPDATE mint_burn_events
            SET price_repair_status = 'recovered', price_repair_reason = NULL
            WHERE stablecoin_id = ?
+             AND chain_id = ?
+             AND timestamp >= ?
+             AND timestamp < ?
              AND price_repair_status = 'pending_aggregate'
              AND amount_usd IS NOT NULL`,
         )
-        .bind(stablecoinId),
+        .bind(hour.stablecoinId, hour.chainId, hour.hourTs, hour.hourTs + 3600),
     ),
   );
-  return ids;
+  return [...new Set([...affectedHours.values()].map((hour) => hour.stablecoinId))].sort();
 }
 
 export async function repairHistoricalMintBurnPrices(
@@ -652,10 +686,13 @@ export async function repairHistoricalMintBurnPrices(
     throw new Error(`unknown stablecoinId: ${options.stablecoinId}`);
   }
   const nowSec = options.nowSec ?? Math.floor(Date.now() / 1000);
-  const existingPendingAggregateCoins = await loadPendingAggregateCoins(db);
+  const existingPendingAggregateHours = await loadPendingAggregateHours(db);
+  const existingPendingAggregateCoins = [
+    ...new Set(existingPendingAggregateHours.map((hour) => hour.stablecoinId)),
+  ].sort();
   let aggregateCoinsRebuilt: string[] = [];
-  if (!options.dryRun && existingPendingAggregateCoins.length > 0) {
-    aggregateCoinsRebuilt = await rebuildAndFinalizeAggregates(db, existingPendingAggregateCoins);
+  if (!options.dryRun && existingPendingAggregateHours.length > 0) {
+    aggregateCoinsRebuilt = await rebuildAndFinalizeAggregates(db, existingPendingAggregateHours);
   }
 
   const rows = await loadRepairRows(db, options, limit);
@@ -774,7 +811,8 @@ export async function repairHistoricalMintBurnPrices(
     const newlyRecoveredCoins = dispositions
       .filter((disposition) => disposition.disposition === "recover")
       .map((disposition) => disposition.stablecoinId);
-    const rebuilt = await rebuildAndFinalizeAggregates(db, newlyRecoveredCoins);
+    const newlyRecoveredHours = await loadPendingAggregateHours(db, newlyRecoveredCoins);
+    const rebuilt = await rebuildAndFinalizeAggregates(db, newlyRecoveredHours);
     aggregateCoinsRebuilt = [...new Set([...aggregateCoinsRebuilt, ...rebuilt])].sort();
   }
 


### PR DESCRIPTION
## Summary
- rebuild missing mint/burn hourly buckets in bounded oldest-first batches from still-retained raw rows
- repair only terminal, Tape-projected hours without unresolved or pending price debt
- narrow manual historical price repair to its affected hours so raw turnover cannot erase unrelated aggregate history
- add repair telemetry, cutoff/protection/bounded-continuation/error-isolation tests, and retention docs

## Production evidence
- PR #680 forward guard is deployed as Worker `e6a615a6-d407-4640-b16a-4764589de8f6`
- first guarded cleanup at `1785051247` completed `ok`: 50,000 raw rows deleted, 5,280 unreferenced hourly rows deleted, hourly eligible backlog null, oldest remaining hourly bucket aligned with the raw dependency frontier
- backlog audit found 49,917 repairable missing hours covering 412,565 terminal rows; no repairable candidate hour contains unresolved price debt
- 520 events in unresolved-only hours remain protected
- production candidate selection returns the first 5,000 hours in 889 ms

## Checks
- focused suite: 52 tests across retention, sync integration, historical repair, and admin API
- exact-runtime production-config release discovery: 57 nodes passed, clean Node 24.16.0 snapshot
- noncritical shards: 1,630 files, 16,698 tests passed, 2 skipped
- Worker typecheck and typed lint
- full generated-artifact check
- env contract, Worker config, cron schedule/connection budget, migrations
- docs source paths, doc sync, API-reference generation
- Gitleaks range and Worker dry-run package proof
- `git diff --check`