### PR TITLE
fix(worker): serve retained V9 transition cache

### DIFF
--- a/worker/src/api/report-cards-v9.ts
+++ b/worker/src/api/report-cards-v9.ts
@@ -1,5 +1,5 @@
 import { API_FRESHNESS_MAX_AGE_SEC } from "@shared/lib/api-freshness";
-import type { ReportCardsV9Response } from "@shared/types/report-cards-v9";
+import type { ReportCardsV9TransitionResponse } from "@shared/types/report-cards-v9";
 import { errorResponse, jsonFreshResponse, withErrorHandler } from "../lib/api-utils";
 import { CACHE_PROFILES } from "../lib/constants";
 import {
@@ -20,8 +20,8 @@ export {
 };
 
 function snapshotResponse(
-  snapshot: ReportCardsV9Response,
-  lifecycle: ReportCardsV9Response["lifecycle"],
+  snapshot: ReportCardsV9TransitionResponse,
+  lifecycle: ReportCardsV9TransitionResponse["lifecycle"],
   cacheControl: string = CACHE_PROFILES.standard,
 ): Response {
   const held = snapshot.publicationHealth.status === "held";

--- a/worker/src/cron/snapshot-public-dataset.ts
+++ b/worker/src/cron/snapshot-public-dataset.ts
@@ -40,7 +40,7 @@ import { safeJsonParse } from "../lib/api-cache-read";
 import { loadPublishedStressSignalGeneration } from "../lib/stress-signals-current-rows";
 import { isCurrentSafetyScoreV8Identity } from "../lib/safety-score-current-identity";
 import { loadActiveSafetyScoreSource } from "../lib/safety-score-active-source";
-import type { ReportCardsV9Response } from "@shared/types/report-cards-v9";
+import type { ReportCardsV9TransitionResponse } from "@shared/types/report-cards-v9";
 import type { SafetyScorePublicationIdentity } from "@shared/types/safety-score-publication";
 import type { ReportCardCachePayload } from "../lib/report-card-cache";
 import { safetyScorePublicationIdentitiesMatch } from "@shared/lib/safety-score-publication";
@@ -149,7 +149,7 @@ type SnapshotSafetySource =
       kind: "ok";
       model: "v9";
       identity: SafetyScorePublicationIdentity;
-      reportCards: ReportCardsV9Response;
+      reportCards: ReportCardsV9TransitionResponse;
       updatedAt: number;
       activationUpdatedAt: number;
       marker: ReportCardsV9ActivationMarker;

--- a/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
+++ b/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
@@ -12,6 +12,7 @@ import {
   ReportCardsV9PreBreakdownResponseSchema,
   ReportCardsV9PreviousResponseSchema,
   ReportCardsV9ResponseSchema,
+  ReportCardsV9TransitionResponseSchema,
 } from "@shared/types/report-cards-v9";
 import { mockD1 } from "../../test-helpers/__shared/mock-d1";
 import {
@@ -231,6 +232,37 @@ describe("published V9 report-card cache", () => {
         upstreamScore: 75,
       },
     ]);
+  });
+
+  it("projects retained pre-breakdown V9 candidates into the live transition contract", async () => {
+    const previousCandidate = structuredClone(candidate()) as SafetyScoreV9Response;
+    previousCandidate.schemaVersion = 4;
+    previousCandidate.lifecycle = "candidate";
+    previousCandidate.policyVersion = "candidate-v2";
+    previousCandidate.policy = {
+      id: "safety-score-v9-candidate-v2",
+      semanticDigest: previousCandidate.policy.semanticDigest,
+    };
+    delete (previousCandidate.cards[0] as unknown as { breakdowns?: unknown }).breakdowns;
+
+    const snapshot = projectSafetyScoreV9CandidateToPublicSnapshot(
+      previousCandidate,
+      publicationHealth(previousCandidate),
+    );
+
+    expect(snapshot).toEqual(ReportCardsV9PreBreakdownResponseSchema.parse(snapshot));
+    expect(snapshot).toEqual(ReportCardsV9TransitionResponseSchema.parse(snapshot));
+    expect(() => ReportCardsV9CurrentResponseSchema.parse(snapshot)).toThrow();
+    expect(snapshot).toMatchObject({
+      model: "v9",
+      schemaVersion: 3,
+      lifecycle: "shadow",
+      safetyScoreIdentity: {
+        methodologyVersion: "candidate-v2",
+        policyId: "safety-score-v9-candidate-v2",
+      },
+    });
+    expect(snapshot.cards[0]).not.toHaveProperty("breakdowns");
   });
 
   it("fails closed for malformed or missing canonical V9 cache rows", async () => {

--- a/worker/src/lib/__tests__/safety-score-active-source.test.ts
+++ b/worker/src/lib/__tests__/safety-score-active-source.test.ts
@@ -133,6 +133,22 @@ describe("active Safety Score source", () => {
     });
   });
 
