### PR TITLE
Cut in-flow mechanism review notes to a lead

### DIFF
--- a/docs/stablecoin-detail-page.md
+++ b/docs/stablecoin-detail-page.md
@@ -164,7 +164,7 @@ The display score is computed from `shared/lib/mint-authority-scoring.ts` throug
 
 Per-dimension mechanism quality ratings (`strong` / `adequate` / `limited` / `weak` / `failed`) are deliberately **not** extracted or published. Publishing them would introduce a public rating vocabulary, which is methodology-visible; the reviewed prose and its sources are not, because they only explain component scores the report card already publishes. A test pins the public view shape so the ratings cannot leak back in. The section hides when the asset has no overlay, or when the overlay carries no notes or no sources.
 
-The rail treatment clamps the notes to six lines behind a single `Show more · N sources` control that opens both the full prose and the source list, because reviewed notes run to roughly 1,700 characters on the median asset and past 6,000 on the longest — neither fits a 22rem column unclamped. Only the in-flow copy carries the `#mechanism-review` anchor.
+The compact rail treatment clamps the notes to six lines behind a single `Show more · N sources` control that opens both the full prose and the source list, because reviewed notes run to roughly 1,700 characters on the median asset and past 6,000 on the longest — neither fits a 22rem column unclamped. The in-flow section uses the full card width and keeps sources visible; notes longer than the collapse threshold render a roughly 320-character lead behind one `Read the full review` control, while shorter notes render whole without a toggle. Only the in-flow copy carries the `#mechanism-review` anchor.
 
 ### Access posture evidence
 

--- a/src/components/stablecoin-detail/__tests__/mechanism-review-panel.test.tsx
+++ b/src/components/stablecoin-detail/__tests__/mechanism-review-panel.test.tsx
@@ -39,6 +39,30 @@ describe("MechanismReviewPanel", () => {
     expect(section?.className).toContain("xl:hidden");
   });
 
