### PR TITLE
docs(safety-score): publish V9 activation content

### DIFF
--- a/docs/process/safety-score-v9-readiness.md
+++ b/docs/process/safety-score-v9-readiness.md
@@ -1,9 +1,11 @@
 # Safety Score V9 Readiness
 
-This document describes the current Safety Score V9 candidate, the evidence
-needed to evaluate it, and the boundary between production shadow observation
-and public activation. It does not define an active methodology. Safety Score
-V8.17 remains active and public.
+This document records the evidence status of the Safety Score V9
+`candidate-v2` policy and the boundary that governed its production shadow
+observation. On 2026-07-27, the owner explicitly authorized activation despite
+the retained no-go evidence described below. That authorization changes the
+runtime model selection; it does not retroactively turn missing evidence into a
+readiness pass.
 
 Release and activation mechanics are governed by the
 [V9 rollout contract](./safety-score-v9-rollout.md). The
@@ -12,19 +14,21 @@ implementation and review status. Neither document authorizes activation.
 
 ## Current State
 
-The current release scope is limited to production shadow observation, subject
-to the normal release checks. That scope does not establish scoring readiness:
-
-- V9 remains a candidate with no public release version.
-- A valid V8 publication is still the prerequisite for each V9 shadow attempt.
-- A V9 compile, evaluation, or persistence failure cannot suppress or replace
-  V8 publication.
-- `safety-score-v9:public-activation` remains the only runtime activation
-  switch and must not be written as part of a shadow release.
-- `/api/report-cards` remains the V8 contract.
-- `/api/report-cards/v9` remains dark while the activation key is absent.
-- No V9 public methodology section or structured activation changelog entry is
-  part of the shadow release.
+- V9 is active under its existing `candidate-v2` identity; the policy still has
+  no numeric release version.
+- `safety-score-v9:public-activation` remains the sole runtime activation
+  switch. A missing, malformed, or identity-mismatched key keeps the versioned
+  endpoint dark.
+- A valid V8 publication remains the prerequisite for V9 compilation during
+  the 24-hour activation observation window.
+- A V9 compile, evaluation, or persistence failure cannot suppress V8
+  compatibility publication and cannot replace the accepted V9 snapshot.
+- `/api/report-cards` remains the V8 compatibility contract during that window.
+- `/api/report-cards/v9` serves the accepted V9 snapshot when the activation
+  key matches; a held publication exposes held status and never falls back to
+  V8.
+- The public methodology and structured activation entry identify the active
+  policy as `candidate-v2`.
 
 The latest calibration changes do not yet have post-change production shadow
 evidence in the verified documentation corpus. Earlier local captures,
@@ -35,8 +39,8 @@ required before assessing the effective distribution or individual ratings.
 There is also no tracked, real holdout package containing a candidate seal,
 content-addressed point-in-time source archive, and two-reviewer blind review.
 The holdout protocol is implemented, but holdout success has not been
-established. No current readiness or activation claim follows from the
-implementation or its synthetic tests.
+established. The owner-authorized activation bypasses that evidence gate; it
+does not establish a holdout success claim.
 
 ## Sources Of Truth
 
@@ -420,14 +424,15 @@ unchecked holdout outcomes remain explicit no-go evidence.
 ## Owner Boundary
 
 Production shadow deployment, green tests, valid candidate publication, and
-stable fresh generations still do not activate V9. The owner alone decides
-whether the candidate is ready and performs the identity-bound activation-key
-write described in the rollout contract.
+stable fresh generations did not activate V9. The owner made that decision on
+2026-07-27 and authorized the identity-bound activation-key write described in
+the rollout contract despite the explicit no-go evidence.
 
-Until that decision:
+The retained evidence statement remains:
 
-- V8.17 remains the public methodology;
-- the V9 public endpoint remains dark;
-- public methodology and changelog content remain unchanged; and
-- readiness, holdout, consumer review, and named-asset findings are reported
-  honestly without being converted into an activation claim.
+- no real release-candidate seal, immutable point-in-time source archive, or
+  two-reviewer blind-review manifest was supplied;
+- the retained accepted canonical snapshot uses an older evaluation-build
+  digest than a replay at the deployed fence build; and
+- activation is an owner override, not a readiness, holdout, or identity-replay
+  pass.

--- a/docs/process/safety-score-v9-rollout.md
+++ b/docs/process/safety-score-v9-rollout.md
@@ -1,10 +1,10 @@
 # Safety Score V9 Rollout
 