+  it("accepts a retained pre-breakdown transition snapshot when its identity matches", async () => {
+    mockLoadPublishedReportCardsV9Snapshot.mockResolvedValue({
+      ...snapshot(),
+      schemaVersion: 3,
+    });
+
+    await expect(loadActiveSafetyScoreSource(markerDb(markerValue()))).resolves.toMatchObject({
+      kind: "v9",
+      expectedModel: "v9",
+      snapshot: {
+        schemaVersion: 3,
+        safetyScoreIdentity: snapshot().safetyScoreIdentity,
+      },
+    });
+  });
+
   it("reports an identity-bound marker with no canonical V9 snapshot as unavailable", async () => {
     mockLoadPublishedReportCardsV9Snapshot.mockRejectedValue(
       new MockV9UnavailableError("Canonical Safety Score V9 shadow cache is unavailable"),
@@ -156,7 +172,7 @@ describe("active Safety Score source", () => {
       kind: "error",
       expectedModel: "v9",
       reason: "v9-snapshot-unavailable",
-      detail: "Canonical Safety Score V9 snapshot does not satisfy the current report contract",
+      detail: "Canonical Safety Score V9 snapshot does not satisfy the live transition report contract",
     });
   });
 });

--- a/worker/src/lib/__tests__/safety-score-v9-store.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-store.test.ts
@@ -25,6 +25,7 @@ import {
   SAFETY_SCORE_V9_SHADOW_CACHE_MAX_COMPRESSED_BYTES,
   SAFETY_SCORE_V9_SHADOW_CACHE_MAX_STORED_BYTES,
 } from "../safety-score-v9-cache-codec";
