### PR TITLE
fix(deps): unblock Pages build after Radix Slot update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.22",
         "@radix-ui/react-label": "^2.1.13",
         "@radix-ui/react-popover": "^1.1.21",
-        "@radix-ui/react-slot": "^1.3.1",
+        "@radix-ui/react-slot": "1.3.3",
         "@radix-ui/react-toggle": "^1.1.16",
         "@radix-ui/react-toggle-group": "^1.1.17",
         "@radix-ui/react-tooltip": "^1.2.14",
@@ -2518,6 +2518,25 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
+      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.4.tgz",
@@ -2917,6 +2936,25 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
+      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.17",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.17.tgz",
@@ -2951,14 +2989,28 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
-      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.4"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -3054,6 +3106,25 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
+      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.22",
     "@radix-ui/react-label": "^2.1.13",
     "@radix-ui/react-popover": "^1.1.21",
-    "@radix-ui/react-slot": "^1.3.1",
+    "@radix-ui/react-slot": "1.3.3",
     "@radix-ui/react-toggle": "^1.1.16",
     "@radix-ui/react-toggle-group": "^1.1.17",
     "@radix-ui/react-tooltip": "^1.2.14",

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -8,11 +8,11 @@
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "data-flow-map": {
-    "dateModified": "2026-07-31T08:27:29+02:00",
+    "dateModified": "2026-07-31T09:10:10+02:00",
     "dateCreated": "2026-03-03T14:17:10+01:00"
   },
   "data-pipeline": {
-    "dateModified": "2026-07-31T08:27:29+02:00",
+    "dateModified": "2026-07-31T09:10:10+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "worker-and-api-limits": {
@@ -40,7 +40,7 @@
     "dateCreated": "2026-03-01T16:18:28+01:00"
   },
   "dex-liquidity": {
-    "dateModified": "2026-07-31T08:27:29+02:00",
+    "dateModified": "2026-07-31T09:10:10+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "stability-index": {


### PR DESCRIPTION
## Summary
- move the direct @radix-ui/react-slot dependency from the problematic 1.3.1 release to 1.3.3
- include the post-squash docs metadata correction surfaced by the pre-push commit-derived artifact check

## Root cause
The production Pages export failed while collecting /about page data because @radix-ui/react-slot@1.3.1 creates a React context at module initialization. Next bundles server components against the react-rsc export, where createContext is intentionally absent. The shared Button primitive imports Slot from this package and is used by server-rendered pages.

## Validation
- GENERATED_ARTIFACTS_SKIP=stablecoin-catalog,world-map,sitemap-dates,case-study-client-index,docs-metadata,cemetery-dataset,public-datasets,homepage-bootstrap,postman,openapi,stablecoin-prevalidated-registry,legacy-stablecoin-redirects,stablecoin-client-registry,api-reference,og-editorial,og-learn,og-case-studies npm run build
- npm ci
- npm audit --omit=dev
- npm run check:commit-derived-artifacts
- git diff --check