### PR TITLE
Protect pending mint/burn repairs from retention

### DIFF
--- a/worker/src/cron/__tests__/mint-burn-retention.test.ts
+++ b/worker/src/cron/__tests__/mint-burn-retention.test.ts
@@ -126,7 +126,7 @@ describe("mint/burn retention", () => {
     insertEvent(sqlite, {
       id: "protected-pending-aggregate",
       timestamp: eventCutoff - 4,
-      amountUsd: null,
+      amountUsd: 123.45,
       priceRepairStatus: "pending_aggregate",
     });
     insertEvent(sqlite, {

--- a/worker/src/cron/mint-burn/retention.ts
+++ b/worker/src/cron/mint-burn/retention.ts
@@ -279,6 +279,7 @@ async function pruneEventRows(
                event.amount_usd IS NOT NULL
                OR event.price_repair_status IN ('recovered', 'irreducible')
              )
+             AND COALESCE(event.price_repair_status, '') <> 'pending_aggregate'
              AND event.timestamp <= COALESCE((
                SELECT CAST(value AS INTEGER)
                  FROM cache
@@ -322,6 +323,7 @@ async function pruneEventRows(
                 event.amount_usd IS NOT NULL
                 OR event.price_repair_status IN ('recovered', 'irreducible')
               )
+              AND COALESCE(event.price_repair_status, '') <> 'pending_aggregate'
               AND event.timestamp <= COALESCE((
                 SELECT CAST(value AS INTEGER)
                   FROM cache


### PR DESCRIPTION
### Motivation

- A retention predicate allowed deleting old `mint_burn_events` rows when `amount_usd` was non-null even if the row's `price_repair_status` remained `pending_aggregate`, risking permanent loss of repaired USD values when aggregate rebuild/finalization later failed or was interrupted.
- The change prevents pruning source rows that are still awaiting hourly-aggregate rebuild and finalization so repaired values are preserved until they are safely aggregated.

### Description

- Add an explicit exclusion for `price_repair_status = 'pending_aggregate'` to the raw-event deletion SQL in `worker/src/cron/mint-burn/retention.ts` so priced-but-unfinalized rows are not eligible for deletion. 
- Apply the same exclusion to the oldest-eligible query used for retention backlog telemetry so reporting matches actual deletion eligibility. 
- Strengthen the focused retention test fixture in `worker/src/cron/__tests__/mint-burn-retention.test.ts` to include a priced event with `price_repair_status = 'pending_aggregate'` and verify it is preserved by retention. 
- Changes are confined to `worker/src/cron/mint-burn/retention.ts` and its unit test `worker/src/cron/__tests__/mint-burn-retention.test.ts`.

### Testing

- Ran the focused test suite with `npx vitest run worker/src/cron/__tests__/mint-burn-retention.test.ts` and all tests passed (11 tests passed). 
- Ran type checks with `npm run typecheck:worker` and it completed successfully. 
- Ran the cron connection budget check with `npm run check:cron-connections` and the trigger connection budget remained within limits. 
- Ran `git diff --check` and the working tree reported no formatting/safety issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66301e0aac8332a2bbe05f457a3ec8)