### PR TITLE
Require the broad API edge rate limit

### DIFF
--- a/scripts/__tests__/check-cloudflare-account-state-drift.test.ts
+++ b/scripts/__tests__/check-cloudflare-account-state-drift.test.ts
@@ -123,6 +123,17 @@ describe("Cloudflare account-state drift comparison", () => {
     expect(compareCloudflareAccountState(manifest, readFixture("healthy-live-state.json"))).toEqual([]);
   });
 
+  it("reports the broad public API rate limit when it is disabled", () => {
+    const liveState = readFixture("healthy-live-state.json");
+    const broadApiRateLimit = liveState.rateLimitRules.find((rule) => rule.description === "api-rate-limit-ip");
+    if (!broadApiRateLimit) throw new Error("healthy fixture is missing api-rate-limit-ip");
+    broadApiRateLimit.enabled = false;
+
+    expect(compareCloudflareAccountState(manifest, liveState)).toContain(
+      "rateLimitRules.api-rate-limit-ip.enabled: expected true, found false",
+    );
+  });
+
   it("reports fixture drift by resource and field without reporting values for secrets", () => {
     expect(compareCloudflareAccountState(manifest, readFixture("drifted-live-state.json"))).toEqual(
       expect.arrayContaining([

--- a/scripts/__tests__/fixtures/cloudflare-account-state/healthy-live-state.json
+++ b/scripts/__tests__/fixtures/cloudflare-account-state/healthy-live-state.json
@@ -80,7 +80,7 @@
   "rateLimitRules": [
     {
       "description": "api-rate-limit-ip",
-      "enabled": false,
+      "enabled": true,
       "action": "block",
       "expression": "(http.host eq \"api.pharos.watch\" and starts_with(http.request.uri.path, \"/api/\") and not cf.bot_management.verified_bot)",
       "ratelimit": {

--- a/scripts/ci/cloudflare-account-state-manifest.json
+++ b/scripts/ci/cloudflare-account-state-manifest.json
@@ -82,7 +82,7 @@
  "rateLimitRules": [
   {
    "description": "api-rate-limit-ip",
-   "enabled": false,
+   "enabled": true,
    "action": "block",
    "expression": "(http.host eq \"api.pharos.watch\" and starts_with(http.request.uri.path, \"/api/\") and not cf.bot_management.verified_bot)",
    "ratelimit": {


### PR DESCRIPTION
### Motivation
- Prevent the weekly Cloudflare account-state drift check from treating a disabled broad API WAF rule (`api-rate-limit-ip`) as the healthy posture so edge-layer volumetric API protection is monitored and cannot be silently removed.

### Description
- Restore `api-rate-limit-ip.enabled = true` in `scripts/ci/cloudflare-account-state-manifest.json`, update the healthy fixture at `scripts/__tests__/fixtures/cloudflare-account-state/healthy-live-state.json`, and add a focused regression in `scripts/__tests__/check-cloudflare-account-state-drift.test.ts` that verifies a disabled broad API rate limit produces a drift finding.

### Testing
- Ran `npm run test -- scripts/__tests__/check-cloudflare-account-state-drift.test.ts`, which executed the focused suite (1 file) and all tests passed (5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b7f56150c8332b7e773a1ea32c644)