### PR TITLE
fix(safety-score): keep V9 fence within runtime budget

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-resource-budget.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-resource-budget.test.ts
@@ -94,10 +94,6 @@ describe("Safety Score V9 resource budget", { timeout: 60_000 }, () => {
             supplyAttributionJournalById: {},
             pegProvenanceById: exactSeed.pegProvenanceById,
           };
-          const fixedInputCache = await buildSafetyScoreV9FixedInputCacheEntry(
-            preparedInput,
-            safetyScoreIdentity,
-          );
           const runnerInput = normalizeFixedInput(preparedInput);
           const baseProjection = (input) => {
             const {
@@ -176,6 +172,10 @@ describe("Safety Score V9 resource budget", { timeout: 60_000 }, () => {
             coverageFloors: [],
             unresolvedCriticalMovementIds,
           });
+          const fixedInputCache = await buildSafetyScoreV9FixedInputCacheEntry(
+            runnerInput,
+            safetyScoreIdentity,
+          );
           const [storedEnvelope, storedDiff] = await Promise.all([
             serializeSafetyScoreV9ShadowEnvelopeCacheValue(envelope),
             serializeSafetyScoreV9DiffReportCacheValue(diff),

--- a/worker/src/lib/safety-score-v9-shadow-runner.ts
+++ b/worker/src/lib/safety-score-v9-shadow-runner.ts
@@ -459,14 +459,6 @@ export async function runSafetyScoreV9ShadowAfterV8Publication(
       }
       fixedInput = preparedFixedInput;
     }
-    const exactInput = await buildSafetyScoreV9FixedInputCacheEntry(
-      fixedInput,
-      buildSafetyScoreV8PublicationIdentity({
-        methodologyVersion: input.v8MethodologyVersion,
-        baseInputGenerationId: fixedInput.baseInputGenerationId,
-        publicationGenerationId: input.v8Publication.generationId,
-      }),
-    );
     stage = "compile";
     const pipeline = buildSafetyScoreV9ShadowCandidateFromNormalizedInput({
       fixedInput,
@@ -625,6 +617,14 @@ export async function runSafetyScoreV9ShadowAfterV8Publication(
       diff,
     });
     const pendingReviewCount = diff.summary.pendingReviewCount;
+    const exactInput = await buildSafetyScoreV9FixedInputCacheEntry(
+      fixedInput,
+      buildSafetyScoreV8PublicationIdentity({
+        methodologyVersion: input.v8MethodologyVersion,
+        baseInputGenerationId: fixedInput.baseInputGenerationId,
+        publicationGenerationId: input.v8Publication.generationId,
+      }),
+    );
     stage = "shadow-write";
     await persistSafetyScoreV9ShadowState(input.db, {
       daily,


### PR DESCRIPTION
## Summary
- defer V9 exact-input compression until after the publication assessment accepts the candidate
- preserve held-attempt canonical and exact-input behavior
- align the production-representative resource probe with runtime ordering

## Validation
- PR merge-gate discovery: 21 passed, 29 omitted (clean Node 24.16.0 snapshot)
- critical coverage: 175 files, 3,290 tests passed
- focused V9 fence suite: 36 tests passed
- worker and test typechecks, lint, evaluation-build manifest check passed

## Production reason
The first fence-enabled scheduled compiler invocation retained the compressed exact input during synchronous candidate compilation and did not reach a terminal health write. This ordering-only correction removes that extra live representation from compilation without changing fence decisions or persistence semantics.