-> **Current state:** Safety Score v8.17 remains the public model. V9 retains one
-> compact shadow row per UTC day and may refresh its private latest candidate
-> every 30 minutes after a valid V8 publication. The owner-approved, unlisted
-> read-only preview remains a shadow consumer. The versioned public V9 endpoint
-> remains dark until the owner writes the identity-bound activation key.
+> **Current state:** The owner authorized V9 activation on 2026-07-27 under the
+> existing `candidate-v2` identity. The identity-bound activation key remains
+> the sole runtime switch: a missing, malformed, or mismatched key keeps the
+> versioned endpoint dark. V8 compatibility publication remains scheduled only
+> through the 24-hour activation observation window.
 
 This document is the durable rollout contract for Safety Score V9. Candidate
 correctness, calibration results, and identity records live in

--- a/docs/report-cards.md
+++ b/docs/report-cards.md
@@ -6,12 +6,14 @@ Report-card snapshots score active tracked and cemetery assets. Frozen archives 
 
 ## Methodology Versioning
 
-- **Current methodology version:** `v8.17`
-- **Runtime/version source:** `shared/lib/methodology-versions/safety-score.ts`
+- **Active model identity:** Safety Score V9, methodology `candidate-v2`
+- **Compatibility methodology version:** `v8.17`
+- **V9 policy source:** `shared/data/safety-score-v9/methodology-policy-candidate-v1.json`
+- **V8 compatibility version source:** `shared/lib/methodology-versions/safety-score.ts`
 - **Public changelog route:** `/methodology/scoring-changelog/`
 - **Structured changelog:** `shared/data/methodology-changelogs/safety-score/`
 
-## Overall Grade (v8.17)
+## Legacy Compatibility Grade (v8.17)
 
 Four-step computation:
 
@@ -24,8 +26,8 @@ Cemetery coins get a permanent F.
 
 Current-version note: v8.17 keeps balance-measured aggregate pool TVL in the generic-proxy class unless the retained evidence includes the exact invariant, fee, output identity, and capacity curve needed for a reserve-based AMM simulation. The public Liquidity Score remains unchanged, but Safety Score caps generic TVL proxies at 60, synthetic/fallback evidence at 55, and provider-inaccessible-only coverage at 45. The 85-point reserve-based simulation class is reserved for exact modeled routes, and same-notional route scoring remains inactive until the P4b rollout gate passes. Old snapshot rows without the new evidence fields and rows explicitly marked `legacy` remain neutral. v8.15 deterministic dependency scoring and v8.14 self-link-free serial variant derivation carry forward unchanged.
 
-Safety Score V9 is implemented as an internal candidate and shadow pipeline,
-not as the active methodology. It replaces unrestricted weighted compensation
+Safety Score V9 is the active model for identity-aware consumers under the
+existing `candidate-v2` policy identity. It replaces unrestricted weighted compensation
 with archetype-specific Backing, Exit, and Economic Control pillars bounded by
 the weakest material failure path, structural ceilings, evidence sufficiency,
 dependencies, peg behavior, and stress propagation. The current candidate also
@@ -113,16 +115,14 @@ The explicitly named historical report reader likewise retains both
 report-v2/trace-v2 and report-v1/trace-v1 snapshots. Live report producers and
 consumers accept only report-v3/trace-v3.
 
-Candidate failures cannot affect V8 publication. A production deployment of V9
-scorer or producer code only changes the private shadow output; it does not
-change the active version, public methodology, or public API. The candidate
-identity is computed from the current policy, evaluation build, compiler schema,
-and producer capability rather than copied into this document. Earlier
-calibration histograms and named-asset scores predate the current implementation
-and are not evidence for it. Fresh exact production shadow generations and a
-real holdout package have not yet established readiness. V8.17 remains public,
-and `/api/report-cards/v9` remains dark until the owner writes a matching
-identity-bound activation key. See
+V9 publication is fail-closed. Stale or unavailable score-bearing inputs and
+new infrastructure-attributed downgrades or NR transitions hold the last
+accepted canonical V9 snapshot. The versioned endpoint exposes `held` status,
+retains accepted-timestamp freshness, and never recomputes or falls back to V8.
+The current policy, evaluation build, compiler schema, and producer capability
+remain bound into the exact publication identity. V8.17 remains available
+through the compatibility contract and during the activation observation
+window. See
 [Safety Score V9 readiness](./process/safety-score-v9-readiness.md), the
 [single-publisher rollout contract](./process/safety-score-v9-rollout.md), and
 the [consumer ledger](./process/safety-score-v9-consumer-ledger.md).
