### PR TITLE
Honor Telegram high-growth retention limits

### DIFF
--- a/worker/src/cron/__tests__/telegram-retention-cleanup-sqlite.test.ts
+++ b/worker/src/cron/__tests__/telegram-retention-cleanup-sqlite.test.ts
@@ -644,6 +644,53 @@ describe("telegram authoritative retention", () => {
     sqlite.close();
   });
 
+  it("applies the configured high-growth limit to job and unresolved-source residue", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW_SEC * 1000);
+    const { sqlite, db } = setupLatestSchema();
+    const insertJob = sqlite.prepare(
+      `INSERT INTO telegram_alert_jobs (
+         job_id, alert_type, source_event_id, severity, created_at, expires_at, status
+       ) VALUES (?, 'dews', ?, 'risk', ?, ?, ?)`,
+    );
+    for (const index of [1, 2, 3]) {
+      insertJob.run(
+        `terminal-${index}`,
+        `missing-terminal-source-${index}`,
+        NOW_SEC - 15 * DAY_SEC,
+        NOW_SEC + DAY_SEC,
+        "sent",
+      );
+      insertJob.run(
+        `unresolved-${index}`,
+        `missing-unresolved-source-${index}`,
+        NOW_SEC - 31 * DAY_SEC,
+        NOW_SEC + DAY_SEC,
+        "queued",
+      );
+      insertUnresolvedSource(sqlite, `unresolved-source-${index}`, 31 * DAY_SEC);
+    }
+
+    const result = await runTelegramRetentionCleanup(db, undefined, { highGrowthDeleteLimit: 2 });
+    const metadata = JSON.parse(result.metadata!) as {
+      legacyTerminalJobsPruned: number;
+      staleUnresolvedJobsPruned: number;
+      staleUnresolvedSourcesPruned: number;
+      highGrowthRetention: { rowLimit: number; cappedAtLimit: boolean };
+    };
+
+    expect(metadata).toMatchObject({
+      legacyTerminalJobsPruned: 2,
+      staleUnresolvedJobsPruned: 2,
+      staleUnresolvedSourcesPruned: 2,
+      highGrowthRetention: { rowLimit: 2, cappedAtLimit: true },
+    });
+    expect(Number(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_jobs").get()?.count)).toBe(2);
+    expect(
+      Number(sqlite.prepare("SELECT COUNT(*) AS count FROM telegram_alert_source_events").get()?.count),
+    ).toBe(1);
+    sqlite.close();
+  });
+
   it("degrades only the high-growth family when its cleanup query fails", async () => {
     vi.spyOn(Date, "now").mockReturnValue(NOW_SEC * 1000);
     const { sqlite, db } = setupLatestSchema();

--- a/worker/src/cron/telegram-retention-cleanup.ts
+++ b/worker/src/cron/telegram-retention-cleanup.ts
@@ -266,6 +266,7 @@ async function pruneTelegramHighGrowthRetention(
           )`,
       terminalCutoff,
       signal,
+      highGrowthDeleteLimit,
     );
     result.legacyTerminalJobsPruned = legacyTerminalJobs.pruned;
     result.cappedAtLimit ||= legacyTerminalJobs.cappedAtLimit;
@@ -294,17 +295,18 @@ async function pruneTelegramHighGrowthRetention(
           )`,
       unresolvedCutoff,
       signal,
+      highGrowthDeleteLimit,
     );
     result.staleUnresolvedJobsPruned = staleUnresolvedJobs.pruned;
     result.cappedAtLimit ||= staleUnresolvedJobs.cappedAtLimit;
     throwIfAborted(signal);
 
     let staleUnresolvedSourcesPruned = 0;
-    while (staleUnresolvedSourcesPruned < RETENTION_DELETE_BATCH_LIMIT) {
+    while (staleUnresolvedSourcesPruned < highGrowthDeleteLimit) {
       throwIfAborted(signal);
       const batchLimit = Math.min(
         RETENTION_DELETE_BATCH_LIMIT,
-        RETENTION_DELETE_BATCH_LIMIT - staleUnresolvedSourcesPruned,
+        highGrowthDeleteLimit - staleUnresolvedSourcesPruned,
       );
       const deleted = await runWithOverloadRetry(
         () => db
@@ -347,7 +349,7 @@ async function pruneTelegramHighGrowthRetention(
       if (batchPruned < batchLimit) break;
     }
     result.staleUnresolvedSourcesPruned = staleUnresolvedSourcesPruned;
-    result.cappedAtLimit ||= staleUnresolvedSourcesPruned >= RETENTION_DELETE_BATCH_LIMIT;
+    result.cappedAtLimit ||= staleUnresolvedSourcesPruned >= highGrowthDeleteLimit;
     throwIfAborted(signal);
 
     const oldestLegacyTarget = await runWithOverloadRetry(


### PR DESCRIPTION
### Motivation
- Fix inconsistent application of the high-growth deletion budget so high-volume Telegram retention passes do not get silently capped at the default 10,000-row helper limit. 
- Prevent operational retention debt and misleading telemetry where `highGrowthDeleteLimit` was reported but not enforced for some residue cleanup passes.

### Description
- Pass the configured `highGrowthDeleteLimit` into legacy terminal-job and stale unresolved-job cleanup calls so `deleteOlderThanCapped` uses the intended budget instead of its `RETENTION_DELETE_BATCH_LIMIT` default. 
- Replace the hard-coded `RETENTION_DELETE_BATCH_LIMIT` loop condition, per-batch calculation, and `cappedAtLimit` check for stale unresolved sources with `highGrowthDeleteLimit`-based logic. 
- Add a SQLite-backed Vitest regression that runs `runTelegramRetentionCleanup` with a small `highGrowthDeleteLimit` to assert all three affected residue passes honor the configured limit. 
- Commit message: `Honor Telegram high-growth retention limits` and include the test and implementation changes in `worker/src/cron/telegram-retention-cleanup.ts` and `worker/src/cron/__tests__/telegram-retention-cleanup-sqlite.test.ts`.

### Testing
- Ran the focused Vitest suite with `npm exec vitest run -- worker/src/cron/__tests__/telegram-retention-cleanup-sqlite.test.ts --reporter=verbose` and all tests passed (6/6). 
- Type-checked the worker with `cd worker && npx tsc --noEmit` which succeeded. 
- Ran repository checks `npm run check:cron-sync` and `npm run check:cron-connections`, both of which passed. 
- Ran `git diff --check` to validate no whitespace/format issues, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66301f53f08332b2b8c1c8952936d6)