### PR TITLE
Preserve null-key digest failures in cron health

### DIFF
--- a/worker/src/lib/status/__tests__/cron-health.test.ts
+++ b/worker/src/lib/status/__tests__/cron-health.test.ts
@@ -269,6 +269,47 @@ describe("loadCronHealth — availabilityImpactingConsecutiveCronErrors", () => 
       sqlite.close();
     }
   });
+
+  it("preserves legacy daily-digest failures without a schedule key", async () => {
+    const { sqlite, db } = createLatestSchemaSqlite();
+    try {
+      const insert = sqlite.prepare(
+        `INSERT INTO cron_runs
+           (job, started_at, duration_ms, status, error, item_count, metadata, schedule_key)
+         VALUES (?, ?, 100, ?, ?, 1, ?, ?)`,
+      );
+      insert.run(
+        "daily-digest",
+        NOW - 10,
+        "error",
+        "scheduled slot abandoned before child job started",
+        JSON.stringify({
+          reason: "stale-slot-reconciled",
+          childDisposition: "not_started",
+        }),
+        null,
+      );
+      insert.run(
+        "daily-digest",
+        NOW - 30,
+        "ok",
+        null,
+        JSON.stringify({ edition: "daily" }),
+        "daily0805Utc",
+      );
+
+      const snapshot = await loadCronHealth(db, NOW);
+
+      expect(snapshot.crons["daily-digest"]?.lastRun?.status).toBe("error");
+      expect(snapshot.crons["daily-digest"]?.recentRuns.map((run) => run.status)).toEqual([
+        "error",
+        "ok",
+      ]);
+      expect(snapshot.crons["daily-digest"]?.healthy).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/lib/status/cron-health.ts
+++ b/worker/src/lib/status/cron-health.ts
@@ -49,7 +49,7 @@ const CRON_HISTORY_SELECT_COLUMNS =
   "job, started_at, duration_ms, status, error, item_count, metadata, schedule_key";
 const LEGACY_IDLE_DIGEST_RECONCILIATION_SQL_FILTER = `NOT (
   job = 'daily-digest'
-  AND schedule_key = 'digestTriggerPoll'
+  AND COALESCE(schedule_key = 'digestTriggerPoll', 0)
   AND CASE
     WHEN metadata IS NOT NULL AND json_valid(metadata)
       THEN COALESCE(json_extract(metadata, '$.reason') = 'stale-slot-reconciled', 0)


### PR DESCRIPTION
### Motivation

- A legacy SQL exclusion intended to ignore idle `daily-digest` polls used `schedule_key = 'digestTriggerPoll'` inside a `NOT(...)` expression, which under SQLite three-valued logic can drop rows whose `schedule_key` is `NULL` and whose metadata matches the stale-slot/not-started shape.
- That caused genuine `daily-digest` failures with `schedule_key = NULL` to be hidden from the cron-health history before the safer in-memory guard could run.

### Description

- Make the nullable schedule-key comparison null-safe by using `COALESCE(schedule_key = 'digestTriggerPoll', 0)` in the `LEGACY_IDLE_DIGEST_RECONCILIATION_SQL_FILTER` so the SQL predicate evaluates deterministically for `NULL` keys (`worker/src/lib/status/cron-health.ts`).
- Add a migration-backed regression test that inserts a newer `daily-digest` error row with `schedule_key = NULL` and verifies the failure is preserved and reported as the latest run (`worker/src/lib/status/__tests__/cron-health.test.ts`).
- Changes are narrowly scoped to the legacy SQL filter and the test; no other behavioral changes were introduced.

### Testing

- Ran the targeted Vitest suite: `npm test -- --run worker/src/lib/status/__tests__/cron-health.test.ts`, all tests passed (28 tests, 28 passed).
- Type-check: `npm run typecheck:worker` completed successfully.
- Per-repository checks: `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66301f58788332a2122bcd149990c8)