### PR TITLE
fix(safety-score): reject stale V9 consumer snapshots

### DIFF
--- a/worker/src/cron/__tests__/snapshot-safety-grade-history.test.ts
+++ b/worker/src/cron/__tests__/snapshot-safety-grade-history.test.ts
@@ -239,6 +239,7 @@ describe("snapshotSafetyGradeHistory", () => {
 
   it("writes identity-rich V9 history without a legacy V8 row", async () => {
     const snapshot = makeWorkerReportCardsV9Response({
+      updatedAt: Math.floor(Date.now() / 1000),
       cards: [
         makeWorkerV9Card({
           id: "usdc-circle",
@@ -327,6 +328,38 @@ describe("snapshotSafetyGradeHistory", () => {
       itemCount: 0,
       metadata: JSON.stringify({
         reason: "v9-publication-held",
+        expectedModel: "v9",
+        historyWritesSkipped: true,
+      }),
+    });
+    expect(batchExecute).not.toHaveBeenCalled();
+    expect(loadActiveV8SafetyScoreHistorySource).not.toHaveBeenCalled();
+    expect(db.getHistory()).toEqual([]);
+  });
+
+  it("writes no V9 history row while the current publication is stale", async () => {
+    const snapshot = makeWorkerReportCardsV9Response({ updatedAt: 1 });
+    vi.mocked(loadActiveSafetyScoreSource).mockResolvedValue({
+      kind: "v9",
+      expectedModel: "v9",
+      marker: {
+        policyId: snapshot.safetyScoreIdentity.policyId,
+        policyDigest: snapshot.safetyScoreIdentity.policyDigest,
+        evaluationBuildDigest: snapshot.safetyScoreIdentity.evaluationBuildDigest,
+        methodologyVersion: snapshot.safetyScoreIdentity.methodologyVersion,
+      },
+      activationUpdatedAt: snapshot.updatedAt,
+      snapshot,
+    });
+    const db = mockD1([]);
+
+    const result = await snapshotSafetyGradeHistory(db);
+
+    expect(result).toEqual({
+      status: "degraded",
+      itemCount: 0,
+      metadata: JSON.stringify({
+        reason: "v9-publication-stale",
         expectedModel: "v9",
         historyWritesSkipped: true,
       }),

--- a/worker/src/cron/snapshot-safety-grade-history.ts
+++ b/worker/src/cron/snapshot-safety-grade-history.ts
@@ -17,6 +17,7 @@ import {
   safetyScoreHistoryIdentityFromV2Row,
 } from "../lib/safety-score-history-v2";
 import { loadActiveSafetyScoreSource } from "../lib/safety-score-active-source";
+import { isSafetyScoreV9SnapshotFresh } from "../lib/safety-score-v9-consumer-freshness";
 
 interface LatestSafetyGradeRow {
   stablecoin_id: string;
@@ -63,6 +64,17 @@ export async function snapshotSafetyGradeHistory(db: D1Database, signal?: AbortS
           itemCount: 0,
           metadata: JSON.stringify({
             reason: "v9-publication-held",
+            expectedModel: "v9",
+            historyWritesSkipped: true,
+          }),
+        };
+      }
+      if (!isSafetyScoreV9SnapshotFresh(active.snapshot, nowSec)) {
+        return {
+          status: "degraded" as const,
+          itemCount: 0,
+          metadata: JSON.stringify({
+            reason: "v9-publication-stale",
             expectedModel: "v9",
             historyWritesSkipped: true,
           }),

--- a/worker/src/lib/__tests__/flight-to-quality-classification.test.ts
+++ b/worker/src/lib/__tests__/flight-to-quality-classification.test.ts
@@ -7,6 +7,7 @@ import type { ReportCardCachePayload } from "../report-card-cache";
 import { SAFETY_SCORE_METHODOLOGY_VERSION } from "@shared/lib/safety-score-version";
 import { SAFETY_SCORE_V8_EVALUATION_BUILD_DIGEST } from "@shared/data/safety-score-v8/evaluation-build-manifest-v1";
 import { makeWorkerReportCardsV9Response, makeWorkerV9Card } from "../../test-helpers/report-cards-v9";
+import { SAFETY_SCORE_V9_CONSUMER_MAX_AGE_SEC } from "../safety-score-v9-consumer-freshness";
 
 function reportCardCache(scores: ReportCardCachePayload["scores"]): ReportCardCachePayload {
   return {
@@ -97,7 +98,10 @@ describe("buildFlightToQualityClassification", () => {
   });
 
   it("requires an explicit shadow-lifecycle opt-in and complete V9 snapshot", () => {
-    const snapshot = makeWorkerReportCardsV9Response({ cards: [makeWorkerV9Card()] });
+    const snapshot = makeWorkerReportCardsV9Response({
+      cards: [makeWorkerV9Card()],
+      updatedAt: Math.floor(Date.now() / 1000),
+    });
 
     expect(buildFlightToQualityClassificationFromV9Snapshot(snapshot, { allowShadowLifecycle: false })).toEqual({
       kind: "unavailable",
@@ -126,5 +130,16 @@ describe("buildFlightToQualityClassification", () => {
       },
       { allowShadowLifecycle: true },
     )).toEqual({ kind: "unavailable", reason: "publication-held" });
+  });
+
+  it("fails closed for a stale current V9 snapshot", () => {
+    const snapshot = makeWorkerReportCardsV9Response({
+      updatedAt: Math.floor(Date.now() / 1000) - SAFETY_SCORE_V9_CONSUMER_MAX_AGE_SEC - 1,
+    });
+
+    expect(buildFlightToQualityClassificationFromV9Snapshot(
+      snapshot,
+      { allowShadowLifecycle: true },
+    )).toEqual({ kind: "unavailable", reason: "source-stale" });
   });
 });

--- a/worker/src/lib/flight-to-quality-classification.ts
+++ b/worker/src/lib/flight-to-quality-classification.ts
@@ -6,6 +6,7 @@ import {
   type SafetyScorePublicationIdentity,
 } from "@shared/types/safety-score-publication";
 import { isCurrentSafetyScoreV8Identity } from "./safety-score-current-identity";
+import { isSafetyScoreV9SnapshotFresh } from "./safety-score-v9-consumer-freshness";
 
 const TRACKED_IDS = new Set(MINT_BURN_CONFIGS.map((config) => config.stablecoinId));
 
@@ -39,6 +40,7 @@ export type FlightToQualityClassificationResult =
         | "identity-mismatch"
         | "lifecycle-not-approved"
         | "publication-held"
+        | "source-stale"
         | "source-contract-invalid";
     };
 
@@ -115,6 +117,9 @@ export function buildFlightToQualityClassificationFromV9Snapshot(
   const source = parsed.data;
   if (source.publicationHealth.status === "held") {
     return { kind: "unavailable", reason: "publication-held" };
+  }
+  if (!isSafetyScoreV9SnapshotFresh(source)) {
+    return { kind: "unavailable", reason: "source-stale" };
   }
   return buildFlightToQualityClassification({
     scores: Object.fromEntries(source.cards.map((card) => [card.id, { score: card.score ?? 0, grade: card.grade }])),


### PR DESCRIPTION
### Motivation

- Prevent consumers from using an ostensibly "current" but stale V9 snapshot that can persist after activation and drive downstream FTQ classification or organic history writes.
- Apply the repository's existing V9 consumer freshness contract uniformly to new V9 consumers so they fail closed when the accepted snapshot ages out.

### Description

- Enforce the V9 freshness window in the V9 FTQ adapter by importing `isSafetyScoreV9SnapshotFresh` and returning `kind: "unavailable", reason: "source-stale"` when the snapshot is stale (`worker/src/lib/flight-to-quality-classification.ts`).
- Skip/degrade safety-grade-history cron writes when the active V9 snapshot exceeds the consumer max-age by checking `isSafetyScoreV9SnapshotFresh` and returning a degraded result with `reason: "v9-publication-stale"` (`worker/src/cron/snapshot-safety-grade-history.ts`).
- Add focused regression tests to assert stale V9 snapshots fail closed for FTQ classification (`worker/src/lib/__tests__/flight-to-quality-classification.test.ts`) and prevent stale V9 history writes (`worker/src/cron/__tests__/snapshot-safety-grade-history.test.ts`).
- Small test/time-related adjustments to ensure the new freshness assertions are exercised deterministically in tests.

### Testing

- Ran focused Vitest suites: `npx vitest run worker/src/lib/__tests__/flight-to-quality-classification.test.ts worker/src/cron/__tests__/snapshot-safety-grade-history.test.ts --reporter=dot` and both test files passed (21 tests total).
- Ran `npx vitest run worker/src/api/__tests__/mint-burn-flows.test.ts --reporter=dot` and the mint-burn flow tests passed (30 tests).
- Type-check performed with `cd worker && npx tsc --noEmit` and succeeded.
- Repository sanity checks `npm run check:cron-sync`, `npm run check:cron-connections`, and `npm run check:migrations` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66904d1a108332b3db5b033f777165)