### PR TITLE
fix(liquidity): trust tracked price for NXUSD output

### DIFF
--- a/docs/dex-liquidity.md
+++ b/docs/dex-liquidity.md
@@ -339,6 +339,12 @@ runtime-code response is semantic code absence and is never eligible for
 last-known-good retention; an unavailable RPC response remains an operational
 failure subject to the bounded freshness policy.
 
+Reviewed Curve composite targets also value quote outputs independently of
+Curve pool metadata. In particular, the Avalanche NXUSD metapool values its
+avUSDC output with the tracked USDC reference; the Curve API's underlying-coin
+price is retained only with source metadata and cannot change measured cost or
+cost-bound results.
+
 Address-grade plain `factory-stable-ng` pools that initially gate as
 rate-bearing may instead contribute an exact reserve model only when the source
 stage pins a fresh block, reads `get_balances()`, `stored_rates()`, `A()`,

--- a/worker/src/cron/measured-execution/__tests__/curve-composite.test.ts
+++ b/worker/src/cron/measured-execution/__tests__/curve-composite.test.ts
@@ -559,7 +559,7 @@ describe("reviewed Curve rate-bearing and metapool targets", () => {
         address: CURVE_NXUSD_METAPOOL_POLICY.executionTokens[2].address,
         symbol: "avUSDC",
         decimals: 6,
-        referencePriceUsd: 0.99986,
+        referencePriceUsd: 1,
       },
       retainedTvlUsd: 328_267,
     });
@@ -570,6 +570,23 @@ describe("reviewed Curve rate-bearing and metapool targets", () => {
       inputIndex: 0,
       outputIndex: 2,
       quoteFunction: "get_dy_underlying",
+    });
+  });
+
+  it("does not value NXUSD output with the Curve API underlying price", () => {
+    const target = nxusdTarget(
+      CURVE_NXUSD_METAPOOL_POLICY.executionTokens.map((token, index) => ({
+        address: token.address,
+        symbol: token.symbol,
+        decimals: token.decimals,
+        usdPrice: index === CURVE_NXUSD_METAPOOL_POLICY.outputIndex ? 1.05 : 1,
+      })),
+    );
+
+    expect(target).not.toBeNull();
+    expect(target?.tokenOut).toMatchObject({
+      symbol: "avUSDC",
+      referencePriceUsd: 1,
     });
   });
 
@@ -903,7 +920,7 @@ describe("reviewed Curve rate-bearing and metapool targets", () => {
     expect(outcomes.every((outcome) => outcome.point != null)).toBe(true);
     expect(outcomes[0]!.point?.outputUsd).toBeGreaterThan(990);
     expect(outcomes[1]!.point?.outputUsd).toBe(999);
-    expect(outcomes[2]!.point?.outputUsd).toBe(998.86014);
+    expect(outcomes[2]!.point?.outputUsd).toBe(999);
     expect(executeMulticall).toHaveBeenCalledTimes(2);
     expect(executeMulticall.mock.calls.map(([call]) => call.chain)).toEqual([
       "ethereum",

--- a/worker/src/cron/measured-execution/curve-composite.ts
+++ b/worker/src/cron/measured-execution/curve-composite.ts
@@ -84,6 +84,7 @@ interface CurveCompositeToken {
   symbol: string;
   decimals: number;
   trackedAssetId?: string;
+  referenceAssetId?: string;
 }
 
 interface CurveCompositePolicyBase {
@@ -318,6 +319,7 @@ export const CURVE_NXUSD_METAPOOL_POLICY: CurveMetapoolPolicy = {
       address: "0x46a51127c3ce23fb7ab1de06226147f446e4a857",
       symbol: "avUSDC",
       decimals: 6,
+      referenceAssetId: "usdc-circle",
     },
     {
       address: "0x532e6537fea298397212f09a61e03311686f548e",
@@ -520,9 +522,10 @@ export function buildCurveCompositeMeasuredExecutionTarget(input: {
   const tokenOut = policy.executionTokens[policy.outputIndex];
   if (!tokenIn || !tokenOut || tokenIn.trackedAssetId !== policy.stablecoinId) return null;
   const inputPrice = input.stablecoinPriceById?.get(policy.stablecoinId);
-  const outputPrice = tokenOut.trackedAssetId
-    ? input.stablecoinPriceById?.get(tokenOut.trackedAssetId)
-    : curveData.underlyingCoins?.[policy.outputIndex]?.usdPrice;
+  const outputReferenceAssetId = tokenOut.trackedAssetId ?? tokenOut.referenceAssetId;
+  const outputPrice = outputReferenceAssetId
+    ? input.stablecoinPriceById?.get(outputReferenceAssetId)
+    : undefined;
   if (
     inputPrice == null ||
     outputPrice == null ||


### PR DESCRIPTION
### Motivation

- A Curve API `underlyingCoins[].usdPrice` value for the NXUSD metapool output (avUSDC) was being used as the authoritative reference price for target generation and measured-execution diagnostics, allowing an upstream/compromised provider to poison public measured-output USD, cost, and `passesCostBound` results. 
- The intent is to ensure measured targets use an independently tracked asset reference when available and fail closed rather than trusting unverified external `usdPrice` fields.

### Description

- Add an optional `referenceAssetId` to `CurveCompositeToken` and set `referenceAssetId: "usdc-circle"` for the NXUSD policy's `avUSDC` execution token. 
- Change `buildCurveCompositeMeasuredExecutionTarget` to resolve the output reference by `tokenOut.trackedAssetId ?? tokenOut.referenceAssetId` and require the price from `input.stablecoinPriceById` instead of falling back to `curveData.underlyingCoins[].usdPrice`. 
- Add a regression test that simulates a poisoned Curve `underlyingCoins` price (e.g. `1.05`) and asserts the built target and measured valuation remain based on the trusted tracked USDC price. 
- Document the provenance boundary in `docs/dex-liquidity.md` to note that reviewed Curve composite outputs are valued from tracked references, not the Curve API `underlyingCoins` price.

### Testing

- Ran the unit tests `npx vitest run worker/src/cron/measured-execution/__tests__/curve-composite.test.ts` and the broader suites `worker/src/cron/measured-execution/__tests__/sync-admission.test.ts` and `worker/src/cron/dex-liquidity/__tests__/fetch-primary.test.ts`, and all tests passed. 
- Performed a TypeScript check with `cd worker && npx tsc --noEmit`, which succeeded. 
- Ran repository checks `npm run check:cron-sync`, `npm run check:cron-connections`, `npm run check:verified-doc-links`, and `npm run check:doc-source-paths`, all of which completed without errors. 
- Verified there are no `git diff --check` issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68d33bebd483329ec46267d8c0ab9d)