### PR TITLE
Prevent DEX liquidity retention starvation

### DIFF
--- a/worker/src/cron/dex-liquidity/__tests__/retention.test.ts
+++ b/worker/src/cron/dex-liquidity/__tests__/retention.test.ts
@@ -103,4 +103,59 @@ describe("DEX liquidity generation retention", () => {
     expect(retention.deletedRows).toBe(0);
     expect(retention.error).toBe("liquidity retention unavailable");
   });
+
+  it("does not let public references without run rows exhaust the bounded candidate set", async () => {
+    const harness = createLatestSchemaSqlite();
+    openDatabases.push(harness.sqlite);
+    const nowSec = 1_700_000_000;
+    const cutoff = nowSec - 3 * 60 * 60;
+    const insertGeneration = harness.sqlite.prepare(
+      `INSERT INTO dex_liquidity_publication_generations (
+         generation_id, started_at, state, expected_row_count,
+         written_row_count, created_at
+       ) VALUES (?, ?, 'published', 1, 1, ?)`,
+    );
+
+    for (let index = 0; index < 16; index++) {
+      const generationId = `stale-public-${index.toString().padStart(2, "0")}`;
+      const startedAt = cutoff - 1_000 + index;
+      insertGeneration.run(generationId, startedAt, startedAt);
+      harness.sqlite.prepare(
+        `INSERT INTO dex_liquidity (
+           stablecoin_id, symbol, updated_at, publication_generation_id, publication_state
+         ) VALUES (?, 'OLD', ?, ?, 'published')`,
+      ).run(`inactive-${index}`, startedAt, generationId);
+    }
+
+    insertGeneration.run("expired-unreferenced", cutoff - 500, cutoff - 500);
+    harness.sqlite.prepare(
+      `INSERT INTO dex_liquidity_run_rows (
+         generation_id, stablecoin_id, symbol, updated_at
+       ) VALUES ('expired-unreferenced', 'expired-coin', 'TST', ?)`,
+    ).run(cutoff - 500);
+
+    const retention = await pruneOldDexLiquidityGenerations(harness.db, nowSec);
+
+    expect(retention).toMatchObject({
+      deletedRunRows: 1,
+      deletedGenerationRows: 1,
+      deletedRows: 2,
+      error: null,
+    });
+    expect(
+      harness.sqlite.prepare(
+        "SELECT COUNT(*) AS count FROM dex_liquidity_run_rows WHERE generation_id = 'expired-unreferenced'",
+      ).get(),
+    ).toEqual({ count: 0 });
+    expect(
+      harness.sqlite.prepare(
+        "SELECT COUNT(*) AS count FROM dex_liquidity_publication_generations WHERE generation_id = 'expired-unreferenced'",
+      ).get(),
+    ).toEqual({ count: 0 });
+    expect(
+      harness.sqlite.prepare(
+        "SELECT COUNT(*) AS count FROM dex_liquidity_publication_generations WHERE generation_id LIKE 'stale-public-%'",
+      ).get(),
+    ).toEqual({ count: 16 });
+  });
 });

--- a/worker/src/cron/dex-liquidity/persistence.ts
+++ b/worker/src/cron/dex-liquidity/persistence.ts
@@ -465,6 +465,10 @@ export async function pruneOldDexLiquidityGenerations(
            FROM dex_liquidity_publication_generations
            WHERE started_at < ?
              AND state IN ('published', 'failed')
+             AND EXISTS (
+               SELECT 1 FROM dex_liquidity_run_rows candidate_row
+               WHERE candidate_row.generation_id = dex_liquidity_publication_generations.generation_id
+             )
              AND generation_id NOT IN (
                SELECT publication_generation_id
                FROM dex_liquidity


### PR DESCRIPTION
### Motivation

- The bounded DEX liquidity prune loop (limit 16) could repeatedly select old public-referenced generations that no longer have run rows, consuming the entire candidate window and starving later eligible generations. 

### Description

- Require bounded run-row prune candidates to still have run rows by adding an `EXISTS` filter to the `DELETE FROM dex_liquidity_run_rows` subquery in `worker/src/cron/dex-liquidity/persistence.ts`. 
- Preserve the existing `__global__` publication protection logic while preventing stale non-global public references from consuming limited prune slots. 
- Add a regression in `worker/src/cron/dex-liquidity/__tests__/retention.test.ts` that seeds 16 stale public-referenced generations without run rows ahead of one eligible expired generation and verifies the eligible generation is pruned while the stale references remain. 

### Testing

- Ran `npx vitest run worker/src/cron/dex-liquidity/__tests__/retention.test.ts` and the tests passed. 
- Ran `npm run typecheck:worker` and TypeScript checks passed. 
- Ran `npx eslint worker/src/cron/dex-liquidity/persistence.ts worker/src/cron/dex-liquidity/__tests__/retention.test.ts --max-warnings=0` and linting passed. 
- Ran `npm run check:sql-safety`, `npm run check:cron-sync`, `npm run check:cron-connections`, and `npm run check:doc-sync`, and each check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66301e23b08332907d88d3f07a9617)