### PR TITLE
Fix V9 parsing for fuzzy quarter launch dates

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
@@ -1139,6 +1139,25 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
     expect(evaluateV9FactSet(compiled, V9_CANDIDATE_POLICY_V1).assets[0]!.trace.finalGrade).not.toBe("NR");
   });
 
+  it("materializes fuzzy quarter implementation dates at the conservative quarter end", () => {
+    const clockSec = Date.parse("2026-07-28T00:00:00Z") / 1_000;
+    const fixed = exactFixedInput({ clockSec });
+    const baseline = buildSafetyScoreV9BaselineExtension(fixed, {
+      metaById: new Map([
+        [
+          "alpha",
+          {
+            id: "alpha",
+            mechanismArchetype: "synthetic-delta-neutral",
+            implementationLaunchDate: "2024-Q4",
+          },
+        ],
+      ]),
+    });
+
+    expect(baseline.assets[0]!.launchedAtSec).toBe(Date.parse("2024-12-31T23:59:59Z") / 1_000);
+  });
+
   it("compiles clock-valid operational-resilience claims with one evidence record per cited source", () => {
     const clockSec = Date.parse("2026-07-24T00:00:00Z") / 1_000;
     const fixed = exactFixedInput({ assetId: "usdt-tether", clockSec });

--- a/worker/src/lib/safety-score-v9-extension.ts
+++ b/worker/src/lib/safety-score-v9-extension.ts
@@ -939,7 +939,11 @@ function maximumObservedAt(values: readonly (number | null | undefined)[], fallb
 function conservativeDateEndSec(value: string | undefined, clockSec: number): number | null {
   if (!value) return null;
   let timestampMs: number;
-  if (/^\d{4}$/.test(value)) {
+  const quarterMatch = /^(\d{4})-Q([1-4])$/.exec(value);
+  if (quarterMatch) {
+    const [, year, quarter] = quarterMatch;
+    timestampMs = Date.UTC(Number(year), Number(quarter) * 3, 0, 23, 59, 59);
+  } else if (/^\d{4}$/.test(value)) {
     timestampMs = Date.UTC(Number(value), 11, 31, 23, 59, 59);
   } else if (/^\d{4}-\d{2}$/.test(value)) {
     const [year, month] = value.split("-").map(Number);


### PR DESCRIPTION
### Motivation
- The Worker Safety Score V9 baseline extension did not recognize schema-valid `YYYY-Qn` fuzzy dates (e.g. `2024-Q4`), falling back to `Date.parse` which yields `NaN` and materializes `launchedAtSec` as `null`, causing a track-record scoring regression.
- The change preserves conservative behavior while ensuring quarter-style implementation dates are available to scoring logic instead of being dropped.

### Description
- Extend `conservativeDateEndSec` in `worker/src/lib/safety-score-v9-extension.ts` to recognize `YYYY-Qn` and conservatively materialize the final second of the quarter as the end timestamp while keeping existing `YYYY`, `YYYY-MM`, and exact-date handling unchanged.
- Add a regression test in `worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts` that asserts a `implementationLaunchDate: "2024-Q4"` is materialized to `2024-12-31T23:59:59Z` (in seconds) in the V9 baseline extension.
- Files changed: `worker/src/lib/safety-score-v9-extension.ts`, `worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts`.

### Testing
- Ran `npx vitest run worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts`, and the test suite passed (66 tests passed).
- Ran worker typecheck with `npm run typecheck:worker` (`npx tsc --noEmit` in `worker`), which succeeded without errors.
- Ran repository preflight checks (`git diff --check`), which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68aea3490c8332a68c424f0a0af279)