@@ -562,7 +562,7 @@ Implementation notes:
 - `publish-report-card-cache` validates the exact active registry set before writing. Missing, duplicate, defunct-active, or unexpected live IDs reject the whole publication; expected coverage must equal scored plus NR rows.
 - Exact fixed-input schema v3 records `captureKind`, the sorted active IDs, source/DEX/redemption generation IDs, registry revision and fingerprint, DEX/redemption payload fingerprints, producer methodology versions, the fixed clock, lane freshness, and optional-default V9 diagnostic fields. The cache envelope stores the normalized JSON as `gzip-base64` with its source generation, SHA-256, and uncompressed byte length; export decoding rechecks the length, checksum, capture kind, and generation. Replay recomputes both payload fingerprints, rejects methodology or current-registry drift unless the invoking tool exposes and receives the corresponding explicit override, and requires exact captures to retain full active DEX and blacklist identity sets. Diagnostic journal rows are canonicalized but never projected into report-card or V9 scoring facts.
 - The full snapshot, exact fixed input, compact `report_card_cache` score map used by lightweight and yield-safety consumers, and Telegram `alert:safety-source-cache` are written in one D1 batch. Each carries the same strict V8 identity, publication generation, methodology, and completeness manifest. Strict compact-cache consumers, including hourly yield publication, publication-health fallback, and the data-invariant canary, require scored IDs plus explicit NR IDs to equal the exact active registry set; count-preserving identity swaps are rejected. The compact cache also carries `degradedInputs` metadata (`inputsStale`, `liquidityStale`, `redemptionStale`, and `staleInputs`).
-- `snapshot-safety-grade-history` owns only append-only grade history. For each healthy current-V8 seed or organic grade change it writes the legacy row and an immutable V2 twin; the V2 row records model, methodology, nullable policy identity, evaluation-build digest, base-input generation, model-publication generation, and transition kind. It still suppresses both writes when the selected report-card inputs are degraded. V9 activation and rollback require explicit non-comparable baseline writers before cutover; this pre-activation release does not expose either transition.
+- `snapshot-safety-grade-history` owns only append-only grade history. For each healthy current-V8 seed or organic grade change it writes the legacy row and an immutable V2 twin; the V2 row records model, methodology, nullable policy identity, evaluation-build digest, base-input generation, model-publication generation, and transition kind. Current V9 writes only identified V2 organic rows and suppresses them while publication is held. The V9 activation baseline is a non-comparable V2 boundary with null previous values, so activation cannot appear as an organic grade movement.
 
 Key types:
 

--- a/docs/report-cards.md
+++ b/docs/report-cards.md
@@ -7,13 +7,16 @@ Report-card snapshots score active tracked and cemetery assets. Frozen archives 
 ## Methodology Versioning
 
 - **Active model identity:** Safety Score V9, methodology `candidate-v2`
-- **Compatibility methodology version:** `v8.17`
+- **Current methodology version:** `v8.17` (V8 compatibility contract)
 - **V9 policy source:** `shared/data/safety-score-v9/methodology-policy-candidate-v1.json`
 - **V8 compatibility version source:** `shared/lib/methodology-versions/safety-score.ts`
 - **Public changelog route:** `/methodology/scoring-changelog/`
 - **Structured changelog:** `shared/data/methodology-changelogs/safety-score/`
 
-## Legacy Compatibility Grade (v8.17)
+## Overall Grade (v8.17)
+
+This section documents the V8 compatibility contract retained during the V9
+activation observation window.
 
 Four-step computation:
 

--- a/scripts/__tests__/fixtures/markdown/changelog-index.md
+++ b/scripts/__tests__/fixtures/markdown/changelog-index.md
@@ -6,6 +6,13 @@ description: "Weekly release notes for Pharos."
 
 # Changelog
 
+## 2026-07-27 to 2026-07-27
+
+Safety Score V9 becomes the active model with fail-closed publication and held-rating continuity.
+
+- **Safety Score V9 activation**: The three-pillar V9 model becomes active under the candidate-v2 policy identity, with Backing, Exit, and Economic Control bounded by evidence and structural failure paths.
+- **Graceful degradation**: Stale or failed score-bearing inputs and new infrastructure-attributed downgrades hold the last accepted V9 snapshot instead of replacing it or recomputing V8.
+
 ## 2026-07-20 to 2026-07-26
 
 Pharos gets a blog, the V9 safety model opens to outside reviewers, and DEX scoring splits to fit its memory budget.

