### PR TITLE
Fix stale report-card publication guard

### DIFF
--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:a391e947766ec6256a7c7fe175498308c8fbfdbcb943a870461075dd923431e9",
+  "sourceChecksum": "sha256:c7321a3971cc53c0e9f566282bdd38dddb9d330a8ac64d391696791992a187cd",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:61cf330716f2d07291b1a29e71a667fbc4691896c84be0bda28a6b60180e432f",
+      "checksum": "sha256:cace119cad84b9af1e8ed4e2a61c4ca2caa6e69c64f973de243684c2a96c943c",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/scripts/__tests__/check-stablecoin-data.test.ts
+++ b/scripts/__tests__/check-stablecoin-data.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getCommodityAllocatedPegMatchIssues, getDependencyReserveOverlapIssues } from "../ci/check-stablecoin-data";
+import {
+  getCommodityAllocatedPegMatchIssues,
+  getDependencyReserveOverlapIssues,
+  getReservePublicLabelIssues,
+} from "../ci/check-stablecoin-data";
 
 describe("stablecoin dependency/reserve source ownership", () => {
   it("allows manual and reserve-derived relationships to coexist when their keys differ", () => {
@@ -64,5 +68,34 @@ describe("commodity-allocated peg-match guard", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0]).toContain("commodity-allocated");
     expect(issues[0]).toContain("USD");
+  });
+});
+
+describe("reserve public-label guard", () => {
+  it("keeps reserve names within the Safety Score V9 backing component label limit", () => {
+    expect(
+      getReservePublicLabelIssues({
+        reserves: [
+          {
+            name: "A".repeat(160),
+            pct: 100,
+            risk: "low",
+          },
+        ],
+      } as never),
+    ).toEqual([]);
+
+    const issues = getReservePublicLabelIssues({
+      reserves: [
+        {
+          name: ` ${"A".repeat(161)} `,
+          pct: 100,
+          risk: "low",
+        },
+      ],
+    } as never);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toContain("is 161 characters");
+    expect(issues[0]).toContain("capped at 160 characters");
   });
 });

--- a/scripts/ci/check-stablecoin-data.ts
+++ b/scripts/ci/check-stablecoin-data.ts
@@ -31,6 +31,7 @@ import {
 } from "../lib/stablecoin-catalog-sources";
 
 const RESERVE_TOTAL_ALLOWLIST = new Set<string>();
