### PR TITLE
Fix coordinator review count in missing-data registry

### DIFF
--- a/scripts/maintenance/generate-safety-score-v9-missing-data-registry.ts
+++ b/scripts/maintenance/generate-safety-score-v9-missing-data-registry.ts
@@ -1091,7 +1091,7 @@ export function generateV9MissingDataRegistry(input: GenerateV9MissingDataRegist
       scoreProjectionReasonNeedingSupplementCount: projectionRows.filter((row) => row.requiresSupplementalTask).length,
       claimGroupCount,
       criticalItemCount: queue.entries.filter((entry) => entry.critical).length,
-      policyBindingReviewCount: queue.entries.filter((entry) => entry.policyBindingIssues.length > 0).length,
+      policyBindingReviewCount: registryItems.filter((item) => item.policyBinding.coordinatorReviewRequired).length,
       responsibilityCounts: queue.summary.responsibilityCounts,
       observationStateCounts: countBy(registryItems, (entry) => entry.observationState),
       gradeCounts: countBy(candidate.cards, (card) => card.grade),


### PR DESCRIPTION
### Motivation
- Fix an inconsistency where the top-level `summary.policyBindingReviewCount` undercounted coordinator-review tasks because supplemental `score-projection-gap` items set `policyBinding.coordinatorReviewRequired` but were not included in the aggregate.

### Description
- Compute `policyBindingReviewCount` from `registryItems.filter((item) => item.policyBinding.coordinatorReviewRequired).length` instead of `queue.entries.filter((entry) => entry.policyBindingIssues.length > 0).length` in `scripts/maintenance/generate-safety-score-v9-missing-data-registry.ts`.

### Testing
- Ran `npx vitest run scripts/__tests__/safety-score-v9-missing-data-registry.test.ts` (29 tests passed), `npx eslint scripts/maintenance/generate-safety-score-v9-missing-data-registry.ts --max-warnings=0` (passed), `npm run typecheck` (passed), and `git diff --check` (no issues); `npm run lint:changed` could not resolve `origin/main` in this checkout but the changed file was linted directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68aea8b8d88332a434835550329bb5)