### PR TITLE
Preserve sealed DDR provenance and improve V9 coverage notice

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,5 @@
+01d8c5f7b6b975500597dfb2042ace25e9aa5371:src/app/safety-scores/data-coverage-view-model.ts:generic-api-key:98
+01d8c5f7b6b975500597dfb2042ace25e9aa5371:src/app/safety-scores/data-coverage-view-model.ts:generic-api-key:104
 036023b2f9a5c0b8f61a55da6ffd6f5a2074fb18:worker/src/cron/reserve-adapters/__tests__/fixtures/frax-balance-sheet.json:generic-api-key:1
 0597d16755012314734e215605cf7bc4c31727fa:src/components/status/__tests__/api-keys-panel.test.tsx:generic-api-key:289
 0fc00a62cb77444203bea7f3c2422827ee5cf1c9:shared/lib/yield-auto-lending.ts:generic-api-key:18

--- a/docs/report-cards.md
+++ b/docs/report-cards.md
@@ -102,11 +102,12 @@ Selector creation currently fails closed with `503` because its recommendation p
 
 ## Frontend
 
-- `src/app/safety-scores/v9-client.tsx` owns the active ratings grid, filters, sorting, and held-state presentation.
+- `src/app/safety-scores/v9-client.tsx` owns the active ratings grid, filters, and sorting.
+- `src/app/safety-scores/data-coverage-view-model.ts` and `data-coverage-module.tsx` render the data-coverage panel: completeness, evaluated component counts per pillar, open data points split by evidence responsibility, the most common reason codes by affected assets, and held-state presentation. The panel replaces the status notice on `/safety-scores`.
 - `src/components/report-card-mini-v9.tsx` renders the V9 card treatment.
 - `src/components/stablecoin-detail/stablecoin-safety-score-v9-card.tsx` renders detail-page score, pillars, evidence, and breakdowns.
 - `src/components/radar-chart-v9.tsx` renders Backing, Exit, and Economic Control comparisons.
-- `src/components/safety-score-v9-status-notice.tsx` renders held and unavailable publication state.
+- `src/components/safety-score-v9-status-notice.tsx` renders held publication state on every other surface. Reason codes and assessment detail are evaluator identifiers and are never rendered raw; both surfaces route hold reasons through `describeDataCoverageHoldCauses`.
 - `src/hooks/api-hooks.ts` exposes `useReportCardsV9` and `useSafetyScoreHistory`.
 
 The retired V8 report-card components, V8 portfolio synthesis, and contagion stress simulator have been removed. A future stress feature must define native V9 semantics rather than recomputing retired V8 dimensions.

--- a/shared/types/depeg-resolver.ts
+++ b/shared/types/depeg-resolver.ts
@@ -140,6 +140,17 @@ export const DdrRelatedContextSchema = z.object({
 });
 export type DdrRelatedContext = z.infer<typeof DdrRelatedContextSchema>;
 
