### PR TITLE
Log post-deploy acceptance probe results

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -256,6 +256,7 @@ jobs:
           }
 
           const acceptance = summarizePostDeployAcceptance(results);
+          console.log(JSON.stringify({ probes: results, acceptance }, null, 2));
           const lines = [
             "## Post-deploy operational acceptance",
             "",


### PR DESCRIPTION
Adds non-sensitive probe-result logging to the read-only post-deploy acceptance job so a failed public smoke check is diagnosable from workflow logs.