### PR TITLE
Fix retained V9 shadow cache lifecycle read

### DIFF
--- a/src/app/portfolio/client.test.tsx
+++ b/src/app/portfolio/client.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PortfolioClient } from "./client";
 import type { ReportCardsV9Response } from "@shared/types";
 
@@ -119,6 +119,10 @@ function basePortfolioState(): typeof portfolioState {
 }
 
 describe("PortfolioClient URL sync", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     portfolioState = basePortfolioState();
     window.history.replaceState(null, "", "/portfolio/");

--- a/worker/src/lib/__tests__/safety-score-v9-store.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-store.test.ts
@@ -481,6 +481,16 @@ describe("Safety Score v9 shadow state persistence", () => {
 
     await expect(loadLatestSafetyScoreV9ShadowEnvelope(db)).resolves.toEqual(state.envelope);
     await expect(loadLatestSafetyScoreV9DiffReport(db)).resolves.toEqual(state.diff);
+
+    const legacyCurrentEnvelope = structuredClone(state.envelope) as typeof state.envelope & {
+      candidate: { lifecycle: "candidate" | "active" };
+    };
+    legacyCurrentEnvelope.candidate.lifecycle = "candidate";
+    sqlite
+      .prepare("UPDATE cache SET value = ? WHERE key = ?")
+      .run(stableJsonStringifyV1(legacyCurrentEnvelope), SAFETY_SCORE_V9_SHADOW_CACHE_KEYS.envelope);
+
+    await expect(loadLatestSafetyScoreV9ShadowEnvelope(db)).resolves.toEqual(state.envelope);
   });
 
   it("rejects corrupt, unbounded, noncanonical, and identity-mismatched cache envelopes", async () => {

--- a/worker/src/lib/safety-score-v9-cache-codec.ts
+++ b/worker/src/lib/safety-score-v9-cache-codec.ts
@@ -57,6 +57,7 @@ interface CacheCodec<T> {
   storageKind: StorageKind;
   schema: z.ZodType<T>;
   identity: (value: T) => CacheIdentity;
+  parseCanonicalPayload?: (raw: string, label: string) => T;
 }
 
 function envelopeIdentity(value: SafetyScoreV9ShadowEnvelope): CacheIdentity {
@@ -78,6 +79,7 @@ const ENVELOPE_CODEC: CacheCodec<SafetyScoreV9ShadowEnvelope> = {
   storageKind: STORAGE_KINDS.envelope,
   schema: SafetyScoreV9ShadowEnvelopeSchema,
   identity: envelopeIdentity,
+  parseCanonicalPayload: parseSafetyScoreV9ShadowEnvelopeCanonicalPayload,
 };
 
 const DIFF_CODEC: CacheCodec<SafetyScoreV9DiffReport> = {
@@ -149,6 +151,40 @@ function parseCanonicalJson<T>(raw: string, schema: z.ZodType<T>, label: string)
   return value;
 }
 
+function parseSafetyScoreV9ShadowEnvelopeCanonicalPayload(
+  raw: string,
+  label: string,
+): SafetyScoreV9ShadowEnvelope {
+  const parsed = parseJson(raw);
+  if (!parsed.ok) throw new Error(`Malformed ${label} JSON: ${parsed.message}`);
+  if (stableJsonStringifyV1(parsed.value) !== raw) throw new Error(`${label} JSON is not canonical`);
+
+  const current = SafetyScoreV9ShadowEnvelopeSchema.safeParse(parsed.value);
+  if (current.success) return current.data;
+
+  const value = parsed.value;
+  if (value && typeof value === "object" && !Array.isArray(value) && "candidate" in value) {
+    const candidate = (value as { candidate?: unknown }).candidate;
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).schemaVersion === 5 &&
+      (candidate as Record<string, unknown>).lifecycle === "candidate"
+    ) {
+      return SafetyScoreV9ShadowEnvelopeSchema.parse({
+        ...value,
+        candidate: {
+          ...candidate,
+          lifecycle: "active",
+        },
+      });
+    }
+  }
+
+  return SafetyScoreV9ShadowEnvelopeSchema.parse(parsed.value);
+}
+
 function compressedStorageCandidate(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
@@ -213,7 +249,8 @@ async function parseCacheValue<T>(
   }
   const raw = parseJson(storedValue);
   if (!raw.ok) throw new Error(`Malformed ${label} JSON: ${raw.message}`);
-  if (!compressedStorageCandidate(raw.value)) return parseCanonicalJson(storedValue, codec.schema, label);
+  const parsePayload = codec.parseCanonicalPayload ?? ((value: string) => parseCanonicalJson(value, codec.schema, label));
+  if (!compressedStorageCandidate(raw.value)) return parsePayload(storedValue, label);
 
   const storage = StorageEnvelopeSchema.parse(raw.value);
   if (stableJsonStringifyV1(storage) !== storedValue) {
@@ -246,7 +283,7 @@ async function parseCacheValue<T>(
     throw new Error(`${label} cache payload is not valid UTF-8`);
   }
   if ((await sha256Hex(uncompressed)) !== storage.payloadSha256) throw new Error(`${label} cache checksum mismatch`);
-  const value = parseCanonicalJson(canonical, codec.schema, label);
+  const value = parsePayload(canonical, label);
   if (stableJsonStringifyV1(codec.identity(value)) !== stableJsonStringifyV1(storage.identity)) {
     throw new Error(`${label} cache identity mismatch`);
   }


### PR DESCRIPTION
## Summary
- normalize persisted schema-v5 V9 shadow envelopes stamped with the old `candidate` lifecycle when reading the canonical cache
- keep strict active lifecycle enforcement for new shadow envelope writes
- add a regression test for retained plain canonical cache rows

## Production symptom
- After PR #692 deployed successfully, keyed live smoke for `/api/report-cards/v9` returned 503 because the accepted production cache row still carried `candidate.lifecycle = candidate`.

## Local validation
- npm run typecheck:worker
- npx vitest run worker/src/lib/__tests__/safety-score-v9-store.test.ts worker/src/lib/__tests__/report-cards-v9-cache.test.ts worker/src/api/__tests__/report-cards-v9.test.ts
- npm run check:worker-boundary
- pre-push hook: npm run check:commit-derived-artifacts passed

## Deployment notes
- Worker deploy required. Pages deploy should be skipped unless CI classifier finds an indirect Pages surface.
- Post-deploy acceptance: rerun keyed live `/api/report-cards/v9` smoke.