### PR TITLE
Align Tron measured execution with shadow policy

### DIFF
--- a/worker/src/cron/measured-execution/tron-sync.ts
+++ b/worker/src/cron/measured-execution/tron-sync.ts
@@ -18,6 +18,7 @@ import {
 } from "./persistence";
 import { buildTronMeasuredExecutionProfile } from "./tron-profiles";
 import { quoteTronMeasuredTarget } from "./tron-quotes";
+import { getTronMeasuredExecutionAdapterByProfile } from "./tron-registry";
 
 const TRON_ADMISSION_SOURCE_KEY = "measured-execution:tron-admission";
 // The native consumer reads one published generation, so the current SunSwap
@@ -25,12 +26,22 @@ const TRON_ADMISSION_SOURCE_KEY = "measured-execution:tron-admission";
 export const TRON_MEASURED_TARGETS_PER_RUN = 21;
 export const TRON_MEASURED_RUNTIME_BUDGET_MS = 7 * 60 * 1_000;
 export const TRON_MEASURED_REQUEST_HEADROOM_MS = 20_000;
-const TRON_MEASURED_EXECUTION_ACTIVATION = "active" as const;
+const TRON_MEASURED_EXECUTION_DEFAULT_ACTIVATION = "shadow" as const;
 
 interface TronQuoteState {
   target: TronMeasuredExecutionTarget;
   profile: TronMeasuredExecutionProfile | null;
   failureReason: string | null;
+}
+
+function getTronMeasuredExecutionActivation(
+  targets: readonly TronMeasuredExecutionTarget[],
+): "active" | "shadow" {
+  return targets.some(
+    (target) => getTronMeasuredExecutionAdapterByProfile(target.adapterProfileId)?.activation === "active",
+  )
+    ? "active"
+    : "shadow";
 }
 
 export function admitTronMeasuredTargets(
@@ -107,12 +118,13 @@ export async function syncTronDexMeasuredExecution(
       itemCount: 0,
       metadata: JSON.stringify({
         reason: "tron-target-generation-missing",
-        activation: TRON_MEASURED_EXECUTION_ACTIVATION,
+        activation: TRON_MEASURED_EXECUTION_DEFAULT_ACTIVATION,
       }),
       productivity: { productive: false, reason: "tron-target-generation-missing" },
     };
   }
 
+  const activation = getTronMeasuredExecutionActivation(targetGeneration.targets);
   const admissionState = await readDexSourcePaginationState(db, TRON_ADMISSION_SOURCE_KEY, "sync-cl-exit-depth");
   const admissionCursor = admissionState.cursor?.trim() || null;
   const { admitted, nextCursor } = admitTronMeasuredTargets(targetGeneration.targets, admissionCursor);
@@ -149,11 +161,11 @@ export async function syncTronDexMeasuredExecution(
     completed++;
     await reportProgress?.({
       stage: "tron-exact-quotes",
-      message: "Capturing active SunSwap V2 exact execution quotes",
+      message: "Capturing Tron exact execution quotes",
       itemsDone: completed,
       itemsTotal: admitted.size,
       metadata: {
-        activation: TRON_MEASURED_EXECUTION_ACTIVATION,
+        activation,
         targetGenerationId: targetGeneration.generationId,
       },
     });
@@ -218,7 +230,7 @@ export async function syncTronDexMeasuredExecution(
       state.failureReason !== "rate-limit-deferred",
   ).length;
   const metadata = {
-    activation: TRON_MEASURED_EXECUTION_ACTIVATION,
+    activation,
     targetGenerationId: targetGeneration.generationId,
     quoteGenerationId: publication.generationId,
     targetCount: targetGeneration.targets.length,

--- a/worker/src/handlers/scheduled/__tests__/half-hourly-measured-execution.test.ts
+++ b/worker/src/handlers/scheduled/__tests__/half-hourly-measured-execution.test.ts
@@ -45,6 +45,24 @@ describe("half-hourly measured execution result aggregation", () => {
     expect(merged.status).toBe("degraded");
   });
 
+  it("retains shadow Tron quote failures as diagnostics", () => {
+    const merged = mergeMeasuredExecutionResults(
+      result("ok", "evm"),
+      result("ok", "solana", 0, { activation: "target-ratified" }),
+      result("degraded", "tron", 1, {
+        activation: "shadow",
+        cursorWriteStatus: "not-needed",
+        failuresByReason: { "profile-validation:quote-price-mismatch": 1 },
+      }),
+    );
+    const metadata = JSON.parse(merged.metadata!);
+
+    expect(merged.status).toBe("ok");
+    expect(metadata.laneStatuses.tron).toBe("degraded");
+    expect(metadata.tron.activation).toBe("shadow");
+    expect(metadata.tron.attemptedFailureCount).toBe(1);
+  });
+
   it("preserves active EVM degradation", () => {
     const merged = mergeMeasuredExecutionResults(
       result("degraded", "evm", 1),


### PR DESCRIPTION
## Summary
- derive Tron measured-execution lane activation from the registry instead of hardcoding active
- neutralize the SunSwap progress copy while leaving SunSwap shadow-only and score-ineligible
- add a regression that shadow Tron quote failures remain diagnostic in merged half-hourly status

## Validation
- PATH="/home/ahirice/.local/node-v24.16.0/bin:/home/ahirice/.local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/ahirice/.bun/bin:/home/ahirice/.codex/tmp/arg0/codex-arg0EKaepn:/home/ahirice/.local/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/ahirice/.cache/.bun/bin:/home/ahirice/.grok/bin:/home/ahirice/.kimi-code/bin:/home/ahirice/.bun/bin:/home/ahirice/.foundry/bin:/home/ahirice/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/ahirice/.lmstudio/bin:/home/ahirice/.lmstudio/bin:/home/ahirice/.lmstudio/bin" npm run check:pr -- --base=origin/main
- npm run test -- worker/src/handlers/scheduled/__tests__/half-hourly-measured-execution.test.ts worker/src/cron/measured-execution/__tests__/native-admission.test.ts worker/src/cron/measured-execution/__tests__/tron-execution.test.ts
- npm run check:cron-sync
- npm run check:cron-connections
- cd worker && npx tsc --noEmit
- git diff --check
- pre-push check:commit-derived-artifacts

## Operational note
Worker cron behavior changes need deployment proof plus the first production sync-cl-exit-depth observation. This is cleanup only, not SunSwap promotion or job-ledger promotion.