### PR TITLE
Fix: CollateralizationCard live-timestamp unit and zero-ratio handling

### DIFF
--- a/src/components/stablecoin-detail/__tests__/collateralization-card.test.tsx
+++ b/src/components/stablecoin-detail/__tests__/collateralization-card.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { CollateralizationCard } from "../collateralization-card";
 import type { MechanismCollateralizationView } from "@/lib/mechanism-collateralization";
@@ -15,7 +15,10 @@ const reviewed: MechanismCollateralizationView = {
 };
 
 describe("CollateralizationCard", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   it("renders the reviewed ratio with an overcollateralized badge and provenance", () => {
     render(<CollateralizationCard reviewed={reviewed} />);
@@ -38,6 +41,23 @@ describe("CollateralizationCard", () => {
     render(<CollateralizationCard reviewed={reviewed} liveRatio={5.176368} liveAtSec={1785168827} />);
     expect(screen.getByText("517.6%")).toBeTruthy();
     expect(screen.getByText(/Live/)).toBeTruthy();
+    expect(screen.queryByText("245.5%")).toBeNull();
+  });
+
+  it("shows the age of a live feed timestamp expressed in Unix seconds", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+    const twoHoursAgoSec = Date.parse("2026-07-28T10:00:00Z") / 1000;
+
+    render(<CollateralizationCard reviewed={reviewed} liveRatio={1.1} liveAtSec={twoHoursAgoSec} />);
+
+    expect(screen.getByText("Live · 2h ago")).toBeTruthy();
+  });
+
+  it("prefers a zero live ratio over reviewed data", () => {
+    render(<CollateralizationCard reviewed={reviewed} liveRatio={0} />);
+    expect(screen.getByText("0.0%")).toBeTruthy();
+    expect(screen.getByText("Undercollateralized")).toBeTruthy();
     expect(screen.queryByText("245.5%")).toBeNull();
   });
 

--- a/src/components/stablecoin-detail/collateralization-card.tsx
+++ b/src/components/stablecoin-detail/collateralization-card.tsx
@@ -37,7 +37,7 @@ const TONE_BADGE_CLASSES: Record<"over" | "par" | "under", string> = {
  * not-applicable ruling renders honestly instead of a number.
  */
 export function CollateralizationCard({ reviewed, liveRatio = null, liveAtSec = null }: CollateralizationCardProps) {
-  const live = typeof liveRatio === "number" && Number.isFinite(liveRatio) && liveRatio > 0 ? liveRatio : null;
+  const live = typeof liveRatio === "number" && Number.isFinite(liveRatio) && liveRatio >= 0 ? liveRatio : null;
   if (live == null && reviewed == null) return null;
 
   const headlineRatio = live ?? reviewed?.ratio ?? null;
@@ -50,7 +50,7 @@ export function CollateralizationCard({ reviewed, liveRatio = null, liveAtSec = 
         {live != null ? (
           <span className="inline-flex h-6 items-center gap-1.5 rounded-full bg-muted/70 px-2 font-mono text-xs font-medium text-muted-foreground">
             <RefreshCw className="h-3 w-3" aria-hidden="true" />
-            {liveAtSec != null ? `Live · ${timeAgo(liveAtSec * 1000)}` : "Live"}
+            {liveAtSec != null ? `Live · ${timeAgo(liveAtSec)}` : "Live"}
           </span>
         ) : reviewed != null ? (
           <span className="inline-flex h-6 items-center rounded-full bg-muted/70 px-2 font-mono text-xs font-medium text-muted-foreground">


### PR DESCRIPTION
### Motivation
- The CollateralizationCard was misinterpreting reserve snapshot timestamps and discarding valid zero live ratios, causing stale snapshots to display as “just now” and `0` collateralization ratios to fall back to reviewed data.
- Preserve the integrity of live reserve displays so users see accurate age and severe undercollateralization signals.

### Description
- Accept finite zero live ratios by changing the live-ratio gate to `liveRatio >= 0` so `0` is treated as a valid live measurement instead of being discarded.
- Pass `liveAtSec` directly to the seconds-based relative-time helper by removing the erroneous `* 1000` conversion so `timeAgo()` receives epoch-seconds as documented.
- Add two regression tests that verify (1) a two-hour-old Unix-seconds `liveAtSec` renders `Live · 2h ago` and (2) a `liveRatio={0}` headline takes precedence over reviewed data.
- Files changed: `src/components/stablecoin-detail/collateralization-card.tsx` and `src/components/stablecoin-detail/__tests__/collateralization-card.test.tsx`.

### Testing
- Unit tests: ran `npm test -- --run src/components/stablecoin-detail/__tests__/collateralization-card.test.tsx`, all tests in that suite passed (7 tests passed).
- Lint: ran `npx eslint` against the modified files with `--max-warnings=0`, results successful for those files.
- Typecheck: ran `npm run typecheck` and it completed successfully.
- Repository checks: ran `git diff --check` with no problems reported for the changed files.
- Notes: `npm run lint:changed` could not determine the comparison due to the local checkout lacking the expected `origin/main` ref so the affected files were linted directly, and Playwright screenshot capture was not possible because the browser binary download failed (Playwright CDN returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68aea2b1ec8332a5be877631aee65b)