--- a/scripts/__tests__/fixtures/markdown/methodology-index.md
+++ b/scripts/__tests__/fixtures/markdown/methodology-index.md
@@ -30,11 +30,11 @@ PSI is deliberately conservative: one small depeg should not move the entire mar
 
 ## Safety Scores Grading Methodology
 
-Pharos synthesizes stablecoin risk into a single transparent grade. The score starts with weighted base dimensions for Liquidity / Exit, Resilience, Decentralization, and Dependency Risk, then applies a peg-stability multiplier.
+Safety Score V9 is the active identity-aware model. It evaluates Backing (40%), Exit (35%), and Economic Control (25%) through bounded aggregation, then applies peg behavior, structural ceilings, evidence sufficiency, track record, dependencies, and wrapper-local risk.
 
-Liquidity / Exit measures how much usable exit capacity exists across DEX depth and eligible redemption backstops. Resilience measures collateral quality and custody model. Chain tier, deployment model, reviewed CDP oracle setup, reviewed bridge-route risk, and Mint Authority affect the Decentralization penalties; branch-aware oracle reviews use the weakest verified branch when present, and resolvable wrappers inherit Decentralization from their wrapped asset with a wrapper-kind haircut. Dependency Risk penalizes wrapper, collateral, and mechanism exposure to other assets, with tracked parent-linked variants applying family-specific wrapper ceilings.
+V9 distinguishes measured adverse evidence from issuer non-disclosure, unsupported methodology, missing integration, and transient producer failure. Bounded gaps can remain rateable under explicit ceilings; an unbounded required fact remains NR, and F is reserved for causally attributed measured danger.
 
-The peg multiplier prevents a structurally strong asset with a bad peg from receiving an inflated grade. Severe active depegs, missing liquidity, stale redemption evidence, and high dependency concentration all cap or penalize the final result.
+Publication is fail-closed. Stale or unavailable score-bearing producers and new infrastructure-attributed downgrades or NR transitions hold the last accepted V9 ratings. Active consumers expose held status and never recompute or fall back to V8. The numeric V8.17 methodology remains documented for the compatibility endpoint and rollback observation window.
 
 
 ## Mint Authority Score

--- a/shared/data/methodology-changelogs/safety-score/v9-activation.ts
+++ b/shared/data/methodology-changelogs/safety-score/v9-activation.ts
@@ -1,0 +1,26 @@
+import type { MethodologyChangelogEntry } from "@shared/lib/methodology-versions/base";
+
+/**
+ * V9 is activated under its existing policy identity, `candidate-v2`.
+ *
+ * This entry is rendered separately from the numeric V8 history because the
+ * active runtime identity deliberately has no numeric release version. It must
+ * not be registered through `createMethodologyVersion()` or replace the V8
+ * version constant while the compatibility publisher remains scheduled.
+ */
+export const SAFETY_SCORE_V9_ACTIVATION: MethodologyChangelogEntry = {
+  version: "candidate-v2",
+  title: "Safety Score V9 becomes the active model",
+  date: "2026-07-27",
+  effectiveAt: 1785129044,
+  summary:
+    "Pharos activates the identity-bound V9 model with three risk pillars, explicit evidence responsibility, structural ceilings, and fail-closed publication health.",
+  impact: [
+    "Active model-aware consumers select V9 without recomputing or falling back to V8",
+    "Backing, Exit, and Economic Control replace the five V8 dimensions for native V9 output",
+    "Transient producer failures hold the last accepted V9 snapshot and expose held status instead of publishing infrastructure-attributed score movement",
+    "The V8.17 methodology remains documented for the compatibility endpoint and rollback observation window",
+  ],
+  commits: [],
+  reconstructed: false,
+};

--- a/src/app/methodology/scoring-changelog/content-shared.tsx
+++ b/src/app/methodology/scoring-changelog/content-shared.tsx
@@ -53,8 +53,15 @@ export function ChangelogTable({
   );
 }
 
