### PR TITLE
fix(safety): prioritize stale peg evidence to preserve producer-failed stale classification

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
@@ -142,6 +142,7 @@ function exactFixedInput(
     pegScore?: number | null;
     currentDeviationBps?: number | null;
     depegEventCoverageLimited?: boolean;
+    pegObservedAtSec?: number;
     activeDepeg?: boolean;
     activeDepegPeakBps?: number;
     routeChain?: string;
@@ -210,7 +211,7 @@ function exactFixedInput(
               : { depegEventCoverageLimited: args.depegEventCoverageLimited }),
             pegScore: args.pegScore === undefined ? 99 : args.pegScore,
             priceSource: "fixture-price",
-            priceObservedAt: observedAtSec,
+            priceObservedAt: args.pegObservedAtSec ?? observedAtSec,
             pegPct: 99,
             severityScore: 0,
             spreadPenalty: 0,
@@ -2103,6 +2104,20 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
     const floorWithheld = exactFixedInput({ currentDeviationBps: null, depegEventCoverageLimited: true });
     expect(pegGaps(floorWithheld)).toMatchObject([
       { reasonCode: "peg-supply-floor-withheld", responsibility: "measured-adverse" },
+    ]);
+
+    // Staleness remains a producer failure even when the deviation was withheld.
+    const staleFloorWithheld = exactFixedInput({
+      currentDeviationBps: null,
+      depegEventCoverageLimited: true,
+      pegObservedAtSec: AS_OF_SEC - 1_000,
+    });
+    expect(pegGaps(staleFloorWithheld)).toMatchObject([
+      {
+        reasonCode: "missing-peg-input",
+        responsibility: "producer-failed",
+        observationState: "stale",
+      },
     ]);
 
     // The same null deviation without the floor flag stays a producer gap.

--- a/worker/src/lib/safety-score-v9-fact-set.ts
+++ b/worker/src/lib/safety-score-v9-fact-set.ts
@@ -2695,7 +2695,18 @@ function buildPeg(context: AssetBuildContext): V9AssetFactsV2["peg"] {
     peg.depegEventCoverageLimited === true &&
     !peg.activeDepeg;
   let status: V9FactStatusV2;
-  if (!complete) {
+  if (evidence.freshness.state === "stale") {
+    status = missingLocalFact(context, {
+      componentKey: "peg",
+      reasonCode: "missing-peg-input",
+      ownerDomain: "peg",
+      responsibility: "producer-failed",
+      policyRuleId: "v9.peg.current",
+      message: "The last-known peg observation is stale.",
+      observationState: "stale",
+      evidenceRefIds: [evidenceId],
+    }).status;
+  } else if (!complete) {
     status = missingLocalFact(context, {
       componentKey: "peg",
       reasonCode:
@@ -2712,17 +2723,6 @@ function buildPeg(context: AssetBuildContext): V9AssetFactsV2["peg"] {
         ? "Peg deviation is withheld by the $1M supply floor: below it, deviation fails closed by methodology design."
         : "The peg row lacks an explicit reference, score, deviation, or active-depeg peak.",
       observationState: "bounded-unknown",
-      evidenceRefIds: [evidenceId],
-    }).status;
-  } else if (evidence.freshness.state === "stale") {
-    status = missingLocalFact(context, {
-      componentKey: "peg",
-      reasonCode: "missing-peg-input",
-      ownerDomain: "peg",
-      responsibility: "producer-failed",
-      policyRuleId: "v9.peg.current",
-      message: "The last-known peg observation is stale.",
-      observationState: "stale",
       evidenceRefIds: [evidenceId],
     }).status;
   } else {


### PR DESCRIPTION
### Motivation

- A newly-added `peg-supply-floor-withheld` branch ran inside the `!complete` clause before freshness was considered, causing stale peg observations that also matched the supply-floor predicate to be misclassified as measured-structural instead of stale producer-failed missing data.  
- The intent is to ensure staleness (evidence freshness) always takes precedence so that stale observations remain `producer-failed` with `observationState: "stale"`.  

### Description

- Move the `evidence.freshness.state === "stale"` check to run before the `!complete` / supply-floor-withheld logic so stale peg evidence is classified as `missing-peg-input` with responsibility `producer-failed`.  
- Preserve the `peg-supply-floor-withheld` measured classification for fresh observations (i.e., only fresh rows that meet the supply-floor predicate become `measured-adverse`).  
- Extend the test fixture with `pegObservedAtSec` and add a regression case that asserts a stale floor-withheld peg is emitted as `missing-peg-input` / `producer-failed` / `stale` while a fresh floor-withheld peg remains `peg-supply-floor-withheld` / `measured-adverse`.  

### Testing

- Ran `npx vitest run worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts` and the suite passed (all tests in the file succeeded).  
- Ran `cd worker && npx tsc --noEmit` and TypeScript compilation completed with no errors.  
- Ran `git diff --check` to validate there are no whitespace or diff-check issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68aea3401483328e9313d104c70353)