### PR TITLE
Complete DUSD V9 mechanism evidence

### DIFF
--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -6,7 +6,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
   "files": [
     {
       "path": "shared/data/safety-score-v9/mechanism-review-overlays-v1.json",
-      "sha256": "5ceac6ade865c1b5552ce7a02fb4680e94ea1062e0060ef3375323e2b28cac98"
+      "sha256": "f4420336f484679a15ccccfdccfeae75ed7ed82e6c01783061f1e87724eff37e"
     },
     {
       "path": "shared/data/safety-score-v9/methodology-policy-candidate-v1.json",
@@ -441,7 +441,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "a7177e8ede754619d98f56fe18b9d65dbfd29f4ac27701a6bbeb1f60fcb92949"
     }
   ],
-  "digest": "0beea030c195be049496ebceba5323ed81fd7e64e19bdc2b6be31c408c4f5468"
+  "digest": "e3c6f992eaced0af0dd879b5b67958892e92e7cb08ecac56e01f9e45e45fcf34"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/safety-score-v9/mechanism-review-overlays-v1.json
+++ b/shared/data/safety-score-v9/mechanism-review-overlays-v1.json
@@ -16332,6 +16332,50 @@
       }
     },
     {
+      "assetId": "dusd-dialectic",
+      "archetype": "fiat-cash",
+      "reviewedAt": "2026-07-29",
+      "sources": [
+        {
+          "label": "Makina Machine share price and AUM documentation — USDC accounting token, NAV-based share price, AUM updates, and share-supply relationship",
+          "url": "https://docs.makina.finance/concepts/architecture/machine/share-price"
+        },
+        {
+          "label": "Makina deposits documentation — DirectDepositor mints Machine shares against accounting-token deposits at the current share price",
+          "url": "https://docs.makina.finance/concepts/architecture/machine/deposits"
+        },
+        {
+          "label": "Makina redemptions documentation — AsyncRedeemer queued withdrawals, whitelisting option, minimum finalization delay, and operator-liquidity dependency",
+          "url": "https://docs.makina.finance/concepts/architecture/machine/redemptions"
+        },
+        {
+          "label": "Makina Caliber positions documentation — strategy asset deployment through approved protocol connectors and base-token accounting",
+          "url": "https://docs.makina.finance/concepts/architecture/caliber/positions"
+        },
+        {
+          "label": "Makina DUSD strategy and allocation APIs, reviewed 2026-07-29",
+          "url": "https://api.makina.finance/v1/strategies/0x6b006870C83b1Cd49E766Ac9209f8d68763Df721"
+        },
+        {
+          "label": "Ethereum PublicNode RPC — fixed-block eth_call reads of the DUSD Machine, share token, fee manager, and governance controls at block 25636769",
+          "url": "https://ethereum-rpc.publicnode.com"
+        }
+      ],
+      "notes": "DUSD is a Dialectic-curated Makina Machine share over USDC, not a par-redeemable issuer dollar. The holder claim is the code-mediated share claim against Machine AUM: deposits mint shares through DirectDepositor at the current share price, redemptions enter the AsyncRedeemer FIFO queue with a 12-hour minimum finalization delay and operator-liquidity dependency, and the share price is AUM divided by share supply in USDC terms. On-chain reads at Ethereum block 25636769 verified the share token 0x1e33e98af620f1d563fcd3cfd3c75ace841204ef, Machine 0x6b006870c83b1cd49e766ac9209f8d68763df721, accountingToken() = Circle USDC, shareToken() = the DUSD share token, shareLimit() = 75,000,000e18, totalSupply() = 5,618,599.537452822458574240 shares, and recoveryMode() = false. CLAIM AND SEGREGATION is limited: the claim is documented and on-chain-enforced through the Makina contracts, but no legal trust, statutory segregation, or bankruptcy-remoteness claim for DUSD holders was located; the economic claim remains exposed to upstream USDC and deployed strategy positions. CUSTODY CONTINUITY is limited: Makina documentation and the reviewed allocation API identify strategy deployment through approved Calibers into protocol positions, and the Machine/fee/governance graph was verified on-chain, but assets are actively deployed into Morpho, Aave, Pareto/FalconX, Re, and Royco exposures and no independent custodian-continuity or operator-replacement framework was established. ASSURANCE AND RECONCILIATION is limited: Makina publishes structured current strategy/AUM/allocation data and the share-supply/accounting-token relationship is verifiable on-chain, but the reviewed evidence is issuer-operated plus on-chain contract state rather than an independent reserve attestation, audit, or third-party reconciliation of strategy positions to DUSD liabilities.",
+      "metrics": {},
+      "components": {
+        "claimAndSegregation": {
+          "quality": "limited"
+        },
+        "custodyContinuity": {
+          "quality": "limited"
+        },
+        "assuranceAndReconciliation": {
+          "quality": "limited"
+        }
+      }
+    },
+    {
       "assetId": "dusd-fluid",
       "archetype": "fiat-cash",
       "reviewedAt": "2026-07-28",

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -52,7 +52,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {
-    "dateModified": "2026-07-29T11:44:50+02:00",
+    "dateModified": "2026-07-29T12:03:35+02:00",
     "dateCreated": "2026-03-12T23:06:41+01:00"
   },
   "chain-health": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -134,7 +134,7 @@
   "/stablecoin/doc-money-on-chain/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/dola-inverse-finance/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/dusd-alto/": "2026-07-29T01:34:59+02:00",
-  "/stablecoin/dusd-dialectic/": "2026-07-29T11:44:50+02:00",
+  "/stablecoin/dusd-dialectic/": "2026-07-29T12:03:35+02:00",
   "/stablecoin/dusd-dtrinity/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/dusd-fluid/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/dusd-standx/": "2026-07-29T01:34:59+02:00",


### PR DESCRIPTION
## Summary\n- add a conservative DUSD Safety Score V9 mechanism overlay for the Makina Machine share structure\n- regenerate the V9 evaluation-build manifest\n- refresh commit-derived sitemap/docs metadata after the source commit\n\n## Validation\n- npm run check:safety-score-v9-evaluation-build\n- npx vitest run worker/src/lib/__tests__/safety-score-v9-extension-mechanism.test.ts scripts/__tests__/generate-safety-score-v9-evaluation-build-manifest.test.ts\n- npm run check:generated-artifacts\n- npm run check:pr -- --base=origin/main\n- git diff --check\n\n## Production notes\n- DUSD CoinGecko history backfill has been run in production with 298 inserted rows.\n- DUSD production page smoke passed with no captured console/API errors.\n- The overlay uses reviewedAt=2026-07-29, so V9 date-only admission will not make it score-bearing until after the UTC day elapses.\n