-export function VersionCard({ entry, children }: { entry: MethodologyChangelogEntry; children: ReactNode }) {
-  const versionLabel = toMethodologyVersionLabel(entry.version);
+export function VersionCard({
+  entry,
+  children,
+  versionLabel = toMethodologyVersionLabel(entry.version),
+}: {
+  entry: MethodologyChangelogEntry;
+  children: ReactNode;
+  versionLabel?: string;
+}) {
   const anchorId = scoringAnchorId(versionLabel);
 
   return (

--- a/src/app/methodology/scoring-changelog/content.tsx
+++ b/src/app/methodology/scoring-changelog/content.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { SAFETY_SCORE_METHODOLOGY_VERSION_LABEL } from "@shared/lib/methodology-versions/constants";
 import { SAFETY_SCORE_METHODOLOGY_CHANGELOG } from "@shared/lib/safety-score-version";
+import { SAFETY_SCORE_V9_ACTIVATION } from "@shared/data/methodology-changelogs/safety-score/v9-activation";
 import { scoringAnchorId, VersionCard } from "./content-shared";
 import { scoringChangelogV8Details } from "./content-v8";
 import { scoringChangelogV729Details } from "./content-v7-29";
@@ -35,6 +36,14 @@ function getScoringChangelogDetail(version: string): ReactNode {
 export function ScoringChangelogContent() {
   return (
     <>
+      <VersionCard entry={SAFETY_SCORE_V9_ACTIVATION} versionLabel="V9 · candidate-v2">
+        <p>{SAFETY_SCORE_V9_ACTIVATION.summary}</p>
+        <ul className="list-disc list-inside space-y-1">
+          {SAFETY_SCORE_V9_ACTIVATION.impact.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </VersionCard>
       {SAFETY_SCORE_METHODOLOGY_CHANGELOG.map((entry) => (
         <VersionCard key={entry.version} entry={entry}>
           {getScoringChangelogDetail(entry.version)}

--- a/src/app/methodology/scoring-changelog/page.tsx
+++ b/src/app/methodology/scoring-changelog/page.tsx
@@ -11,22 +11,25 @@ const route = createMethodologyChangelogRoute({
   path: changelog.publicPath,
   metadataTitle: "Safety Scores Changelog — Version History",
   metadataDescription:
-    `Full version history of the Pharos safety scoring methodology, from v1.0 through ${changelog.currentLabel}. Every weight change, new dimension, and structural decision documented.`,
+    "Safety Score methodology history from V1 through the active V9 candidate-v2 identity, including the retained V8 compatibility methodology.",
   breadcrumbName: "Scoring Changelog",
   title: "Safety Scores Changelog",
   lead: (
     <>
-      Full version history of the grading methodology &mdash; every weight
-      change, new dimension, and structural decision from v1.0 to {changelog.currentLabel}.
+      The active V9 identity and the full numeric V8-and-earlier grading history
+      &mdash; every weight change, new pillar or dimension, and structural decision.
     </>
   ),
   entries: changelog.entries,
-  sections: SAFETY_SCORE_METHODOLOGY_CHANGELOG_NAV_VERSIONS.map((version) => ({
-    id: scoringAnchorId(version),
-    label: version,
-  })),
+  sections: [
+    { id: scoringAnchorId("V9 · candidate-v2"), label: "V9 · candidate-v2" },
+    ...SAFETY_SCORE_METHODOLOGY_CHANGELOG_NAV_VERSIONS.map((version) => ({
+      id: scoringAnchorId(version),
+      label: version,
+    })),
+  ],
   renderContent: () => <ScoringChangelogContent />,
-  citation: { id: changelog.citationId, versionLabel: changelog.currentLabel },
+  citation: { id: changelog.citationId, versionLabel: "v9-candidate-v2" },
 });
 
 export const metadata = route.metadata;

--- a/src/app/methodology/sections/core/safety-scores-overview.tsx
+++ b/src/app/methodology/sections/core/safety-scores-overview.tsx
@@ -1,31 +1,33 @@
 import {
   METHODOLOGY_LINK_CLASS,
-  MethodologyDetails,
   MethodologyFacts,
-  WorkedExample,
 } from "../../methodology-shared";
-import { SafetyScoreCalculator } from "@/components/methodology/safety-score-calculator";
-import { ReserveRelatedSignalsMethodologyCopy } from "../core-sections-fragments";
 
 export function SafetyScoresOverview() {
   return (
     <>
       <p>
-        Pharos synthesizes multiple data signals into a single transparent grade per stablecoin. The overall score
-        is computed in two steps: first, a weighted average of four base dimensions (exit liquidity, resilience,
-        decentralization, dependency risk), then a peg stability multiplier that penalizes coins with poor pegs
-        while barely affecting well-pegged ones. The exit-liquidity dimension blends raw DEX liquidity with
-        redemption-backstop quality only when the route has usable current evidence. Reviewer-gated wrapper capacity
-        can come from same-run withdrawable strategy or Stability Pool balances, or an exact cross-chain route whose
-        endpoints and executable inventory are validated together, rather than idle underlying alone;
-        reviewed opaque fees can preserve capacity evidence for bounded downstream analysis but do not make the
-        current redemption route score-eligible without a numeric cost bound. Reserve data is a separate
-        resilience input: live reserve sync can improve collateral quality only when the latest snapshot is fresh,
-        independent, clean, and score-grade. When some base dimensions lack data (NR), their weight is redistributed proportionally among rated ones. Active depeg caps use the open event&apos;s peak deviation, while the peg
-        dimension itself remains a direct pegScore passthrough.
+        Safety Score V9 is the active model for identity-aware consumers. It evaluates three material risk pillars:
+        Backing (40%), Exit (35%), and Economic Control (25%). The aggregation allows bounded headroom above the
+        weakest material path, then applies peg behavior, structural ceilings, evidence sufficiency, track record,
+        dependencies, and wrapper-local risk. A strong unrelated pillar therefore cannot erase a weak material
+        failure path.
+      </p>
+      <p>
+        V9 distinguishes measured adverse evidence from issuer non-disclosure, unsupported methodology, missing
+        integration, and transient producer failure. Bounded gaps can remain rateable under explicit ceilings; an
+        unbounded required fact remains NR. F is reserved for causally attributed measured danger, while a D requires
+        measured weakness or traceable policy-bounded uncertainty.
+      </p>
+      <p>
+        Publication is fail-closed. If a score-bearing producer is stale, unavailable, or would create a new
+        infrastructure-attributed downgrade or NR transition, Pharos retains the last accepted V9 ratings and exposes
+        the publication as held. Active consumers do not recompute or fall back to V8.
       </p>
       <p className="text-xs text-muted-foreground">
         See also:{" "}
+        <a href="/methodology/scoring-changelog/" className={METHODOLOGY_LINK_CLASS}>Safety Score changelog</a>
+        {" · "}
         <a href="#pegscore-dews-methodology" className={METHODOLOGY_LINK_CLASS}>PegScore + DEWS</a>
         {" · "}
         <a href="#liquidity-methodology" className={METHODOLOGY_LINK_CLASS}>Liquidity Score</a>
@@ -34,37 +36,24 @@ export function SafetyScoresOverview() {
       </p>
       <MethodologyFacts
         facts={[
-          { label: "Model shape", value: "4 dimensions + peg multiplier" },
+          { label: "Model shape", value: "3 pillars + bounded aggregation" },
           { label: "Grade output", value: "A+ to F, with NR" },
-          { label: "Key caveat", value: "No exit signal = 10% penalty" },
+          { label: "Publication state", value: "Current or held; never V8 fallback" },
         ]}
       />
       <div className="space-y-2">
         <h3 className="text-foreground font-medium">Preconditions &amp; Failure Modes</h3>
         <MethodologyFacts
           facts={[
-            { label: "Minimum data", value: "At least 2 rated non-peg dimensions" },
-            { label: "Required sources", value: "Peg summary, DEX liquidity/redemption data, and dependency/metadata inputs" },
+            { label: "Minimum data", value: "Mechanism-appropriate required facts for all material pillars" },
+            { label: "Required sources", value: "Backing, exit, control, peg, dependency, and evidence-provenance inputs" },
             {
               label: "Failure behavior",
-              value: "NR if peg is missing on non-NAV coins; no-liquidity penalty when both DEX and redemption evidence are unavailable; live reserve adapters stay detail-visible when they are stale, degraded, or proof-only",
+              value: "Unbounded evidence gaps return NR; transient producer failures hold the last accepted publication",
             },
           ]}
         />
       </div>
-      <ReserveRelatedSignalsMethodologyCopy />
-      <WorkedExample summary="Worked example (verified against computeOverallGrade)">
-        <p className="pharos-numeric">Inputs: DEX 30, Redemption 88, Exit 91, Res 70, Decen 60, Dep 75, Peg 92</p>
-        <p className="pharos-numeric">base=(91*0.30+70*0.20+60*0.15+75*0.25)/0.90=76.72</p>
-        <p className="pharos-numeric">final=round(base*(92/100)^0.40)=round(76.72*0.9672)=74</p>
-        <p>
-          Result: <span className="text-foreground">Score 74 (grade B)</span>.
-        </p>
-      </WorkedExample>
-
-      <MethodologyDetails summary="Interactive calculator: explore how weights and thresholds shape the grade">
-        <SafetyScoreCalculator />
-      </MethodologyDetails>
     </>
   );
 }

--- a/src/app/methodology/sections/core/safety-scores-section.tsx
+++ b/src/app/methodology/sections/core/safety-scores-section.tsx
@@ -1,7 +1,4 @@
-import {
-  SAFETY_SCORE_METHODOLOGY_CHANGELOG_PATH,
-  SAFETY_SCORE_METHODOLOGY_VERSION_LABEL,
-} from "@shared/lib/methodology-versions/constants";
+import { SAFETY_SCORE_METHODOLOGY_CHANGELOG_PATH } from "@shared/lib/methodology-versions/constants";
 import { MethodologySectionShell } from "../../methodology-shared";
 import { SAFETY_SCORES_SECTION_CONTENT } from "../methodology-content";
 import { SafetyScoresOverview } from "./safety-scores-overview";
@@ -12,9 +9,9 @@ export function SafetyScoresMethodologySection() {
     <MethodologySectionShell
       id={SAFETY_SCORES_SECTION_CONTENT.id}
       title={SAFETY_SCORES_SECTION_CONTENT.title}
-      versionBadge={{ label: SAFETY_SCORE_METHODOLOGY_VERSION_LABEL }}
+      versionBadge={{ label: "V9 · candidate-v2" }}
       changelogPath={SAFETY_SCORE_METHODOLOGY_CHANGELOG_PATH}
-      versionNote="Version increments when weights, thresholds, or dimension definitions change."
+      versionNote="Active V9 policy identity; the compatibility endpoint retains the numeric V8.17 methodology."
       changelogClassName="hover:text-amber-700 dark:hover:text-amber-400"
     >
       <SafetyScoresOverview />

--- a/src/app/methodology/sections/core/safety-scores-technical-details.tsx
+++ b/src/app/methodology/sections/core/safety-scores-technical-details.tsx
@@ -4,7 +4,7 @@ import { SafetyScoresScoringDetails } from "./safety-scores-scoring-details";
 
 export function SafetyScoresTechnicalDetails() {
   return (
-    <MethodologyDetails summary="Technical details: full pipeline, dimension formulas, thresholds, and caveats">
+    <MethodologyDetails summary="Legacy V8.17 compatibility details: dimensions, formulas, thresholds, and caveats">
       <SafetyScoresScoringDetails />
       <SafetyScoresDimensionDetails />
     </MethodologyDetails>

--- a/src/app/methodology/sections/methodology-content.ts
+++ b/src/app/methodology/sections/methodology-content.ts
@@ -57,9 +57,9 @@ export const SAFETY_SCORES_SECTION_CONTENT = defineMethodologySectionContent({
   id: "safety-scores-methodology",
   title: "Safety Scores Grading Methodology",
   markdownParagraphs: [
-    "Pharos synthesizes stablecoin risk into a single transparent grade. The score starts with weighted base dimensions for Liquidity / Exit, Resilience, Decentralization, and Dependency Risk, then applies a peg-stability multiplier.",
-    "Liquidity / Exit measures how much usable exit capacity exists across DEX depth and eligible redemption backstops. Resilience measures collateral quality and custody model. Chain tier, deployment model, reviewed CDP oracle setup, reviewed bridge-route risk, and Mint Authority affect the Decentralization penalties; branch-aware oracle reviews use the weakest verified branch when present, and resolvable wrappers inherit Decentralization from their wrapped asset with a wrapper-kind haircut. Dependency Risk penalizes wrapper, collateral, and mechanism exposure to other assets, with tracked parent-linked variants applying family-specific wrapper ceilings.",
-    "The peg multiplier prevents a structurally strong asset with a bad peg from receiving an inflated grade. Severe active depegs, missing liquidity, stale redemption evidence, and high dependency concentration all cap or penalize the final result.",
+    "Safety Score V9 is the active identity-aware model. It evaluates Backing (40%), Exit (35%), and Economic Control (25%) through bounded aggregation, then applies peg behavior, structural ceilings, evidence sufficiency, track record, dependencies, and wrapper-local risk.",
+    "V9 distinguishes measured adverse evidence from issuer non-disclosure, unsupported methodology, missing integration, and transient producer failure. Bounded gaps can remain rateable under explicit ceilings; an unbounded required fact remains NR, and F is reserved for causally attributed measured danger.",
+    "Publication is fail-closed. Stale or unavailable score-bearing producers and new infrastructure-attributed downgrades or NR transitions hold the last accepted V9 ratings. Active consumers expose held status and never recompute or fall back to V8. The numeric V8.17 methodology remains documented for the compatibility endpoint and rollback observation window.",
   ],
 });
 

--- a/src/data/changelogs/2026-07-27.ts
+++ b/src/data/changelogs/2026-07-27.ts
@@ -1,0 +1,28 @@
+import type { ChangelogEntry } from "./types";
+
+export const entry: ChangelogEntry = {
+  dateRange: { from: "2026-07-27", to: "2026-07-27" },
+  headline: "Safety Score V9 becomes the active model with fail-closed publication and held-rating continuity.",
+  fieldNotes:
+    "V9 now serves identity-aware consumers. Its publication fence separates real risk movement from transient worker failures: unhealthy attempts retain the last accepted ratings, report held status, and never fall back to V8.",
+  summary: [
+    {
+      label: "Safety Score V9 activation",
+      tag: "feature",
+      href: "/methodology/",
+      description:
+        "The three-pillar V9 model becomes active under the candidate-v2 policy identity, with Backing, Exit, and Economic Control bounded by evidence and structural failure paths.",
+    },
+    {
+      label: "Graceful degradation",
+      tag: "infra",
+      href: "/methodology/scoring-changelog/",
+      description:
+        "Stale or failed score-bearing inputs and new infrastructure-attributed downgrades hold the last accepted V9 snapshot instead of replacing it or recomputing V8.",
+    },
+  ],
+  stats: { totalCommits: 1 },
+  commits: [
+    { hash: "1e7eaba0", message: "fix(safety-score): keep V9 fence within runtime budget" },
+  ],
+};

--- a/src/data/changelogs/index.ts
+++ b/src/data/changelogs/index.ts
@@ -20,6 +20,7 @@ import { entry as e20260705 } from "./2026-07-05";
 import { entry as e20260712 } from "./2026-07-12";
 import { entry as e20260719 } from "./2026-07-19";
 import { entry as e20260726 } from "./2026-07-26";
+import { entry as e20260727 } from "./2026-07-27";
 
 const all: ChangelogEntry[] = [
   e20260308,
@@ -42,6 +43,7 @@ const all: ChangelogEntry[] = [
   e20260712,
   e20260719,
   e20260726,
+  e20260727,
 ];
 
 export const changelogs: ChangelogEntry[] = all.sort(

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -48,7 +48,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "report-cards": {
-    "dateModified": "2026-07-27T07:16:04+02:00",
+    "dateModified": "2026-07-27T07:27:57+02:00",
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -48,7 +48,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "report-cards": {
-    "dateModified": "2026-07-26T22:18:21+02:00",
+    "dateModified": "2026-07-27T07:16:04+02:00",
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -41,7 +41,7 @@
   "/methodology/liquidity-score-changelog/": "2026-06-26T11:46:09+02:00",
   "/methodology/mint-burn-flow-changelog/": "2026-06-26T11:46:09+02:00",
   "/methodology/pricing-pipeline-changelog/": "2026-06-26T11:46:09+02:00",
-  "/methodology/scoring-changelog/": "2026-06-26T11:46:09+02:00",
+  "/methodology/scoring-changelog/": "2026-07-27T07:16:04+02:00",
   "/methodology/stability-index-changelog/": "2026-06-26T11:46:09+02:00",
   "/methodology/yield-changelog/": "2026-06-26T11:46:09+02:00",
   "/pharoswatchbot/": "2026-07-17T13:19:24+02:00",


### PR DESCRIPTION
## Summary
- publish the owner-authorized V9 candidate-v2 activation on /methodology and in the structured scoring changelog
- add HERALD activation content and retain V8.17 as the compatibility methodology during the observation window
- preserve the missing holdout package and evaluation-build replay mismatch as explicit no-go evidence; activation is recorded as an owner override, not a readiness pass

## Production sequence
- V9 history boundary was recorded before this PR (336 cards, exact retained identity)
- activation marker remains absent and will be written only after this Pages content is live
- the 24-hour observation and V8 runtime retirement remain the next documented steps

## Validation
- MERGE_GATE_PRODUCTION_ENV=1 npm run test:merge-gate:discover -- --target=release
- 57 passed, 34 intentionally omitted external/advisory nodes
- production Pages build, 16,796 noncritical tests, typechecks, lint, SEO, generated artifacts, build budgets, and Worker package proof passed