+const SAFETY_SCORE_V9_PUBLIC_BACKING_COMPONENT_LABEL_MAX_LENGTH = 160;
 const ACTIVE_DEAD_LLAMA_ID_OVERLAP_ALLOWLIST = new Set([
   // Kava USDX remains a live tracked feed while the cemetery keeps the 2022
   // UST-collateral depeg incident as a separate historical row.
@@ -162,6 +163,22 @@ function getReserveTotalIssue(coin: StablecoinMeta): string | null {
   }
 
   return null;
+}
+
+export function getReservePublicLabelIssues(coin: StablecoinMeta): string[] {
+  const issues: string[] = [];
+
+  (coin.reserves ?? []).forEach((reserve, index) => {
+    const publicLabelLength = reserve.name.trim().length;
+    if (publicLabelLength <= SAFETY_SCORE_V9_PUBLIC_BACKING_COMPONENT_LABEL_MAX_LENGTH) return;
+    issues.push(
+      `reserves[${index}] "${reserve.name}" is ${publicLabelLength} characters; ` +
+        `Safety Score V9 public backing component labels are capped at ` +
+        `${SAFETY_SCORE_V9_PUBLIC_BACKING_COMPONENT_LABEL_MAX_LENGTH} characters`,
+    );
+  });
+
+  return issues;
 }
 
 // D2 honesty guard (owner ruling 2026-07-23): the privileged commodity-allocated
@@ -516,6 +533,10 @@ function runStablecoinDataCheck(): void {
       const reserveTotalIssue = getReserveTotalIssue(entry.coin);
       if (reserveTotalIssue) {
         reportError(`${entry.file} (${entry.coin.id}): ${reserveTotalIssue}`);
+      }
+
+      for (const reservePublicLabelIssue of getReservePublicLabelIssues(entry.coin)) {
+        reportError(`${entry.file} (${entry.coin.id}): ${reservePublicLabelIssue}`);
       }
 
       const dependencyTotalIssue = getDependencyTotalIssue(entry.coin);

--- a/shared/data/stablecoins/coins/bnusd-balanced.json
+++ b/shared/data/stablecoins/coins/bnusd-balanced.json
@@ -1674,7 +1674,7 @@
       "liquidityHorizon": "seven-days"
     },
     {
-      "name": "Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%, and sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS below 0.02% combined",
+      "name": "Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%; sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS <0.02% combined",
       "pct": 0.95,
       "risk": "high",
       "assetClass": "cryptoasset",

--- a/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
+++ b/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
@@ -8,4 +8,4 @@
  * requests do not serialize and hash the full catalog at runtime.
  */
 export const REPORT_CARDS_REGISTRY_FINGERPRINT =
-  "63f7e36d72af6c0fa7c16fffe57785d959dd25a2cc7c1645fd851a083db7e85a";
+  "dd1d476f0a8262c538f6a6b8706c8ff7c993e30e29e4ca13826ffbd3d18e5902";

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -91,7 +91,7 @@
   "/stablecoin/bfusd-binance/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/bib01-backed/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/bils-bitsofgold/": "2026-07-29T01:34:59+02:00",
-  "/stablecoin/bnusd-balanced/": "2026-07-31T07:27:40+02:00",
+  "/stablecoin/bnusd-balanced/": "2026-07-31T11:48:00+02:00",
   "/stablecoin/bold-liquity/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/brd-volpon/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/brl-b3/": "2026-07-29T01:34:59+02:00",

--- a/src/lib/__tests__/reserve-coinid-validation.test.ts
+++ b/src/lib/__tests__/reserve-coinid-validation.test.ts
@@ -61,11 +61,11 @@ const REVIEWED_WARNING_IDS = new Map<string, string>([
     "apxUSD's cash bucket aggregates USDC and short-duration U.S. Treasury Bills, so no single coinId is representative.",
   ],
   [
-    "bnusd-balanced::Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%, and sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS below 0.02% combined::DAI",
+    "bnusd-balanced::Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%; sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS <0.02% combined::DAI",
     "Substring artifact: the DAI match sits inside sodaINJ. Balanced reports no DAI collateral in this aggregated sub-0.5% tail.",
   ],
   [
-    "bnusd-balanced::Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%, and sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS below 0.02% combined::USDS",
+    "bnusd-balanced::Tail borrower collateral: sodaNEAR 0.42%, sodaPOL 0.24%, sodaXLM 0.21%, sodaS 0.05%, bnUSD 0.02%; sodaLL/sodaINJ/sodaWBTC/sodaKAIA/sodaSUSDS <0.02% combined::USDS",
     "Substring artifact: the USDS match sits inside sodaSUSDS, a below-0.02% wrapped sUSDS tail position that carries no separate weight.",
   ],
   [


### PR DESCRIPTION
## Summary
- Shorten the BNUSD tail reserve label that exceeded the Safety Score V9 public backing-component label cap and blocked fresh report-card publication.
- Add a stablecoin-data guard and focused regression test for reserve labels over the public schema limit.
- Refresh affected generated artifacts: report-card registry fingerprint, sitemap date, and cemetery dataset checksum metadata.

## Validation
- npm run check:stablecoin-data
- npm run check:generated-artifacts
- npm run check:commit-derived-artifacts
- npx vitest run scripts/__tests__/check-stablecoin-data.test.ts
- npx vitest run shared/lib/stablecoins shared/lib/__tests__/stablecoin-id-registry.test.ts
- npx vitest run src/lib/__tests__/reserve-coinid-validation.test.ts
- npx eslint scripts/ci/check-stablecoin-data.ts scripts/__tests__/check-stablecoin-data.test.ts src/lib/__tests__/reserve-coinid-validation.test.ts --cache --cache-strategy content --cache-location .cache/eslint/ --max-warnings=0
- git diff --check
- npm run check:pr -- --base=origin/main