### PR TITLE
Accept Aerodrome alias for Slipstream exact-route scoring

### DIFF
--- a/shared/lib/__tests__/p4-exit-route-capacity.test.ts
+++ b/shared/lib/__tests__/p4-exit-route-capacity.test.ts
@@ -742,35 +742,37 @@ describe("P4 DEX exit route observations", () => {
   it("accepts the active Base Aerodrome Slipstream adapter as exact measured evidence", () => {
     const observedAt = 1_752_560_000;
     const profile = aerodromeMeasuredProfile(observedAt - 60);
-    const result = buildP4DexExitRouteObservations({
-      stablecoinId: "usdc-circle",
-      observedAt,
-      retainedPools: [{
-        poolId: "defillama-yields-uuid",
-        project: "aerodrome-slipstream",
-        chain: "base",
-        tvlUsd: 2_000_000,
-        symbol: "USDC-USDT",
-        poolType: "aerodrome-slipstream",
-        source: "dl",
-        extra: {
-          measuredExecution: profile,
-          measuredExecutionPhysicalPoolId: profile.poolId,
-        },
-      }],
-    });
+    for (const project of ["aerodrome", "aerodrome-slipstream"]) {
+      const result = buildP4DexExitRouteObservations({
+        stablecoinId: "usdc-circle",
+        observedAt,
+        retainedPools: [{
+          poolId: "defillama-yields-uuid",
+          project,
+          chain: "base",
+          tvlUsd: 2_000_000,
+          symbol: "USDC-USDT",
+          poolType: "aerodrome-slipstream",
+          source: "dl",
+          extra: {
+            measuredExecution: profile,
+            measuredExecutionPhysicalPoolId: profile.poolId,
+          },
+        }],
+      });
 
-    expect(result.observations[0]).toMatchObject({
-      adapterProfileId: "aerodrome-slipstream-quoter-v2",
-      evidenceKind: "measured-executable-depth",
-      scoreEligible: true,
-    });
-    expect(result.coverage).toMatchObject({
-      scoreEligibleCapabilityPoolCount: 1,
-      scoreEligiblePoolCount: 1,
-      unsupportedPoolCount: 0,
-    });
-    expect(isDexExitRouteCoverageComplete(result.coverage)).toBe(true);
+      expect(result.observations[0]).toMatchObject({
+        adapterProfileId: "aerodrome-slipstream-quoter-v2",
+        evidenceKind: "measured-executable-depth",
+        scoreEligible: true,
+      });
+      expect(result.coverage).toMatchObject({
+        scoreEligibleCapabilityPoolCount: 1,
+        scoreEligiblePoolCount: 1,
+        unsupportedPoolCount: 0,
+      });
+      expect(isDexExitRouteCoverageComplete(result.coverage)).toBe(true);
+    }
   });
 
   it("keeps the 3pool reserve model score-facing until the atomic packet matures", () => {

--- a/shared/lib/p4-exit-route-capacity.ts
+++ b/shared/lib/p4-exit-route-capacity.ts
@@ -692,6 +692,8 @@ function validateMeasuredExecutionProfile(
   const projectKey = normalizedKey(context.pool.project);
   const protocolMatches = profile.adapterProfileId === "sunswap-v2-router-v1"
     ? projectKey === "sunswap" || projectKey === "sunswap-v2"
+    : profile.adapterProfileId === "aerodrome-slipstream-quoter-v2"
+      ? projectKey === "aerodrome" || projectKey === "aerodrome-slipstream"
     : normalizedKey(profile.protocol) === projectKey;
   if (
     canonicalExitRouteChain(profile.chain) !== canonicalExitRouteChain(context.pool.chain) ||


### PR DESCRIPTION
### Motivation

- Fix a functional mismatch where measured Aerodrome Slipstream observations (adapter `aerodrome-slipstream-quoter-v2`) were score-eligible but rejected by measured-profile validation because `profile.protocol` required exact equality with `pool.project` and the scoring pipeline sometimes supplies `pool.project === "aerodrome"`.

### Description

- Update `validateMeasuredExecutionProfile` to special-case `aerodrome-slipstream-quoter-v2` so it accepts `pool.project` normalized to either `aerodrome` or `aerodrome-slipstream` when checking protocol/project identity. 
- Expand the regression test in `shared/lib/__tests__/p4-exit-route-capacity.test.ts` to exercise both retained-pool spellings (`"aerodrome"` and `"aerodrome-slipstream"`) and assert the observation is score-eligible and coverage is complete for both.
- Keep all other adapter validation behavior unchanged so other adapters still require the existing protocol/project equality rules.

### Testing

- Ran the focused unit suite with `npx vitest run shared/lib/__tests__/p4-exit-route-capacity.test.ts`, and the test file passed (31 tests passed). 
- Ran type checks with `npm run typecheck:tests`, which completed successfully. 
- Ran import-boundary checks with `npm run check:worker-boundary`, which passed. 
- Ran `npm run check:shared-cycles`, which completed analysis but reported a pre-existing circular dependency unrelated to this change; the report did not block the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66301de8388332ae44463ef07b6da6)