### PR TITLE
Normalize retired safety context in sealed DDR rows

### DIFF
--- a/worker/src/cron/__tests__/depeg-resolver-public-projection.test.ts
+++ b/worker/src/cron/__tests__/depeg-resolver-public-projection.test.ts
@@ -365,9 +365,85 @@ describe("depeg-resolver public projection", () => {
     });
   });
 
+  it("normalizes retired safety contexts in immutable sealed predictions", () => {
+    const row = resolverRow({ eventId: 6 });
+    const incident = canonicalIncident(row);
+    const sealed = sealedPrediction(row, incident, 6);
+    const publication = firstPublication(sealed);
+    const fallback = buildDdrResponse({
+      candidateRows: [row],
+      incidentsByEventId: new Map([[row.eventId, incident]]),
+      sealed: [sealed],
+      firstPublication: [publication],
+      manifest: null,
+      errata: [],
+      lineage: LINEAGE,
+      nowSec: NOW_SEC,
+      storageAvailable: true,
+    }).rows[0];
+    if (fallback?.kind !== "prediction") {
+      throw new Error("Expected sealed prediction fixture");
+    }
+    const retiredContext = {
+      status: "retired-identified",
+      reason: null,
+      identity: { model: "retired" },
+    };
+    const frozen = {
+      ...fallback.frozen,
+      relatedContext: {
+        ...fallback.frozen.relatedContext,
+        safetyContext: retiredContext,
+      },
+      sourceRow: {
+        ...fallback.frozen.sourceRow,
+        relatedContext: {
+          ...fallback.frozen.sourceRow.relatedContext,
+          safetyContext: retiredContext,
+        },
+      },
+    };
+    const sealedWithRetiredContext = {
+      ...sealed,
+      sealedPayload: {
+        ...sealed.sealedPayload,
+        frozen,
+      },
+    };
+
+    const response = buildDdrResponse({
+      candidateRows: [row],
+      incidentsByEventId: new Map([[row.eventId, incident]]),
+      sealed: [sealedWithRetiredContext],
+      firstPublication: [publication],
+      manifest: null,
+      errata: [],
+      lineage: LINEAGE,
+      nowSec: NOW_SEC,
+      storageAvailable: true,
+    });
+    const projected = response.rows[0];
+    if (projected?.kind !== "prediction") {
+      throw new Error("Expected projected prediction");
+    }
+
+    expect(projected.frozen.relatedContext.safetyContext).toEqual({
+      status: "unsupported-model",
+      reason: "retired-safety-model",
+      identity: null,
+    });
+    expect(
+      projected.frozen.sourceRow.relatedContext.safetyContext,
+    ).toEqual({
+      status: "unsupported-model",
+      reason: "retired-safety-model",
+      identity: null,
+    });
+  });
+
   it("sorts public prediction ids in v2 publication base payloads", () => {
-    const firstRow = resolverRow({ eventId: 6 });
-    const secondRow = resolverRow({ eventId: 7 });
+    const firstRow = resolverRow({ eventId: 7 });
+    const secondRow = resolverRow({ eventId: 8 });
     const firstIncident = canonicalIncident(firstRow);
     const secondIncident = canonicalIncident(secondRow);
     const secondSealed = sealedPrediction(secondRow, secondIncident, 3, { rowHash: hashFor("e") });
@@ -377,8 +453,8 @@ describe("depeg-resolver public projection", () => {
     const basePayload = buildV2PublicationBasePayload({
       snapshot,
       incidentsByEventId: new Map([
-        [6, firstIncident],
-        [7, secondIncident],
+        [7, firstIncident],
+        [8, secondIncident],
       ]),
       sealed: [secondSealed, firstSealed],
       firstPublication: [firstPublication(secondSealed), firstPublication(firstSealed)],

--- a/worker/src/cron/depeg-resolver/public-projection.ts
+++ b/worker/src/cron/depeg-resolver/public-projection.ts
@@ -33,6 +33,58 @@ import type { DdrDiagnosticResponse, DdrLineage } from "./types";
 import { eligibleAt, nullableNumberValue, nullableStringValue, numberValue, recordValue, stringValue } from "./utils";
 import { firstPublicationByPredictionId, publicPredictionIdOf, sealedByIncident } from "./storage-adapters";
 
+const CURRENT_SAFETY_CONTEXT_STATUSES = new Set([
+  "v9-identified",
+  "identity-missing",
+  "identity-mismatch",
+  "unsupported-model",
+  "cache-unavailable",
+]);
+
+function normalizeSealedSafetyContext(
+  outcome: Record<string, unknown>,
+): Record<string, unknown> {
+  const normalizeRelatedContext = (
+    relatedContext: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    const safetyContext = recordValue(relatedContext.safetyContext);
+    if (
+      !safetyContext ||
+      (typeof safetyContext.status === "string" &&
+        CURRENT_SAFETY_CONTEXT_STATUSES.has(safetyContext.status))
+    ) {
+      return relatedContext;
+    }
+    return {
+      ...relatedContext,
+      safetyContext: {
+        status: "unsupported-model",
+        reason: "retired-safety-model",
+        identity: null,
+      },
+    };
+  };
+  const relatedContext = recordValue(outcome.relatedContext);
+  const sourceRow = recordValue(outcome.sourceRow);
+  const sourceRelatedContext = recordValue(sourceRow?.relatedContext);
+  return {
+    ...outcome,
+    ...(relatedContext
+      ? {
+          relatedContext: normalizeRelatedContext(relatedContext),
+        }
+      : {}),
+    ...(sourceRow && sourceRelatedContext
+      ? {
+          sourceRow: {
+            ...sourceRow,
+            relatedContext: normalizeRelatedContext(sourceRelatedContext),
+          },
+        }
+      : {}),
+  };
+}
+
 function buildFrozenDuration(row: DdrRow, lockedAt: number): Record<string, unknown> {
   const medianSec = row.duration.medianSec ?? null;
   const iqrSec = row.duration.iqrSec ?? null;
@@ -538,12 +590,14 @@ function buildPublicRows(input: {
 
     if (sealed.outcomeKind === "no_call") {
       const sealedNoCall = recordValue(sealed.sealedPayload.noCall);
-      const noCall = sealedNoCall ?? {
-        lockedAt: sealed.lockedAt,
-        eventAgeAtLockSec: sealed.eventAgeAtLockSec,
-        missingReasons: row.resolution.insufficientReasons ?? [],
-        relatedContext: row.relatedContext,
-      };
+      const noCall = sealedNoCall
+        ? normalizeSealedSafetyContext(sealedNoCall)
+        : {
+            lockedAt: sealed.lockedAt,
+            eventAgeAtLockSec: sealed.eventAgeAtLockSec,
+            missingReasons: row.resolution.insufficientReasons ?? [],
+            relatedContext: row.relatedContext,
+          };
       if (errataHistory.length > 0) {
         return {
           ...buildBasePublicRowFromSealed(sealed, base),
@@ -584,12 +638,14 @@ function buildPublicRows(input: {
     }
 
     const sealedFrozen = recordValue(sealed.sealedPayload.frozen);
-    const frozen = sealedFrozen ?? {
-      resolution: row.resolution,
-      duration: buildFrozenDuration(row, sealed.lockedAt),
-      relatedContext: row.relatedContext,
-      sourceRow: row,
-    };
+    const frozen = sealedFrozen
+      ? normalizeSealedSafetyContext(sealedFrozen)
+      : {
+          resolution: row.resolution,
+          duration: buildFrozenDuration(row, sealed.lockedAt),
+          relatedContext: row.relatedContext,
+          sourceRow: row,
+        };
     if (errataHistory.length > 0) {
       return {
         ...buildBasePublicRowFromSealed(sealed, base),


### PR DESCRIPTION
## Summary
- normalize unsupported persisted safety provenance while projecting immutable depeg forecasts
- preserve sealed payloads and row hashes while emitting the canonical `unsupported-model` state
- cover both frozen safety-context copies with a regression test

## Validation
- focused depeg-resolver tests (20 passed)
- Worker typecheck
- ESLint
- cron schedule and connection-budget checks
- Worker boundary and shared cycle checks
- git diff --check