### PR TITLE
Fix held retained V9 transition cache

### DIFF
--- a/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
+++ b/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
@@ -162,6 +162,18 @@ function publicationHealth(
   };
 }
 
+function heldPublicationHealth(): V9PublicationHealth {
+  return {
+    schemaVersion: 1,
+    status: "held",
+    acceptedPublicationGenerationId: null,
+    acceptedAtSec: null,
+    attemptedAtSec: 1_700_000_900,
+    heldSinceSec: 1_700_000_900,
+    reasons: [{ code: "assessment-failed", detail: "retained candidate requires compatibility projection" }],
+  };
+}
+
 function project(value: SafetyScoreV9Response = candidate()) {
   return projectSafetyScoreV9CandidateToPublicSnapshot(
     value,
@@ -263,6 +275,32 @@ describe("published V9 report-card cache", () => {
       },
     });
     expect(snapshot.cards[0]).not.toHaveProperty("breakdowns");
+  });
+
+  it("projects a retained held candidate when no accepted publication health exists yet", () => {
+    const previousCandidate = structuredClone(candidate()) as SafetyScoreV9Response;
+    previousCandidate.schemaVersion = 4;
+    previousCandidate.lifecycle = "candidate";
+    previousCandidate.policyVersion = "candidate-v2";
+    previousCandidate.policy = {
+      id: "safety-score-v9-candidate-v2",
+      semanticDigest: previousCandidate.policy.semanticDigest,
+    };
+    delete (previousCandidate.cards[0] as unknown as { breakdowns?: unknown }).breakdowns;
+
+    const snapshot = projectSafetyScoreV9CandidateToPublicSnapshot(
+      previousCandidate,
+      heldPublicationHealth(),
+    );
+
+    expect(snapshot).toEqual(ReportCardsV9PreBreakdownResponseSchema.parse(snapshot));
+    expect(snapshot).toEqual(ReportCardsV9TransitionResponseSchema.parse(snapshot));
+    expect(snapshot.publicationHealth).toMatchObject({
+      status: "held",
+      acceptedPublicationGenerationId: null,
+      acceptedAtSec: null,
+    });
+    expect(snapshot.updatedAt).toBe(previousCandidate.publishedAtSec);
   });
 
   it("fails closed for malformed or missing canonical V9 cache rows", async () => {

--- a/worker/src/lib/__tests__/safety-score-active-source.test.ts
+++ b/worker/src/lib/__tests__/safety-score-active-source.test.ts
@@ -149,6 +149,34 @@ describe("active Safety Score source", () => {
     });
   });
 
+  it("accepts an activated retained snapshot while publication health is held without an accepted generation", async () => {
+    mockLoadPublishedReportCardsV9Snapshot.mockResolvedValue({
+      ...snapshot(),
+      schemaVersion: 3,
+      publicationHealth: {
+        schemaVersion: 1,
+        status: "held",
+        acceptedPublicationGenerationId: null,
+        acceptedAtSec: null,
+        attemptedAtSec: 1_700_000_900,
+        heldSinceSec: 1_700_000_900,
+        reasons: [{ code: "assessment-failed", detail: "retained candidate requires compatibility projection" }],
+      },
+    });
+
+    await expect(loadActiveSafetyScoreSource(markerDb(markerValue()))).resolves.toMatchObject({
+      kind: "v9",
+      expectedModel: "v9",
+      snapshot: {
+        schemaVersion: 3,
+        publicationHealth: {
+          status: "held",
+          acceptedPublicationGenerationId: null,
+        },
+      },
+    });
+  });
+
   it("reports an identity-bound marker with no canonical V9 snapshot as unavailable", async () => {
     mockLoadPublishedReportCardsV9Snapshot.mockRejectedValue(
       new MockV9UnavailableError("Canonical Safety Score V9 shadow cache is unavailable"),

--- a/worker/src/lib/report-cards-v9-cache.ts
+++ b/worker/src/lib/report-cards-v9-cache.ts
@@ -48,11 +48,15 @@ export function projectSafetyScoreV9CandidateToPublicSnapshot(
   const responseSchemaVersion = currentCandidateResult.success
     ? REPORT_CARDS_V9_RESPONSE_SCHEMA_VERSION
     : REPORT_CARDS_V9_PRE_BREAKDOWN_RESPONSE_SCHEMA_VERSION;
-  if (
-    publicationHealth.acceptedPublicationGenerationId !==
-      currentCandidate.publicationGenerationId ||
-    publicationHealth.acceptedAtSec !== currentCandidate.publishedAtSec
-  ) {
+  const acceptedPublicationMatchesCandidate =
+    publicationHealth.acceptedPublicationGenerationId ===
+      currentCandidate.publicationGenerationId &&
+    publicationHealth.acceptedAtSec === currentCandidate.publishedAtSec;
+  const heldWithoutAcceptedPublication =
+    publicationHealth.status === "held" &&
+    publicationHealth.acceptedPublicationGenerationId === null &&
+    publicationHealth.acceptedAtSec === null;
+  if (!acceptedPublicationMatchesCandidate && !heldWithoutAcceptedPublication) {
     throw new Error(
       "Safety Score V9 publication health does not match the accepted candidate",
     );


### PR DESCRIPTION
## Summary\n- allow retained V9 transition snapshots to project when publication health is held without an accepted generation\n- preserve strict accepted-publication matching whenever publication health names an accepted candidate\n- cover the production retained-cache repair path at projection and activation boundaries\n\n## Verification\n- npx vitest run worker/src/lib/__tests__/report-cards-v9-cache.test.ts worker/src/lib/__tests__/safety-score-active-source.test.ts worker/src/lib/__tests__/safety-score-v9-store.test.ts worker/src/api/__tests__/report-cards-v9.test.ts worker/src/lib/__tests__/flight-to-quality-classification.test.ts worker/src/lib/__tests__/alert-safety-source-cache.test.ts\n- npm run typecheck:worker\n- npm run check:worker-boundary\n- git diff --check