+const DdrSealedRelatedContextSchema = DdrRelatedContextSchema.extend({
+  safetyContext: z.object({
+    status: z.union([
+      DdrRelatedContextSchema.shape.safetyContext.unwrap().shape.status,
+      z.string().regex(/^[a-z0-9]+-identified$/),
+    ]),
+    reason: z.string().nullable(),
+    identity: SafetyScorePublicationIdentitySchema.nullable(),
+  }).optional(),
+});
+
 export const DdrRowSchema = z.object({
   stablecoinId: z.string(),
   symbol: z.string(),
@@ -342,8 +353,10 @@ export type DdrV2LiveOverlay = z.infer<typeof DdrV2LiveOverlaySchema>;
 export const DdrV2FrozenPayloadSchema = z.object({
   resolution: DdrResolutionSchema,
   duration: DdrFrozenDurationSchema,
-  relatedContext: DdrRelatedContextSchema,
-  sourceRow: DdrRowSchema,
+  relatedContext: DdrSealedRelatedContextSchema,
+  sourceRow: DdrRowSchema.extend({
+    relatedContext: DdrSealedRelatedContextSchema,
+  }),
 });
 export type DdrV2FrozenPayload = z.infer<typeof DdrV2FrozenPayloadSchema>;
 
@@ -351,7 +364,7 @@ export const DdrV2NoCallPayloadSchema = z.object({
   lockedAt: z.number().int().nonnegative(),
   eventAgeAtLockSec: z.number().int().nonnegative(),
   missingReasons: z.array(z.string()),
-  relatedContext: DdrRelatedContextSchema,
+  relatedContext: DdrSealedRelatedContextSchema,
 });
 export type DdrV2NoCallPayload = z.infer<typeof DdrV2NoCallPayloadSchema>;
 

--- a/src/app/safety-scores/data-coverage-module.tsx
+++ b/src/app/safety-scores/data-coverage-module.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { ChevronDown, PauseCircle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { DataCoverageModel } from "./data-coverage-view-model";
+
+/** Static swatch per gap owner, in the canonical owner order of the view model. */
+const OWNER_SWATCHES: Record<string, string> = {
+  "issuer-undisclosed": "bg-amber-500",
+  "integration-missing": "bg-frost-blue",
+  "producer-failed": "bg-rose-500",
+  "method-unsupported": "bg-muted-foreground",
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function formatHeldSince(heldSinceSec: number): string {
+  const ageSec = Math.max(0, Math.floor(Date.now() / 1000 - heldSinceSec));
+  if (ageSec < 3600) return `${Math.max(1, Math.floor(ageSec / 60))}m ago`;
+  if (ageSec < 86_400) return `${Math.floor(ageSec / 3600)}h ago`;
+  return `${Math.floor(ageSec / 86_400)}d ago`;
+}
+
+function HeadlineStat({
+  value,
+  label,
+  detail,
+}: {
+  value: string;
+  label: string;
+  detail: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <p className="pharos-numeric text-2xl font-semibold leading-none tracking-tight text-foreground sm:text-[1.75rem]">
+        {value}
+      </p>
+      <p className="mt-1.5 pharos-kicker">{label}</p>
+      <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function GapOwnerBar({ model }: { model: DataCoverageModel }) {
+  if (model.gapOwners.length === 0) return null;
+  return (
+    <div className="space-y-3">
+      <p className="pharos-kicker">Why the data is missing</p>
+      <div
+        className="flex h-3 w-full gap-0.5 overflow-hidden rounded-md bg-background/70"
+        role="img"
+        aria-label="Open data points by cause"
+      >
+        {model.gapOwners.map((owner, index) => (
+          <span
+            key={owner.key}
+            className={cn(
+              OWNER_SWATCHES[owner.key] ?? "bg-muted-foreground",
+              index === 0 && "rounded-l-md",
+              index === model.gapOwners.length - 1 && "rounded-r-md",
+            )}
+            style={{ flexGrow: owner.count }}
+            title={`${owner.label}: ${formatCount(owner.count)}`}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+      <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+        {model.gapOwners.map((owner) => (
+          <li key={owner.key} className="flex min-w-0 items-baseline gap-2">
+            <span
+              aria-hidden="true"
+              className={cn(
+                "mt-1 h-2 w-2 shrink-0 rounded-sm",
+                OWNER_SWATCHES[owner.key] ?? "bg-muted-foreground",
+              )}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-medium text-foreground">{owner.label}</span>
+              <span className="block text-[11px] leading-snug text-muted-foreground">{owner.detail}</span>
+            </span>
+            <span className="pharos-numeric shrink-0 text-sm font-semibold tabular-nums text-foreground">
+              {formatCount(owner.count)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function GapTypeRow({ label, assetCount }: { label: string; assetCount: number }) {
+  return (
+    <li className="flex items-baseline justify-between gap-3 border-b border-border/30 py-1.5 last:border-b-0">
+      <span className="min-w-0 text-xs text-foreground/85">{label}</span>
+      <span className="pharos-numeric shrink-0 text-[11px] tabular-nums text-muted-foreground">
+        {formatCount(assetCount)} {assetCount === 1 ? "asset" : "assets"}
+      </span>
+    </li>
+  );
+}
+
+function HoldRow({ hold }: { hold: NonNullable<DataCoverageModel["hold"]> }) {
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/[0.08] px-3 py-2.5">
+      <PauseCircle
+        className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-400"
+        aria-hidden="true"
+      />
+      <p className="min-w-0 text-xs leading-relaxed text-amber-800 dark:text-amber-300">
+        Ratings are held at the last verified snapshot
+        {hold.heldSinceSec !== null ? (
+          <>
+            {" "}since{" "}
+            <time
+              suppressHydrationWarning
+              dateTime={new Date(hold.heldSinceSec * 1000).toISOString()}
+              title={new Date(hold.heldSinceSec * 1000).toLocaleString()}
+            >
+              {formatHeldSince(hold.heldSinceSec)}
+            </time>
+          </>
+        ) : null}
+        .{hold.causes.length > 0 ? ` ${hold.causes.join(" ")}` : ""}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Reader-facing account of what the Safety Score has measured and what it is
+ * still missing. Replaces the raw publication-hold notice on this page: the
+ * hold folds in as one plain-English row of a much larger coverage picture.
+ */
+export function SafetyScoreDataCoverage({ model }: { model: DataCoverageModel | null }) {
+  if (!model) return null;
+
+  const backingKnownPct =
+    model.backingObservedCount === 0
+      ? null
+      : Math.round((model.backingKnownCount / model.backingObservedCount) * 100);
+
+  return (
+    <Card className="pharos-card-shell overflow-hidden" data-safety-model="v9">
+      <CardContent className="space-y-5 px-4 py-5 sm:px-6 sm:py-6">
+        <h2 className="pharos-kicker">Score inputs</h2>
+
+        <div className="grid gap-5 border-y border-border/40 py-4 sm:grid-cols-3">
+          <HeadlineStat
+            value={formatCount(model.assetCount)}
+            label="assets scored"
+            detail={`${formatCount(model.ratedCount)} rated · ${formatCount(model.notRatedCount)} not rated`}
+          />
+          <HeadlineStat
+            value={formatCount(model.inputsEvaluated)}
+            label="inputs evaluated"
+            detail={model.inputsByPillar
+              .map((pillar) => `${pillar.label.toLowerCase()} ${formatCount(pillar.count)}`)
+              .join(" · ")}
+          />
+          <HeadlineStat
+            value={formatCount(model.openGapCount)}
+            label="open data points"
+            detail={
+              model.criticalGapCount > 0
+                ? `${formatCount(model.criticalGapCount)} block a rating outright`
+                : "None block a rating outright"
+            }
+          />
+        </div>
+
+        <GapOwnerBar model={model} />
+
+        {model.gapTypes.length > 0 ? (
+          <details className="group border-t border-border/40 pt-3">
+            <summary className="pharos-focus-ring flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-sm md:min-h-0">
+              <span className="pharos-kicker">
+                Which inputs are missing ({formatCount(model.gapTypes.length)})
+              </span>
+              <ChevronDown
+                className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180"
+                aria-hidden="true"
+              />
+            </summary>
+            <ul className="pt-2">
+              {model.gapTypes.map((gap) => (
+                <GapTypeRow key={gap.code} label={gap.label} assetCount={gap.assetCount} />
+              ))}
+            </ul>
+            {backingKnownPct !== null ? (
+              <p className="pt-3 text-[11px] leading-relaxed text-muted-foreground">
+                Reserve inputs are the one set with a published observation state:{" "}
+                <span className="font-medium text-foreground">{backingKnownPct}%</span> of{" "}
+                {formatCount(model.backingObservedCount)} are fully known. Exit and economic-control
+                inputs are counted but do not publish that split, so the two totals above are
+                separate counts rather than a single ratio.
+              </p>
+            ) : null}
+          </details>
+        ) : null}
+
+        {model.hold ? <HoldRow hold={model.hold} /> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/safety-scores/data-coverage-module.tsx
+++ b/src/app/safety-scores/data-coverage-module.tsx
@@ -56,9 +56,9 @@ function GapOwnerBar({ model }: { model: DataCoverageModel }) {
       >
         {model.gapOwners.map((owner, index) => (
           <span
-            key={owner.key}
+            key={owner.responsibility}
             className={cn(
-              OWNER_SWATCHES[owner.key] ?? "bg-muted-foreground",
+              OWNER_SWATCHES[owner.responsibility] ?? "bg-muted-foreground",
               index === 0 && "rounded-l-md",
               index === model.gapOwners.length - 1 && "rounded-r-md",
             )}
@@ -70,12 +70,12 @@ function GapOwnerBar({ model }: { model: DataCoverageModel }) {
       </div>
       <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
         {model.gapOwners.map((owner) => (
-          <li key={owner.key} className="flex min-w-0 items-baseline gap-2">
+          <li key={owner.responsibility} className="flex min-w-0 items-baseline gap-2">
             <span
               aria-hidden="true"
               className={cn(
                 "mt-1 h-2 w-2 shrink-0 rounded-sm",
-                OWNER_SWATCHES[owner.key] ?? "bg-muted-foreground",
+                OWNER_SWATCHES[owner.responsibility] ?? "bg-muted-foreground",
               )}
             />
             <span className="min-w-0 flex-1">

--- a/src/app/safety-scores/data-coverage-view-model.test.ts
+++ b/src/app/safety-scores/data-coverage-view-model.test.ts
@@ -96,7 +96,7 @@ describe("buildDataCoverageModel", () => {
 
     const model = buildDataCoverageModel(response)!;
 
-    expect(model.gapOwners.map((owner) => owner.key)).toEqual([
+    expect(model.gapOwners.map((owner) => owner.responsibility)).toEqual([
       "producer-failed",
       "issuer-undisclosed",
     ]);

--- a/src/app/safety-scores/data-coverage-view-model.test.ts
+++ b/src/app/safety-scores/data-coverage-view-model.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import type { SafetyScoreV9CurrentCard } from "@shared/types/safety-score-v9-public";
+import { makeReportCardsV9Response, makeV9Card } from "@/test/fixtures/safety-score-v9";
+import {
+  buildDataCoverageModel,
+  describeDataCoverageHoldCauses,
+} from "./data-coverage-view-model";
+
+function withGaps(
+  card: SafetyScoreV9CurrentCard,
+  summaries: Array<{
+    responsibility: "integration-missing" | "issuer-undisclosed" | "measured-adverse" | "method-unsupported" | "producer-failed";
+    factCount: number;
+    criticalFactCount: number;
+    reasonCodes: string[];
+  }>,
+): SafetyScoreV9CurrentCard {
+  const base = card.scoreTrace.evidenceResponsibility.summaries.map((summary) => {
+    const override = summaries.find((entry) => entry.responsibility === summary.responsibility);
+    return override ? { ...summary, ...override } : summary;
+  }) as SafetyScoreV9CurrentCard["scoreTrace"]["evidenceResponsibility"]["summaries"];
+  return {
+    ...card,
+    scoreTrace: {
+      ...card.scoreTrace,
+      evidenceResponsibility: {
+        ...card.scoreTrace.evidenceResponsibility,
+        totalFactCount: base.reduce((sum, summary) => sum + summary.factCount, 0),
+        summaries: base,
+      },
+    },
+  };
+}
+
+describe("buildDataCoverageModel", () => {
+  it("returns null without a response", () => {
+    expect(buildDataCoverageModel(null)).toBeNull();
+    expect(buildDataCoverageModel(undefined)).toBeNull();
+  });
+
+  it("reconciles completeness, inputs, and open gaps across cards", () => {
+    const response = makeReportCardsV9Response({
+      cards: [
+        withGaps(makeV9Card({ id: "aaa-one" }), [
+          {
+            responsibility: "issuer-undisclosed",
+            factCount: 3,
+            criticalFactCount: 1,
+            reasonCodes: ["missing-reserve-composition"],
+          },
+        ]),
+        withGaps(makeV9Card({ id: "bbb-two" }), [
+          {
+            responsibility: "issuer-undisclosed",
+            factCount: 2,
+            criticalFactCount: 0,
+            reasonCodes: ["missing-reserve-composition"],
+          },
+          {
+            responsibility: "producer-failed",
+            factCount: 4,
+            criticalFactCount: 0,
+            reasonCodes: ["missing-runtime-route-evidence"],
+          },
+        ]),
+      ],
+    });
+
+    const model = buildDataCoverageModel(response)!;
+
+    expect(model.assetCount).toBe(2);
+    expect(model.ratedCount).toBe(2);
+    expect(model.notRatedCount).toBe(0);
+    // Each fixture card contributes 1 backing + 6 exit route + 1 control component.
+    expect(model.inputsByPillar).toEqual([
+      { key: "backing", label: "Backing", count: 2 },
+      { key: "exit", label: "Exit", count: 12 },
+      { key: "control", label: "Econ. control", count: 2 },
+    ]);
+    expect(model.inputsEvaluated).toBe(16);
+    expect(model.openGapCount).toBe(9);
+    expect(model.criticalGapCount).toBe(1);
+    expect(model.backingObservedCount).toBe(2);
+    expect(model.backingKnownCount).toBe(2);
+  });
+
+  it("ranks gap owners by size and drops empty owners", () => {
+    const response = makeReportCardsV9Response({
+      cards: [
+        withGaps(makeV9Card({ id: "aaa-one" }), [
+          { responsibility: "issuer-undisclosed", factCount: 1, criticalFactCount: 0, reasonCodes: [] },
+          { responsibility: "producer-failed", factCount: 5, criticalFactCount: 0, reasonCodes: [] },
+        ]),
+      ],
+    });
+
+    const model = buildDataCoverageModel(response)!;
+
+    expect(model.gapOwners.map((owner) => owner.key)).toEqual([
+      "producer-failed",
+      "issuer-undisclosed",
+    ]);
+    expect(model.gapOwners[0]!.share).toBeCloseTo(5 / 6);
+  });
+
+  it("counts gap types by affected assets and labels them in plain English", () => {
+    const response = makeReportCardsV9Response({
+      cards: [
+        withGaps(makeV9Card({ id: "aaa-one" }), [
+          {
+            responsibility: "issuer-undisclosed",
+            factCount: 1,
+            criticalFactCount: 0,
+            reasonCodes: ["missing-reserve-composition", "missing-access-review"],
+          },
+        ]),
+        withGaps(makeV9Card({ id: "bbb-two" }), [
+          {
+            responsibility: "issuer-undisclosed",
+            factCount: 1,
+            criticalFactCount: 0,
+            reasonCodes: ["missing-reserve-composition"],
+          },
+        ]),
+      ],
+    });
+
+    const model = buildDataCoverageModel(response)!;
+
+    expect(model.gapTypes[0]).toEqual({
+      code: "missing-reserve-composition",
+      label: "Reserve composition not published",
+      assetCount: 2,
+    });
+    expect(model.gapTypes[1]!.assetCount).toBe(1);
+    expect(model.gapTypes.every((gap) => !gap.label.includes("-"))).toBe(true);
+  });
+
+  it("counts gaps carried by not-rated cards", () => {
+    const notRated = withGaps(
+      makeV9Card({
+        id: "ccc-three",
+        score: null,
+        grade: "NR",
+        qualityScore: null,
+        pegMultiplier: null,
+        pegAdjustedScore: null,
+        nrReasons: [
+          {
+            code: "insufficient-evidence",
+            message: "Not enough evidence",
+            field: null,
+            origin: "asset",
+          },
+        ],
+      }),
+      [
+        {
+          responsibility: "integration-missing",
+          factCount: 7,
+          criticalFactCount: 2,
+          reasonCodes: ["insufficient-evidence"],
+        },
+      ],
+    );
+    const model = buildDataCoverageModel(
+      makeReportCardsV9Response({ cards: [notRated] }),
+    )!;
+
+    expect(model.notRatedCount).toBe(1);
+    expect(model.openGapCount).toBe(7);
+    expect(model.criticalGapCount).toBe(2);
+    // NR cards publish no component breakdowns.
+    expect(model.inputsEvaluated).toBe(0);
+  });
+
+  it("reports no hold when the publication is current", () => {
+    expect(buildDataCoverageModel(makeReportCardsV9Response())!.hold).toBeNull();
+  });
+});
+
+describe("describeDataCoverageHoldCauses", () => {
+  it("folds repeated producer failures into one asset-scoped sentence", () => {
+    const causes = describeDataCoverageHoldCauses([
+      {
+        code: "producer-failed-downgrade",
+        assetId: "msusd-metronome",
+        source: "reason",
+        reasonCode: "missing-runtime-route-evidence",
+        path: "exit:missing-runtime-route-evidence",
+        effect: "score-or-grade-downgrade",
+      },
+      {
+        code: "producer-failed-downgrade",
+        assetId: "msusd-metronome",
+        source: "reason",
+        reasonCode: "missing-same-notional-route",
+        path: "exit:missing-same-notional-route",
+        effect: "score-or-grade-downgrade",
+      },
+      {
+        code: "producer-failed-nr",
+        assetId: "cdxusd-cod3x",
+        source: "reason",
+        reasonCode: "missing-runtime-route-evidence",
+        path: "exit:missing-runtime-route-evidence",
+        effect: "not-rated",
+      },
+    ]);
+
+    expect(causes).toHaveLength(1);
+    expect(causes[0]).toContain("2 assets");
+    expect(causes[0]).toContain("rely on a data feed that did not deliver");
+    expect(causes[0]).not.toContain("missing-runtime-route-evidence");
+    expect(causes[0]).not.toContain("exit:");
+  });
+
+  it("never echoes internal assessment detail", () => {
+    const causes = describeDataCoverageHoldCauses([
+      {
+        code: "assessment-failed",
+        detail: '[{"code":"custom","path":["candidate","lifecycle"]}]',
+      },
+    ]);
+
+    expect(causes).toEqual(["The latest ratings update could not be verified."]);
+    expect(causes.join(" ")).not.toContain("candidate");
+    expect(causes.join(" ")).not.toContain("lifecycle");
+  });
+
+  it("describes input-health and coverage-floor holds without raw identifiers", () => {
+    const causes = describeDataCoverageHoldCauses([
+      { code: "dex-stale" },
+      { code: "live-reserves-unavailable" },
+      { code: "coverage-floor-failed", floorIds: ["floor-a", "floor-b"] },
+    ]);
+
+    expect(causes).toEqual([
+      "DEX liquidity data is behind schedule.",
+      "Live reserve data is unavailable.",
+      "Coverage fell below the required floor for 2 checks.",
+    ]);
+    expect(causes.join(" ")).not.toContain("floor-a");
+  });
+
+  it("returns nothing for an empty reason set", () => {
+    expect(describeDataCoverageHoldCauses([])).toEqual([]);
+  });
+});

--- a/src/app/safety-scores/data-coverage-view-model.ts
+++ b/src/app/safety-scores/data-coverage-view-model.ts
@@ -1,0 +1,263 @@
+import type {
+  ReportCardsV9CurrentResponse,
+  V9PublicationHoldReason,
+} from "@shared/types/report-cards-v9";
+import type { V9ReasonCode } from "@shared/types";
+import type { V9EvidenceResponsibility } from "@shared/types/safety-score-v9-facts";
+import { CLIENT_TRACKED_META_BY_ID } from "@shared/lib/stablecoins/client-registry";
+
+/**
+ * Plain-English labels for the public V9 reason codes. The enum values are
+ * evaluator identifiers, not reader-facing copy, so every code surfaced in the
+ * data-coverage module carries an explicit label instead of a humanized slug.
+ */
+const REASON_CODE_LABELS: Record<V9ReasonCode, string> = {
+  "bounded-mechanism-review": "Mechanism review incomplete",
+  "bounded-unknown-reserve-exposure": "Part of the reserve is unidentified",
+  "correlated-exit-routes": "Exit routes share the same failure point",
+  "critical-unresolved": "A rating-critical input is unresolved",
+  "future-dated-input-fact": "An input is dated in the future",
+  "historical-critical-input": "A rating-critical input is out of date",
+  "immaterial-unrecognized-chain-pool": "Small liquidity pool not recognized",
+  "implementation-parent-cycle": "Circular dependency on a parent asset",
+  "incomparable-route-requests": "Exit routes cannot be compared like for like",
+  "incomplete-dex-route-coverage": "DEX exit routes only partly covered",
+  "incomplete-oracle-liquidation-branch": "Oracle liquidation path only partly reviewed",
+  "insufficient-evidence": "Not enough evidence to rate this input",
+  "material-bridge-supply-unmatched": "Bridged supply does not reconcile",
+  "material-dependency-unavailable": "A material dependency could not be scored",
+  "material-reserve-slice-unstructured": "Part of the reserve is not itemized",
+  "material-unknown-reserve-exposure": "A material reserve holding is unidentified",
+  "mint-control-question": "Open question about mint control",
+  "missing-applicable-peg": "No applicable peg reference",
+  "missing-archetype": "Mechanism archetype not classified",
+  "missing-bridge-route-rows": "Bridge route data not available",
+  "missing-bridge-routes": "Bridge routes not mapped",
+  "missing-custody-profile": "Custody arrangements not published",
+  "missing-implementation-date": "Implementation date unknown",
+  "missing-latest-assurance-report": "No current attestation or audit",
+  "missing-mint-authority": "Mint authority not identified",
+  "missing-oracle-profile": "Oracle setup not documented",
+  "missing-parent-score": "Parent asset has no score",
+  "missing-peg-input": "Peg reference data missing",
+  "missing-pillar": "A scoring pillar has no inputs",
+  "missing-access-review": "Transfer and freeze powers not reviewed",
+  "missing-pillar-evidence": "A scoring pillar has no evidence",
+  "missing-required-oracle-branches": "Required oracle paths not documented",
+  "missing-reserve-composition": "Reserve composition not published",
+  "missing-runtime-route-evidence": "Live exit-route data unavailable",
+  "missing-same-notional-route": "No exit route at the tested size",
+  "missing-upgrade-control": "Upgrade controls not identified",
+  "missing-upgradeability-review": "Contract upgradeability not reviewed",
+  "nonmaterial-dependency-unavailable": "A minor dependency could not be scored",
+  "no-viable-exit-path": "No viable exit path found",
+  "parent-cycle": "Circular dependency between assets",
+  "partial-reserve-review": "Reserve review only partly complete",
+  "runtime-bridge-materiality-unavailable": "Live bridge exposure unavailable",
+  "selected-bridge-route-missing": "Selected bridge route not found",
+  "selected-bridge-route-unresolved": "Selected bridge route unresolved",
+  "unknown-control-cap-authority": "Supply-cap authority unknown",
+  "unknown-control-mint-ability": "Mint ability unknown",
+  "unknown-upgrade-authority": "Upgrade authority unknown",
+  "unresolved-control-identity": "Controlling entity not identified",
+  "unresolved-exit-output": "Exit route payout asset unresolved",
+  "unresolved-mint-authority": "Mint authority unresolved",
+  "unresolved-oracle-branch-applicability": "Oracle path applicability unresolved",
+  "unsupported-same-notional-route": "Exit route cannot be tested at size",
+  "unreviewed-dependency-relationships": "Dependency relationships not reviewed",
+  "unreviewed-oracle-profile": "Oracle setup not reviewed",
+  "unreviewed-reserve-envelope": "Reserve scope not reviewed",
+};
+
+/**
+ * Reader-facing owner of a gap. `measured-adverse` is excluded from the module:
+ * it records a measured negative finding, not an absence of data.
+ */
+const GAP_OWNERS = [
+  {
+    key: "issuer-undisclosed",
+    label: "Issuer has not disclosed it",
+    detail: "The data exists but is not published by the issuer.",
+  },
+  {
+    key: "integration-missing",
+    label: "Pharos has not integrated it yet",
+    detail: "A source exists; wiring it into the pipeline is our work.",
+  },
+  {
+    key: "producer-failed",
+    label: "A data feed failed",
+    detail: "An upstream source we rely on did not deliver.",
+  },
+  {
+    key: "method-unsupported",
+    label: "No supported method",
+    detail: "No method can measure this input for this asset yet.",
+  },
+] as const satisfies ReadonlyArray<{
+  key: V9EvidenceResponsibility;
+  label: string;
+  detail: string;
+}>;
+
+export interface DataCoverageGapOwner {
+  key: V9EvidenceResponsibility;
+  label: string;
+  detail: string;
+  count: number;
+  share: number;
+}
+
+export interface DataCoverageGapType {
+  code: V9ReasonCode;
+  label: string;
+  assetCount: number;
+}
+
+export interface DataCoverageHold {
+  heldSinceSec: number | null;
+  /** One reader-facing sentence per distinct cause. */
+  causes: string[];
+}
+
+export interface DataCoverageModel {
+  assetCount: number;
+  ratedCount: number;
+  notRatedCount: number;
+  inputsEvaluated: number;
+  inputsByPillar: Array<{ key: "backing" | "exit" | "control"; label: string; count: number }>;
+  backingKnownCount: number;
+  backingObservedCount: number;
+  openGapCount: number;
+  criticalGapCount: number;
+  gapOwners: DataCoverageGapOwner[];
+  gapTypes: DataCoverageGapType[];
+  hold: DataCoverageHold | null;
+}
+
+function assetLabel(assetId: string): string {
+  return CLIENT_TRACKED_META_BY_ID.get(assetId)?.symbol ?? assetId;
+}
+
+function assetListLabel(assetIds: readonly string[]): string {
+  const labels = assetIds.map(assetLabel);
+  if (labels.length <= 2) return labels.join(" and ");
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
+}
+
+/**
+ * Collapses the publication hold reasons into reader-facing sentences. Producer
+ * failures repeat per asset and per reason code, so they fold into a single
+ * asset-scoped sentence. Assessment detail is never echoed: it carries internal
+ * validation paths.
+ */
+export function describeDataCoverageHoldCauses(
+  reasons: readonly V9PublicationHoldReason[],
+): string[] {
+  const causes: string[] = [];
+  const producerAssetIds = [
+    ...new Set(
+      reasons.flatMap((reason) =>
+        reason.code === "producer-failed-downgrade" || reason.code === "producer-failed-nr"
+          ? [reason.assetId]
+          : [],
+      ),
+    ),
+  ].sort();
+  if (producerAssetIds.length > 0) {
+    causes.push(
+      `${producerAssetIds.length} ${producerAssetIds.length === 1 ? "asset" : "assets"} (${assetListLabel(producerAssetIds)}) rely on a data feed that did not deliver.`,
+    );
+  }
+  for (const reason of reasons) {
+    if (reason.code === "dex-stale") causes.push("DEX liquidity data is behind schedule.");
+    if (reason.code === "dex-unavailable") causes.push("DEX liquidity data is unavailable.");
+    if (reason.code === "redemption-stale") causes.push("Redemption data is behind schedule.");
+    if (reason.code === "redemption-unavailable") causes.push("Redemption data is unavailable.");
+    if (reason.code === "live-reserves-unavailable") causes.push("Live reserve data is unavailable.");
+    if (reason.code === "assessment-failed") causes.push("The latest ratings update could not be verified.");
+    if (reason.code === "coverage-floor-failed") {
+      causes.push(
+        `Coverage fell below the required floor for ${reason.floorIds.length} ${reason.floorIds.length === 1 ? "check" : "checks"}.`,
+      );
+    }
+  }
+  return [...new Set(causes)];
+}
+
+const PILLAR_LABELS = [
+  ["backing", "Backing"],
+  ["exit", "Exit"],
+  ["control", "Econ. control"],
+] as const;
+
+export function buildDataCoverageModel(
+  response: ReportCardsV9CurrentResponse | null | undefined,
+): DataCoverageModel | null {
+  if (!response) return null;
+
+  const inputsByPillar = { backing: 0, exit: 0, control: 0 };
+  let backingKnownCount = 0;
+  let backingObservedCount = 0;
+  let openGapCount = 0;
+  let criticalGapCount = 0;
+  const gapCountByOwner = new Map<V9EvidenceResponsibility, number>();
+  const assetCountByCode = new Map<V9ReasonCode, number>();
+
+  for (const card of response.cards) {
+    const responsibility = card.scoreTrace.evidenceResponsibility;
+    openGapCount += responsibility.totalFactCount;
+    for (const summary of responsibility.summaries) {
+      criticalGapCount += summary.criticalFactCount;
+      gapCountByOwner.set(
+        summary.responsibility,
+        (gapCountByOwner.get(summary.responsibility) ?? 0) + summary.factCount,
+      );
+      for (const code of summary.reasonCodes) {
+        assetCountByCode.set(code, (assetCountByCode.get(code) ?? 0) + 1);
+      }
+    }
+
+    if (card.breakdowns === null) continue;
+    inputsByPillar.backing += card.breakdowns.backing.components.length;
+    inputsByPillar.exit += card.breakdowns.exit.primaryRoute?.components.length ?? 0;
+    inputsByPillar.control += card.breakdowns.control.components.length;
+    for (const component of card.breakdowns.backing.components) {
+      backingObservedCount += 1;
+      if (component.observationState === "known") backingKnownCount += 1;
+    }
+  }
+
+  const ownerTotal = GAP_OWNERS.reduce(
+    (sum, owner) => sum + (gapCountByOwner.get(owner.key) ?? 0),
+    0,
+  );
+
+  return {
+    assetCount: response.completeness.expectedCount,
+    ratedCount: response.completeness.ratedCount,
+    notRatedCount: response.completeness.notRatedCount,
+    inputsEvaluated: inputsByPillar.backing + inputsByPillar.exit + inputsByPillar.control,
+    inputsByPillar: PILLAR_LABELS.map(([key, label]) => ({ key, label, count: inputsByPillar[key] })),
+    backingKnownCount,
+    backingObservedCount,
+    openGapCount,
+    criticalGapCount,
+    gapOwners: GAP_OWNERS.map((owner) => {
+      const count = gapCountByOwner.get(owner.key) ?? 0;
+      return { ...owner, count, share: ownerTotal === 0 ? 0 : count / ownerTotal };
+    })
+      .filter((owner) => owner.count > 0)
+      .sort((left, right) => right.count - left.count),
+    gapTypes: [...assetCountByCode.entries()]
+      .map(([code, assetCount]) => ({ code, label: REASON_CODE_LABELS[code], assetCount }))
+      .sort((left, right) => right.assetCount - left.assetCount || left.code.localeCompare(right.code)),
+    hold:
+      response.publicationHealth.status === "held"
+        ? {
+            heldSinceSec: response.publicationHealth.heldSinceSec,
+            causes: describeDataCoverageHoldCauses(response.publicationHealth.reasons),
+          }
+        : null,
+  };
+}

--- a/src/app/safety-scores/data-coverage-view-model.ts
+++ b/src/app/safety-scores/data-coverage-view-model.ts
@@ -75,33 +75,33 @@ const REASON_CODE_LABELS: Record<V9ReasonCode, string> = {
  */
 const GAP_OWNERS = [
   {
-    key: "issuer-undisclosed",
+    responsibility: "issuer-undisclosed",
     label: "Issuer has not disclosed it",
     detail: "The data exists but is not published by the issuer.",
   },
   {
-    key: "integration-missing",
+    responsibility: "integration-missing",
     label: "Pharos has not integrated it yet",
     detail: "A source exists; wiring it into the pipeline is our work.",
   },
   {
-    key: "producer-failed",
+    responsibility: "producer-failed",
     label: "A data feed failed",
     detail: "An upstream source we rely on did not deliver.",
   },
   {
-    key: "method-unsupported",
+    responsibility: "method-unsupported",
     label: "No supported method",
     detail: "No method can measure this input for this asset yet.",
   },
 ] as const satisfies ReadonlyArray<{
-  key: V9EvidenceResponsibility;
+  responsibility: V9EvidenceResponsibility;
   label: string;
   detail: string;
 }>;
 
 export interface DataCoverageGapOwner {
-  key: V9EvidenceResponsibility;
+  responsibility: V9EvidenceResponsibility;
   label: string;
   detail: string;
   count: number;
@@ -229,7 +229,8 @@ export function buildDataCoverageModel(
   }
 
   const ownerTotal = GAP_OWNERS.reduce(
-    (sum, owner) => sum + (gapCountByOwner.get(owner.key) ?? 0),
+    (sum, owner) =>
+      sum + (gapCountByOwner.get(owner.responsibility) ?? 0),
     0,
   );
 
@@ -244,7 +245,7 @@ export function buildDataCoverageModel(
     openGapCount,
     criticalGapCount,
     gapOwners: GAP_OWNERS.map((owner) => {
-      const count = gapCountByOwner.get(owner.key) ?? 0;
+      const count = gapCountByOwner.get(owner.responsibility) ?? 0;
       return { ...owner, count, share: ownerTotal === 0 ? 0 : count / ownerTotal };
     })
       .filter((owner) => owner.count > 0)

--- a/src/app/safety-scores/v9-client.tsx
+++ b/src/app/safety-scores/v9-client.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { LazySection } from "@/components/lazy-section";
 import { QueryFreshnessNotices } from "@/components/query-freshness-notices";
 import { ReportCardMiniV9 } from "@/components/report-card-mini-v9";
-import { SafetyScoreV9StatusNotice } from "@/components/safety-score-v9-status-notice";
 import { useReportCardsV9 } from "@/hooks/api-hooks";
 import { useLogos } from "@/hooks/use-logos";
 import { useStablecoins } from "@/hooks/use-stablecoins";
@@ -13,6 +12,8 @@ import { refetchQueryGroup } from "@/lib/query-refetch-group";
 import { getSafetyGradeMetadata } from "@/lib/report-card-ui";
 import { cn } from "@/lib/utils";
 import type { V9ConsumerCard } from "@/lib/safety-score-v9-consumers";
+import { SafetyScoreDataCoverage } from "./data-coverage-module";
+import { buildDataCoverageModel } from "./data-coverage-view-model";
 import {
   SafetyEmptyState,
   SafetyResultsSummary,
@@ -223,6 +224,10 @@ export function ReportCardsV9Client() {
     [cards, gradeFilter, mcapMap, sortKey],
   );
   const groupedCards = useMemo(() => groupV9CardsByGrade(filteredCards), [filteredCards]);
+  const dataCoverage = useMemo(
+    () => buildDataCoverageModel(reportCardsQuery.data),
+    [reportCardsQuery.data],
+  );
   const showGroupedCards = gradeFilter === "all" && sortKey === "overall";
   const handleRetry = useCallback(
     () => refetchQueryGroup([reportCardsQuery.refetch, stablecoinsQuery.refetch]),
@@ -267,9 +272,9 @@ export function ReportCardsV9Client() {
           },
         ]}
       />
-      <SafetyScoreV9StatusNotice response={reportCardsQuery.data} />
-
       <SafetyScoresHero stats={headlineStats} gradeCounts={gradeCounts} totalCards={totalCards} />
+
+      <SafetyScoreDataCoverage model={dataCoverage} />
 
       <V9Controls
         gradeFilter={gradeFilter}

--- a/src/components/safety-score-v9-status-notice.tsx
+++ b/src/components/safety-score-v9-status-notice.tsx
@@ -1,21 +1,12 @@
-import type {
-  ReportCardsV9CurrentResponse,
-  V9PublicationHoldReason,
-} from "@shared/types/report-cards-v9";
+import Link from "next/link";
+import type { ReportCardsV9CurrentResponse } from "@shared/types/report-cards-v9";
+import { describeDataCoverageHoldCauses } from "@/app/safety-scores/data-coverage-view-model";
 
-function describeHoldReason(reason: V9PublicationHoldReason): string {
-  if (reason.code === "coverage-floor-failed") {
-    return `Coverage floor failed for ${reason.floorIds.join(", ")}.`;
-  }
-  if (reason.code === "assessment-failed") {
-    return "The latest ratings update could not be verified.";
-  }
-  if (reason.code === "producer-failed-downgrade" || reason.code === "producer-failed-nr") {
-    return `${reason.assetId}: ${reason.reasonCode}.`;
-  }
-  return `${reason.code.replaceAll("-", " ")}.`;
-}
-
+/**
+ * Compact held-publication notice for every surface other than `/safety-scores`,
+ * which renders the full data-coverage module instead. Reason codes are never
+ * printed raw: they are evaluator identifiers, not reader-facing copy.
+ */
 export function SafetyScoreV9StatusNotice({
   response,
 }: {
@@ -24,16 +15,31 @@ export function SafetyScoreV9StatusNotice({
   if (response?.publicationHealth?.status !== "held") return null;
 
   const heldSince = response.publicationHealth.heldSinceSec;
-  const reasons = response.publicationHealth.reasons.map(describeHoldReason).join(" ");
+  const causes = describeDataCoverageHoldCauses(response.publicationHealth.reasons);
 
   return (
     <div
       className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-300"
       role="status"
     >
-      Ratings held at the last verified snapshot
-      {heldSince ? ` since ${new Date(heldSince * 1000).toLocaleString()}` : ""}.
-      {reasons ? ` ${reasons}` : ""}
+      Ratings are held at the last verified snapshot
+      {heldSince ? (
+        <>
+          {" "}since{" "}
+          <time
+            suppressHydrationWarning
+            dateTime={new Date(heldSince * 1000).toISOString()}
+          >
+            {new Date(heldSince * 1000).toLocaleString()}
+          </time>
+        </>
+      ) : null}
+      , because some inputs are missing.
+      {causes.length > 0 ? ` ${causes.join(" ")}` : ""}{" "}
+      <Link href="/safety-scores/" className="pharos-focus-ring rounded-sm underline">
+        See what data is missing
+      </Link>
+      .
     </div>
   );
 }

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -48,7 +48,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "report-cards": {
-    "dateModified": "2026-07-27T16:59:50+02:00",
+    "dateModified": "2026-07-27T18:22:46+02:00",
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {

--- a/worker/src/cron/__tests__/depeg-resolver-public-projection.test.ts
+++ b/worker/src/cron/__tests__/depeg-resolver-public-projection.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { DDR_SNAPSHOT_CACHE_GENERATION } from "@shared/lib/depeg-resolver-version";
-import type { DdrPredictionErratum, DdrRow } from "@shared/types/depeg-resolver";
+import {
+  DdrResponseSchema,
+  type DdrPredictionErratum,
+  type DdrRow,
+} from "@shared/types/depeg-resolver";
+import {
+  attachDdrPublicRowHash,
+  computeDdrPublicRowHash,
+  validateDdrPublicCacheContract,
+} from "@shared/lib/depeg-resolver/public-contract";
 import type {
   DdrCanonicalIncident,
   DdrFirstPublicationMembership,
@@ -365,7 +374,7 @@ describe("depeg-resolver public projection", () => {
     });
   });
 
-  it("normalizes retired safety contexts in immutable sealed predictions", () => {
+  it("preserves hash-addressed retired safety contexts in immutable sealed predictions", () => {
     const row = resolverRow({ eventId: 6 });
     const incident = canonicalIncident(row);
     const sealed = sealedPrediction(row, incident, 6);
@@ -387,7 +396,7 @@ describe("depeg-resolver public projection", () => {
     const retiredContext = {
       status: "retired-identified",
       reason: null,
-      identity: { model: "retired" },
+      identity: null,
     };
     const frozen = {
       ...fallback.frozen,
@@ -403,12 +412,18 @@ describe("depeg-resolver public projection", () => {
         },
       },
     };
+    const { live: _live, ...sealedPayloadWithoutHash } = {
+      ...fallback,
+      frozen,
+    };
+    const rowHash = computeDdrPublicRowHash(sealedPayloadWithoutHash);
     const sealedWithRetiredContext = {
       ...sealed,
-      sealedPayload: {
-        ...sealed.sealedPayload,
-        frozen,
-      },
+      rowHash,
+      sealedPayload: attachDdrPublicRowHash(
+        sealedPayloadWithoutHash,
+        rowHash,
+      ),
     };
 
     const response = buildDdrResponse({
@@ -427,17 +442,15 @@ describe("depeg-resolver public projection", () => {
       throw new Error("Expected projected prediction");
     }
 
-    expect(projected.frozen.relatedContext.safetyContext).toEqual({
-      status: "unsupported-model",
-      reason: "retired-safety-model",
-      identity: null,
-    });
+    expect(projected.frozen.relatedContext.safetyContext).toEqual(
+      retiredContext,
+    );
     expect(
       projected.frozen.sourceRow.relatedContext.safetyContext,
-    ).toEqual({
-      status: "unsupported-model",
-      reason: "retired-safety-model",
-      identity: null,
+    ).toEqual(retiredContext);
+    expect(DdrResponseSchema.safeParse(response).success).toBe(true);
+    expect(validateDdrPublicCacheContract(response)).toMatchObject({
+      ok: true,
     });
   });
 

--- a/worker/src/cron/depeg-resolver/public-projection.ts
+++ b/worker/src/cron/depeg-resolver/public-projection.ts
@@ -33,58 +33,6 @@ import type { DdrDiagnosticResponse, DdrLineage } from "./types";
 import { eligibleAt, nullableNumberValue, nullableStringValue, numberValue, recordValue, stringValue } from "./utils";
 import { firstPublicationByPredictionId, publicPredictionIdOf, sealedByIncident } from "./storage-adapters";
 
-const CURRENT_SAFETY_CONTEXT_STATUSES = new Set([
-  "v9-identified",
-  "identity-missing",
-  "identity-mismatch",
-  "unsupported-model",
-  "cache-unavailable",
-]);
-
-function normalizeSealedSafetyContext(
-  outcome: Record<string, unknown>,
-): Record<string, unknown> {
-  const normalizeRelatedContext = (
-    relatedContext: Record<string, unknown>,
-  ): Record<string, unknown> => {
-    const safetyContext = recordValue(relatedContext.safetyContext);
-    if (
-      !safetyContext ||
-      (typeof safetyContext.status === "string" &&
-        CURRENT_SAFETY_CONTEXT_STATUSES.has(safetyContext.status))
-    ) {
-      return relatedContext;
-    }
-    return {
-      ...relatedContext,
-      safetyContext: {
-        status: "unsupported-model",
-        reason: "retired-safety-model",
-        identity: null,
-      },
-    };
-  };
-  const relatedContext = recordValue(outcome.relatedContext);
-  const sourceRow = recordValue(outcome.sourceRow);
-  const sourceRelatedContext = recordValue(sourceRow?.relatedContext);
-  return {
-    ...outcome,
-    ...(relatedContext
-      ? {
-          relatedContext: normalizeRelatedContext(relatedContext),
-        }
-      : {}),
-    ...(sourceRow && sourceRelatedContext
-      ? {
-          sourceRow: {
-            ...sourceRow,
-            relatedContext: normalizeRelatedContext(sourceRelatedContext),
-          },
-        }
-      : {}),
-  };
-}
-
 function buildFrozenDuration(row: DdrRow, lockedAt: number): Record<string, unknown> {
   const medianSec = row.duration.medianSec ?? null;
   const iqrSec = row.duration.iqrSec ?? null;
@@ -590,14 +538,12 @@ function buildPublicRows(input: {
 
     if (sealed.outcomeKind === "no_call") {
       const sealedNoCall = recordValue(sealed.sealedPayload.noCall);
-      const noCall = sealedNoCall
-        ? normalizeSealedSafetyContext(sealedNoCall)
-        : {
-            lockedAt: sealed.lockedAt,
-            eventAgeAtLockSec: sealed.eventAgeAtLockSec,
-            missingReasons: row.resolution.insufficientReasons ?? [],
-            relatedContext: row.relatedContext,
-          };
+      const noCall = sealedNoCall ?? {
+        lockedAt: sealed.lockedAt,
+        eventAgeAtLockSec: sealed.eventAgeAtLockSec,
+        missingReasons: row.resolution.insufficientReasons ?? [],
+        relatedContext: row.relatedContext,
+      };
       if (errataHistory.length > 0) {
         return {
           ...buildBasePublicRowFromSealed(sealed, base),
@@ -638,14 +584,12 @@ function buildPublicRows(input: {
     }
 
     const sealedFrozen = recordValue(sealed.sealedPayload.frozen);
-    const frozen = sealedFrozen
-      ? normalizeSealedSafetyContext(sealedFrozen)
-      : {
-          resolution: row.resolution,
-          duration: buildFrozenDuration(row, sealed.lockedAt),
-          relatedContext: row.relatedContext,
-          sourceRow: row,
-        };
+    const frozen = sealedFrozen ?? {
+      resolution: row.resolution,
+      duration: buildFrozenDuration(row, sealed.lockedAt),
+      relatedContext: row.relatedContext,
+      sourceRow: row,
+    };
     if (errataHistory.length > 0) {
       return {
         ...buildBasePublicRowFromSealed(sealed, base),


### PR DESCRIPTION
## Summary
- replace the cryptic V9 hold notice with the committed data-coverage module
- keep active DDR safety context V9-strict while preserving immutable retired provenance under its original canonical hash
- remove the projection-normalization hotfix that changed hash-addressed sealed content
- refresh report-card documentation metadata

## Validation
- focused DDR projection and compute suites (20 passed)
- root and Worker TypeScript checks
- focused ESLint
- canonical DDR cache-contract regression
- commit-derived artifact pre-push check