### PR TITLE
Fix Pages release USDT RSC budget

### DIFF
--- a/scripts/maintenance/report-build-size.mjs
+++ b/scripts/maintenance/report-build-size.mjs
@@ -71,7 +71,10 @@ const DEFAULT_BUDGETS = {
   // (~68 KB raw) that replaced the render-blocking global stylesheet, so the
   // ceiling sits above the ~253 KB optimized payload.
   representativeDetailHtmlBytes: 270_000,
-  representativeDetailPageTxtBytes: 90_000,
+  // Safety Score V9 fact/provenance surfaces raise the production USDT route
+  // to 93,408 bytes. Keep the ceiling intentionally narrow while leaving
+  // enough headroom for the representative detail payloads to remain useful.
+  representativeDetailPageTxtBytes: 95_000,
   // Sum of gzip sizes of every script chunk referenced by a representative
   // detail page's HTML — the eager first-load JS budget per route (Mythos
   // #50). Ratcheted from 810 KB after the chart-section deferral (P1-6/P1-5)


### PR DESCRIPTION
## Summary
- ratchet the representative stablecoin RSC helper budget from 90 KB to 95 KB
- accommodate the measured 93,408-byte USDT Safety Score V9 payload while retaining a narrow release guardrail

## Validation
- npm run check:build-size
- npm run check:commit-derived-artifacts
- static half of npm run check:pr -- --base=origin/main

The previous production run #30344569318 built successfully but stopped at the stale size threshold before publishing Pages.