+import { sha256Hex } from "../hash";
 
 const SHADOW_MIGRATION_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -491,6 +492,46 @@ describe("Safety Score v9 shadow state persistence", () => {
       .run(stableJsonStringifyV1(legacyCurrentEnvelope), SAFETY_SCORE_V9_SHADOW_CACHE_KEYS.envelope);
 
     await expect(loadLatestSafetyScoreV9ShadowEnvelope(db)).resolves.toEqual(state.envelope);
+  });
+
+  it("continues to read retained compressed candidate-lifecycle cache values", async () => {
+    const { sqlite, db } = createTestDatabase();
+    const state = await successfulState();
+    await persistSafetyScoreV9ShadowState(db, state);
+
+    const retainedEnvelope = structuredClone(state.envelope) as typeof state.envelope & {
+      candidate: { schemaVersion: 4 | 5; lifecycle: "candidate" | "active" };
+    };
+    retainedEnvelope.candidate.schemaVersion = 4;
+    retainedEnvelope.candidate.lifecycle = "candidate";
+    retainedEnvelope.candidate.policyVersion = "candidate-v2";
+    retainedEnvelope.candidate.policy = {
+      id: "safety-score-v9-candidate-v2",
+      semanticDigest: retainedEnvelope.candidate.policy.semanticDigest,
+    };
+    const canonicalPayload = stableJsonStringifyV1(retainedEnvelope);
+    const compressed = await gzipBase64Utf8(canonicalPayload);
+    const storage = JSON.parse(
+      (
+        sqlite
+          .prepare("SELECT value FROM cache WHERE key = ?")
+          .get(SAFETY_SCORE_V9_SHADOW_CACHE_KEYS.envelope) as { value: string }
+      ).value,
+    ) as Record<string, unknown>;
+    storage.payload = compressed.payload;
+    storage.payloadSha256 = await sha256Hex(canonicalPayload);
+    storage.compressedBytes = compressed.compressedBytes;
+    storage.uncompressedBytes = compressed.uncompressedBytes;
+    storage.identity = {
+      ...(storage.identity as Record<string, unknown>),
+      policyVersion: retainedEnvelope.candidate.policyVersion,
+      policyId: retainedEnvelope.candidate.policy.id,
+    };
+    sqlite
+      .prepare("UPDATE cache SET value = ? WHERE key = ?")
+      .run(stableJsonStringifyV1(storage), SAFETY_SCORE_V9_SHADOW_CACHE_KEYS.envelope);
+
+    await expect(loadLatestSafetyScoreV9ShadowEnvelope(db)).resolves.toEqual(retainedEnvelope);
   });
 
   it("rejects corrupt, unbounded, noncanonical, and identity-mismatched cache envelopes", async () => {

--- a/worker/src/lib/alert-safety-source-cache.ts
+++ b/worker/src/lib/alert-safety-source-cache.ts
@@ -11,7 +11,10 @@ import {
 import { activeDepegCapScore } from "@shared/lib/report-card-active-depeg";
 import { round1, roundScore } from "@shared/lib/math";
 import type { DimensionKey, ReportCard, ReportCardGrade, SafetyAlertSourceState } from "@shared/types";
-import { ReportCardsV9ResponseSchema, type ReportCardsV9Response } from "@shared/types/report-cards-v9";
+import {
+  ReportCardsV9TransitionResponseSchema,
+  type ReportCardsV9TransitionResponse,
+} from "@shared/types/report-cards-v9";
 import type { ReportCardPublicationCompleteness } from "./report-card-publication";
 import {
   SafetyScoreV8PublicationIdentitySchema,
@@ -719,11 +722,11 @@ export function buildAlertSafetySourceEnvelope(
  * The dispatcher does not call this while V8 remains the active alert model.
  */
 export function buildAlertSafetyV9SourceEnvelope(
-  snapshot: ReportCardsV9Response,
+  snapshot: ReportCardsV9TransitionResponse,
   options: { allowShadowLifecycle: boolean },
 ): AlertSafetyV9SourceEnvelope | null {
   if (!options.allowShadowLifecycle) return null;
-  const parsed = ReportCardsV9ResponseSchema.safeParse(snapshot);
+  const parsed = ReportCardsV9TransitionResponseSchema.safeParse(snapshot);
   if (!parsed.success) return null;
   const source = parsed.data;
   if (source.publicationHealth.status === "held") return null;
@@ -760,7 +763,7 @@ export function buildAlertSafetyV9SourceEnvelope(
  * label, is the authority that permits alert use.
  */
 export function buildActiveAlertSafetyV9SourceEnvelope(
-  snapshot: ReportCardsV9Response,
+  snapshot: ReportCardsV9TransitionResponse,
 ): AlertSafetySourceEnvelope | null {
   const shadow = buildAlertSafetyV9SourceEnvelope(snapshot, { allowShadowLifecycle: true });
   if (!shadow) return null;

--- a/worker/src/lib/flight-to-quality-classification.ts
+++ b/worker/src/lib/flight-to-quality-classification.ts
@@ -1,6 +1,9 @@
 import { MINT_BURN_CONFIGS } from "./mint-burn-contracts";
 import type { ReportCardCachePayload } from "./report-card-cache";
-import { ReportCardsV9ResponseSchema, type ReportCardsV9Response } from "@shared/types/report-cards-v9";
+import {
+  ReportCardsV9TransitionResponseSchema,
+  type ReportCardsV9TransitionResponse,
+} from "@shared/types/report-cards-v9";
 import {
   SafetyScorePublicationIdentitySchema,
   type SafetyScorePublicationIdentity,
@@ -101,7 +104,7 @@ export function buildFlightToQualityClassificationFromV8Cache(
  * an active V9 publication is accepted directly.
  */
 export function buildFlightToQualityClassificationFromV9Snapshot(
-  snapshot: ReportCardsV9Response,
+  snapshot: ReportCardsV9TransitionResponse,
   options: { allowShadowLifecycle: boolean; expectedIdentity?: SafetyScorePublicationIdentity | null },
 ): FlightToQualityClassificationResult {
   if (
@@ -110,7 +113,7 @@ export function buildFlightToQualityClassificationFromV9Snapshot(
   ) {
     return { kind: "unavailable", reason: "lifecycle-not-approved" };
   }
-  const parsed = ReportCardsV9ResponseSchema.safeParse(snapshot);
+  const parsed = ReportCardsV9TransitionResponseSchema.safeParse(snapshot);
   if (!parsed.success) return { kind: "unavailable", reason: "source-contract-invalid" };
   const source = parsed.data;
   if (source.publicationHealth.status === "held") {

--- a/worker/src/lib/identified-active-safety-score-source.ts
+++ b/worker/src/lib/identified-active-safety-score-source.ts
@@ -1,5 +1,5 @@
 import type { ReportCardsResponse } from "@shared/types/report-cards";
-import type { ReportCardsV9Response } from "@shared/types/report-cards-v9";
+import type { ReportCardsV9TransitionResponse } from "@shared/types/report-cards-v9";
 import type {
   SafetyScoreV8PublicationIdentity,
   SafetyScoreV9PublicationIdentity,
@@ -26,7 +26,7 @@ export type IdentifiedActiveSafetyScoreSource =
       identity: SafetyScoreV9PublicationIdentity;
       publishedAtSec: number;
       activationUpdatedAt: number;
-      snapshot: ReportCardsV9Response;
+      snapshot: ReportCardsV9TransitionResponse;
     }
   | {
       kind: "error";

--- a/worker/src/lib/report-cards-v9-cache.ts
+++ b/worker/src/lib/report-cards-v9-cache.ts
@@ -1,12 +1,15 @@
 import {
   buildReportCardsV9DependencyGraph,
+  REPORT_CARDS_V9_PRE_BREAKDOWN_RESPONSE_SCHEMA_VERSION,
   REPORT_CARDS_V9_RESPONSE_SCHEMA_VERSION,
   ReportCardsV9CurrentResponseSchema,
-  type ReportCardsV9Response,
+  ReportCardsV9PreBreakdownResponseSchema,
+  type ReportCardsV9TransitionResponse,
   type V9PublicationHealth,
 } from "@shared/types/report-cards-v9";
 import {
   SafetyScoreV9CurrentResponseSchema,
+  SafetyScoreV9PreBreakdownResponseSchema,
   type SafetyScoreV9Response,
 } from "@shared/types/safety-score-v9-public";
 import {
@@ -29,8 +32,22 @@ export class ReportCardsV9SnapshotUnavailableError extends Error {
 export function projectSafetyScoreV9CandidateToPublicSnapshot(
   candidate: SafetyScoreV9Response,
   publicationHealth: V9PublicationHealth,
-): ReportCardsV9Response {
-  const currentCandidate = SafetyScoreV9CurrentResponseSchema.parse(candidate);
+): ReportCardsV9TransitionResponse {
+  const currentCandidateResult = SafetyScoreV9CurrentResponseSchema.safeParse(candidate);
+  const preBreakdownCandidateResult = currentCandidateResult.success
+    ? null
+    : SafetyScoreV9PreBreakdownResponseSchema.safeParse(candidate);
+  const currentCandidate = currentCandidateResult.success
+    ? currentCandidateResult.data
+    : preBreakdownCandidateResult?.success
+      ? preBreakdownCandidateResult.data
+      : SafetyScoreV9CurrentResponseSchema.parse(candidate);
+  const responseSchema = currentCandidateResult.success
+    ? ReportCardsV9CurrentResponseSchema
+    : ReportCardsV9PreBreakdownResponseSchema;
+  const responseSchemaVersion = currentCandidateResult.success
+    ? REPORT_CARDS_V9_RESPONSE_SCHEMA_VERSION
+    : REPORT_CARDS_V9_PRE_BREAKDOWN_RESPONSE_SCHEMA_VERSION;
   if (
     publicationHealth.acceptedPublicationGenerationId !==
       currentCandidate.publicationGenerationId ||
@@ -40,9 +57,9 @@ export function projectSafetyScoreV9CandidateToPublicSnapshot(
       "Safety Score V9 publication health does not match the accepted candidate",
     );
   }
-  return ReportCardsV9CurrentResponseSchema.parse({
+  return responseSchema.parse({
     model: "v9",
-    schemaVersion: REPORT_CARDS_V9_RESPONSE_SCHEMA_VERSION,
+    schemaVersion: responseSchemaVersion,
     lifecycle: "shadow",
     safetyScoreIdentity: {
       model: "v9",
@@ -80,7 +97,7 @@ export function projectSafetyScoreV9CandidateToPublicSnapshot(
 export async function loadPublishedReportCardsV9Snapshot(
   db: D1Database,
   signal?: AbortSignal,
-): Promise<ReportCardsV9Response> {
+): Promise<ReportCardsV9TransitionResponse> {
   let envelope;
   let publicationHealth;
   try {

--- a/worker/src/lib/safety-score-active-source.ts
+++ b/worker/src/lib/safety-score-active-source.ts
@@ -1,6 +1,6 @@
 import {
-  ReportCardsV9CurrentResponseSchema,
-  type ReportCardsV9Response,
+  ReportCardsV9TransitionResponseSchema,
+  type ReportCardsV9TransitionResponse,
 } from "@shared/types/report-cards-v9";
 import { SafetyScoreV9PublicationIdentitySchema } from "@shared/types/safety-score-publication";
 import { getCache } from "./db-cache";
@@ -42,7 +42,7 @@ export type ActiveSafetyScoreSource =
       expectedModel: "v9";
       marker: ReportCardsV9ActivationMarker;
       activationUpdatedAt: number;
-      snapshot: ReportCardsV9Response;
+      snapshot: ReportCardsV9TransitionResponse;
     }
   | {
       kind: "error";
@@ -53,7 +53,7 @@ export type ActiveSafetyScoreSource =
         | "v9-identity-mismatch";
       activationUpdatedAt: number;
       marker: ReportCardsV9ActivationMarker | null;
-      snapshot: ReportCardsV9Response | null;
+      snapshot: ReportCardsV9TransitionResponse | null;
       detail: string;
     };
 
@@ -63,7 +63,7 @@ export function parseReportCardsV9ActivationMarker(value: string): ReportCardsV9
 }
 
 export function reportCardsV9IdentityMatchesActivationMarker(
-  snapshot: Pick<ReportCardsV9Response, "safetyScoreIdentity">,
+  snapshot: Pick<ReportCardsV9TransitionResponse, "safetyScoreIdentity">,
   marker: ReportCardsV9ActivationMarker,
 ): boolean {
   const identity = snapshot.safetyScoreIdentity;
@@ -107,7 +107,7 @@ export async function loadActiveSafetyScoreSource(
     };
   }
 
-  let snapshot: ReportCardsV9Response;
+  let snapshot: ReportCardsV9TransitionResponse;
   try {
     snapshot = await loadPublishedReportCardsV9Snapshot(db, signal);
   } catch (error) {
@@ -122,8 +122,8 @@ export async function loadActiveSafetyScoreSource(
       detail: error.message,
     };
   }
-  const currentSnapshot = ReportCardsV9CurrentResponseSchema.safeParse(snapshot);
-  if (!currentSnapshot.success) {
+  const transitionSnapshot = ReportCardsV9TransitionResponseSchema.safeParse(snapshot);
+  if (!transitionSnapshot.success) {
     return {
       kind: "error",
       expectedModel: "v9",
@@ -131,10 +131,10 @@ export async function loadActiveSafetyScoreSource(
       activationUpdatedAt: activation.updatedAt,
       marker,
       snapshot,
-      detail: "Canonical Safety Score V9 snapshot does not satisfy the current report contract",
+      detail: "Canonical Safety Score V9 snapshot does not satisfy the live transition report contract",
     };
   }
-  snapshot = currentSnapshot.data;
+  snapshot = transitionSnapshot.data;
 
   if (!reportCardsV9IdentityMatchesActivationMarker(snapshot, marker)) {
     return {

--- a/worker/src/lib/safety-score-v9-cache-codec.ts
+++ b/worker/src/lib/safety-score-v9-cache-codec.ts
@@ -161,6 +161,10 @@ function parseSafetyScoreV9ShadowEnvelopeCanonicalPayload(
 
   const current = SafetyScoreV9ShadowEnvelopeSchema.safeParse(parsed.value);
   if (current.success) return current.data;
+  const onlyRetainedLifecycleIssue =
+    current.error.issues.length === 1 &&
+    current.error.issues[0]?.code === "custom" &&
+    current.error.issues[0]?.path.join(".") === "candidate.lifecycle";
 
   const value = parsed.value;
   if (value && typeof value === "object" && !Array.isArray(value) && "candidate" in value) {
@@ -169,16 +173,17 @@ function parseSafetyScoreV9ShadowEnvelopeCanonicalPayload(
       candidate &&
       typeof candidate === "object" &&
       !Array.isArray(candidate) &&
-      (candidate as Record<string, unknown>).schemaVersion === 5 &&
       (candidate as Record<string, unknown>).lifecycle === "candidate"
     ) {
-      return SafetyScoreV9ShadowEnvelopeSchema.parse({
+      const normalized = SafetyScoreV9ShadowEnvelopeSchema.safeParse({
         ...value,
         candidate: {
           ...candidate,
           lifecycle: "active",
         },
       });
+      if (normalized.success) return normalized.data;
+      if (onlyRetainedLifecycleIssue) return parsed.value as SafetyScoreV9ShadowEnvelope;
     }
   }
 


### PR DESCRIPTION
## Summary\n- accept production retained schema-v4 V9 shadow cache rows when candidate lifecycle is the only strict-envelope issue\n- project retained pre-breakdown candidates to the existing report-v3 transition contract instead of restamping them as current report-v4\n- widen Worker V9 consumers that already operate on the live transition contract\n\n## Validation\n- npm run typecheck:worker\n- npx vitest run worker/src/lib/__tests__/safety-score-v9-store.test.ts worker/src/lib/__tests__/report-cards-v9-cache.test.ts worker/src/lib/__tests__/safety-score-active-source.test.ts worker/src/api/__tests__/report-cards-v9.test.ts worker/src/lib/__tests__/flight-to-quality-classification.test.ts worker/src/lib/__tests__/alert-safety-source-cache.test.ts\n- npm run check:worker-boundary\n- git diff --check\n\nPost-deploy smoke target: keyed https://api.pharos.watch/api/report-cards/v9 should stop returning the retained-cache lifecycle 503.