### PR TITLE
fix(dex): preserve trusted primary price exclusions

### DIFF
--- a/worker/src/cron/__tests__/dex-liquidity-scoring.test.ts
+++ b/worker/src/cron/__tests__/dex-liquidity-scoring.test.ts
@@ -1880,16 +1880,7 @@ describe("dex-liquidity scoring", () => {
     ]);
   });
 
-  it("loads a missing strict primary price when the preloaded price map is partial", async () => {
-    vi.mocked(getCache).mockResolvedValueOnce({
-      value: JSON.stringify({
-        peggedAssets: [
-          { id: "usdt-tether", symbol: "USDT", price: 0.3 },
-        ],
-      }),
-      updatedAt: 1_700_000_000,
-    });
-
+  it("does not restore an untrusted primary price omitted from the preloaded map", async () => {
     await computeDexPrices(
       makeQueryDb([]),
       new Map([
@@ -1928,18 +1919,19 @@ describe("dex-liquidity scoring", () => {
       new Map([["usdc-circle", 1]]),
     );
 
-    expect(getCache).toHaveBeenCalledOnce();
+    expect(getCache).not.toHaveBeenCalled();
     const [, statements] = vi.mocked(batchExecute).mock.calls[0]!;
     const upserts = statements as PreparedStatementWithMeta[];
     expect(upserts[0]?.boundValues).toEqual([
       "usdt-tether",
       "USDT",
-      0.3,
+      1,
       3,
       1_200_000,
-      0,
-      0.3,
+      null,
+      null,
       JSON.stringify([
+        { protocol: "raydium", chain: "Solana", price: 1, tvl: 1_000_000, sourceFamily: "gecko_terminal" },
         { protocol: "curve", chain: "Ethereum", price: 0.3, tvl: 100_000, sourceFamily: "dl" },
         { protocol: "uniswap-v3", chain: "Base", price: 0.31, tvl: 100_000, sourceFamily: "direct_api" },
       ]),

--- a/worker/src/cron/dex-liquidity/scoring.ts
+++ b/worker/src/cron/dex-liquidity/scoring.ts
@@ -1393,7 +1393,8 @@ export async function computeDexPrices(
   throwIfAborted(signal);
 
   const primaryPrices = new Map(preloadedPrimaryPrices);
-  let loadedStrictPrimaryPrices = false;
+  // A supplied map is already trust-filtered; missing entries are intentional.
+  let loadedStrictPrimaryPrices = preloadedPrimaryPrices !== undefined;
   const loadPrimaryPrices = async (stablecoinId: string): Promise<Map<string, number>> => {
     if (primaryPrices.has(stablecoinId) || loadedStrictPrimaryPrices) return primaryPrices;
     loadedStrictPrimaryPrices = true;


### PR DESCRIPTION
### Motivation

- Prevent untrusted or stale primary prices from the strict stablecoins cache reintroducing omitted assets and influencing DEX median filtering and public price_sources output.  
- Treat an orchestrator-supplied `preloadedPrimaryPrices` map as the intentional, trust-filtered set so missing entries remain excluded.

### Description

- Change `computeDexPrices` to treat a supplied `preloadedPrimaryPrices` map as already trust-filtered by initializing the strict-cache fallback flag when the map is provided.  
- Add an explanatory comment indicating that missing entries in the supplied map are intentional and should not be backfilled.  
- Replace the previous partial-map fallback test with a regression test asserting that an omitted weak/stale primary price is not restored, that the strict cache is not read when a preload is provided, and that published DB fields for primary price/deviation remain null when appropriate.  
- Keep the existing strict-cache fallback behavior active only when no `preloadedPrimaryPrices` is supplied.

### Testing

- Ran the focused Vitest suite: `npx vitest run worker/src/cron/__tests__/dex-liquidity-scoring.test.ts --reporter=dot` and all tests passed (`34 passed`).  
- Type-check: `cd worker && npx tsc --noEmit` completed successfully.  
- Cron checks: `npm run check:cron-sync` and `npm run check:cron-connections` both passed and reported expected mappings and connection budgets.  
- Verified staged diff checks with `git diff --cached --check` with no formatting or diff warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69b1da12248332bca45b765cf8cbd4)