+  it("cuts long in-flow notes to a lead behind one control and keeps the sources visible", () => {
+    const longNotes = `${review.notes} `.repeat(20).trim();
+    render(<MechanismReviewPanel review={{ ...review, notes: longNotes }} />);
+
+    // The cut happens in the string, not with line-clamp: one full-width line
+    // carries ~150 characters, so a line-based fold would hide almost nothing.
+    const lead = screen.getByText(/Segregated Accounts/).textContent ?? "";
+    expect(lead.length).toBeLessThan(400);
+    expect(lead.endsWith("…")).toBe(true);
+    // The full-width section keeps its citations visible while the prose is cut.
+    expect(screen.getByText("Sources (2)")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Read the full review/ }));
+
+    expect(screen.getByText(/Segregated Accounts/).textContent).toBe(longNotes);
+    expect(screen.getByRole("button", { name: /Show less/ })).toBeTruthy();
+  });
+
+  it("omits the in-flow toggle for notes short enough to lose nothing to the fold", () => {
+    render(<MechanismReviewPanel review={review} />);
+    expect(screen.queryByRole("button", { name: /Read the full review/ })).toBeNull();
+    expect(screen.getByText(/Segregated Accounts/).textContent).toBe(review.notes);
+  });
+
   it("clamps the compact rail copy until it is expanded", () => {
     render(<MechanismReviewPanel review={review} compact />);
     // Reviewed notes run past 6,000 characters on the longest assets, which

--- a/src/components/stablecoin-detail/mechanism-review-panel.tsx
+++ b/src/components/stablecoin-detail/mechanism-review-panel.tsx
@@ -31,13 +31,19 @@ function ArchetypeBadge({ review }: { review: MechanismReviewView }) {
   );
 }
 
-function SourceList({ review }: { review: MechanismReviewView }) {
+function SourceList({
+  review,
+  listClassName,
+}: {
+  review: MechanismReviewView;
+  listClassName?: string;
+}) {
   return (
     <>
       <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
         Sources ({review.sources.length})
       </h3>
-      <ul className="mt-2 space-y-2">
+      <ul className={cn("mt-2 space-y-2", listClassName)}>
         {review.sources.map((source) => (
           <li key={source.url} className="flex min-w-0 gap-2 text-xs leading-relaxed">
             <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -120,6 +126,76 @@ function CompactMechanismReview({ review }: { review: MechanismReviewView }) {
 }
 
 /**
+ * Collapsed length of the in-flow lead, in characters. Cut in the string rather
+ * than with `line-clamp` so the fold does not move with the viewport: at the
+ * full card width one clamped line already carries ~150 characters, so a
+ * line-based cut hides almost nothing on wide screens.
+ */
+const NOTES_LEAD_CHARS = 320;
+
+/** Notes at or under this length would lose nothing to the fold. */
+const NOTES_COLLAPSE_THRESHOLD = 420;
+
+function buildLead(notes: string) {
+  const cut = notes.slice(0, NOTES_LEAD_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
+/**
+ * In-flow treatment below `xl`. The prose runs the full card width — a
+ * `max-w-prose` column left most of the card empty — and long notes cut to a
+ * lead behind one control the way the rail does.
+ */
+function FullMechanismReview({ review }: { review: MechanismReviewView }) {
+  const [open, setOpen] = useState(false);
+  const collapsible = review.notes.length > NOTES_COLLAPSE_THRESHOLD;
+  const showLead = collapsible && !open;
+
+  return (
+    <Card id="mechanism-review" className={cn(DETAIL_MODULE_SHELL_CLASS, SECTION_SCROLL_MT, "xl:hidden")}>
+      <CardHeader className={DETAIL_MODULE_HEADER_CLASS}>
+        <div className="flex min-w-0 items-center gap-2">
+          <FlaskConical className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <DetailSectionTitle className={DETAIL_MODULE_TITLE_CLASS}>Mechanism review</DetailSectionTitle>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <ArchetypeBadge review={review} />
+          <span className="font-mono text-[11px] text-muted-foreground">Reviewed {review.reviewedAt}</span>
+        </div>
+      </CardHeader>
+      <CardContent className={DETAIL_MODULE_BODY_CLASS}>
+        <p className="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+          {showLead ? buildLead(review.notes) : review.notes}
+        </p>
+
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={() => setOpen((value) => !value)}
+            aria-expanded={open}
+            className="pharos-focus-ring mt-3 inline-flex min-h-7 items-center gap-1 rounded-sm text-xs font-medium text-frost-blue"
+          >
+            {open ? "Show less" : "Read the full review"}
+            <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} aria-hidden="true" />
+          </button>
+        ) : null}
+
+        <div className="mt-5 border-t border-border/40 pt-4">
+          {/* Citation labels are long; two columns keep the list from running
+              the full card width as one sparse stack. */}
+          <SourceList review={review} listClassName="md:grid md:grid-cols-2 md:gap-x-8 md:space-y-0 md:gap-y-2" />
+        </div>
+
+        <p className="mt-4">
+          <ExplainerLink review={review} />
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
  * The reviewed evidence behind the Backing pillar's mechanism component scores.
  * Those scores render in the report card; this is the "why we believe this" —
  * dated analyst prose and the sources it was measured against.
@@ -137,32 +213,5 @@ export function MechanismReviewPanel({
 }) {
   if (review === null) return null;
   if (compact) return <CompactMechanismReview review={review} />;
-
-  return (
-    <Card id="mechanism-review" className={cn(DETAIL_MODULE_SHELL_CLASS, SECTION_SCROLL_MT, "xl:hidden")}>
-      <CardHeader className={DETAIL_MODULE_HEADER_CLASS}>
-        <div className="flex min-w-0 items-center gap-2">
-          <FlaskConical className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <DetailSectionTitle className={DETAIL_MODULE_TITLE_CLASS}>Mechanism review</DetailSectionTitle>
-        </div>
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
-          <ArchetypeBadge review={review} />
-          <span className="font-mono text-[11px] text-muted-foreground">Reviewed {review.reviewedAt}</span>
-        </div>
-      </CardHeader>
-      <CardContent className={DETAIL_MODULE_BODY_CLASS}>
-        <p className="max-w-prose whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
-          {review.notes}
-        </p>
-
-        <div className="mt-5 border-t border-border/40 pt-4">
-          <SourceList review={review} />
-        </div>
-
-        <p className="mt-4">
-          <ExplainerLink review={review} />
-        </p>
-      </CardContent>
-    </Card>
-  );
+  return <FullMechanismReview review={review} />;
 }

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -91,7 +91,7 @@
   "/stablecoin/bfusd-binance/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/bib01-backed/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/bils-bitsofgold/": "2026-07-29T01:34:59+02:00",
-  "/stablecoin/bnusd-balanced/": "2026-07-31T11:48:00+02:00",
+  "/stablecoin/bnusd-balanced/": "2026-07-31T11:58:49+02:00",
   "/stablecoin/bold-liquity/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/brd-volpon/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/brl-b3/": "2026-07-29T01:34:59+02:00",


### PR DESCRIPTION
## Summary
- cut long in-flow mechanism review prose to a concise lead behind one control
- keep citations visible and use the full card width below xl
- update the stablecoin-detail route contract and generated sitemap date artifact

## Local validation
- npm run check:commit-derived-artifacts
- npm run check:generated-artifacts
- npx vitest run src/components/stablecoin-detail/__tests__/mechanism-review-panel.test.tsx
- npm run check:pr -- --base=origin/main
- npm run build
- npm run seo:check

Note: a direct full-corpus npm run check:doc-source-paths currently fails on pre-existing migration source references in unrelated docs; this non-doc PR path does not select that gate.