### PR TITLE
Resolve Dependabot undici alerts

### DIFF
--- a/docs/deployment-process.md
+++ b/docs/deployment-process.md
@@ -203,9 +203,7 @@ Current explicitly deferred major cohort:
 - `@types/node@25` — next review: 2026-08-15
 - `typescript@6` — next review: 2026-08-15
 
-Current risk-accepted transitive advisories are machine-readable in `scripts/ci/dependency-audit-exceptions.json`; the verifier rejects malformed, expired, or widened entries. The registry is the weekly workflow's authority, while this section records the review rationale:
-
-- `brace-expansion` / `GHSA-mh99-v99m-4gvg` (accepted 2026-07-25; review by 2026-08-15): the affected v1 copies are dev-only transitive dependencies of ESLint through `minimatch@3`. They process repository-owned lint/config patterns, are absent from production installs, and are not reachable from user input or a deployed request path. The patched `brace-expansion@5` export is not compatible with these parents, and npm currently offers only breaking parent upgrades; retain this exception until the lint toolchain adopts a compatible patched dependency.
+Risk-accepted transitive advisories are machine-readable in `scripts/ci/dependency-audit-exceptions.json`; the verifier rejects malformed, expired, or widened entries. The registry is the weekly workflow's authority, while this section records the review rationale. There are currently no active exceptions.
 
 The production-scope check is `npm run audit:deps` (`npm audit --audit-level=high --omit=dev`) and reflects the deployed surface. Root manifest or lockfile PRs run it through `check:pr:static`. The weekly `dependency-audit.yml` job runs the broader full-lockfile audit through `scripts/ci/verify-dependency-audit.mjs`; it passes only when every high/critical finding is the exact, unexpired reviewed exception.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,9 +1291,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1372,9 +1372,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5758,9 +5758,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7365,9 +7365,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7691,9 +7691,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13738,9 +13738,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
   "overrides": {
     "postcss": "8.5.23",
     "sharp": "0.35.3",
+    "undici": "7.29.0",
     "viem": {
       "ws": "8.21.0"
     }

--- a/scripts/__tests__/dependency-audit-exceptions.test.ts
+++ b/scripts/__tests__/dependency-audit-exceptions.test.ts
@@ -22,7 +22,20 @@ type AuditReport = {
   vulnerabilities: Record<string, AuditVulnerability>;
 };
 
-const exception = DEPENDENCY_AUDIT_EXCEPTION_REGISTRY.exceptions[0];
+const exception = {
+  advisoryId: "GHSA-reviewed-fixture",
+  source: 1,
+  dependency: "brace-expansion",
+  severity: "high",
+  range: "<1.1.18",
+  expiresOn: "2026-08-15",
+  nodes: [
+    "node_modules/@eslint/config-array/node_modules/brace-expansion",
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion",
+  ],
+  affectedPackages: ["brace-expansion", "minimatch"],
+} as const;
+const reviewedRegistry = { version: 1, exceptions: [exception] };
 const reviewedNow = new Date("2026-07-29T12:00:00.000Z");
 
 function reviewedReport(): AuditReport {
@@ -57,14 +70,21 @@ function reviewedReport(): AuditReport {
 }
 
 describe("dependency-audit exceptions", () => {
+  it("keeps the live registry empty after the reviewed advisories are patched", () => {
+    expect(DEPENDENCY_AUDIT_EXCEPTION_REGISTRY).toEqual({ version: 1, exceptions: [] });
+    expect(verifyDependencyAuditReport({ auditReportVersion: 2, vulnerabilities: {} }, { now: reviewedNow })).toEqual({
+      acceptedExceptionIds: [],
+    });
+  });
+
   it("suppresses only the exact reviewed advisory and dependency nodes", () => {
-    expect(verifyDependencyAuditReport(reviewedReport(), { now: reviewedNow })).toEqual({
+    expect(verifyDependencyAuditReport(reviewedReport(), { registry: reviewedRegistry, now: reviewedNow })).toEqual({
       acceptedExceptionIds: [exception.advisoryId],
     });
 
     const changedPath = reviewedReport();
     changedPath.vulnerabilities["brace-expansion"].nodes.push("node_modules/unreviewed/node_modules/brace-expansion");
-    expect(() => verifyDependencyAuditReport(changedPath, { now: reviewedNow })).toThrow(
+    expect(() => verifyDependencyAuditReport(changedPath, { registry: reviewedRegistry, now: reviewedNow })).toThrow(
       "Unreviewed high/critical advisory affects brace-expansion.",
     );
   });
@@ -88,15 +108,18 @@ describe("dependency-audit exceptions", () => {
       nodes: ["node_modules/new-risk"],
     };
 
-    expect(() => verifyDependencyAuditReport(report, { now: reviewedNow })).toThrow(
+    expect(() => verifyDependencyAuditReport(report, { registry: reviewedRegistry, now: reviewedNow })).toThrow(
       "Unreviewed high/critical advisory affects new-risk.",
     );
   });
 
   it("fails closed after the exception expiry date", () => {
-    expect(() => verifyDependencyAuditReport(reviewedReport(), { now: new Date("2026-08-16T00:00:00.000Z") })).toThrow(
-      "Dependency-audit exception expired on 2026-08-15.",
-    );
+    expect(() =>
+      verifyDependencyAuditReport(reviewedReport(), {
+        registry: reviewedRegistry,
+        now: new Date("2026-08-16T00:00:00.000Z"),
+      }),
+    ).toThrow("Dependency-audit exception expired on 2026-08-15.");
   });
 
   it("processes npm audit's expected finding exit code before applying exceptions", () => {
@@ -110,7 +133,7 @@ describe("dependency-audit exceptions", () => {
       signal: null,
     }));
 
-    expect(runFullLockfileDependencyAudit({ now: reviewedNow, spawn })).toEqual({
+    expect(runFullLockfileDependencyAudit({ now: reviewedNow, registry: reviewedRegistry, spawn })).toEqual({
       acceptedExceptionIds: [exception.advisoryId],
     });
     expect(spawn).toHaveBeenCalledWith(

--- a/scripts/ci/dependency-audit-exceptions.json
+++ b/scripts/ci/dependency-audit-exceptions.json
@@ -1,38 +1,4 @@
 {
   "version": 1,
-  "exceptions": [
-    {
-      "advisoryId": "GHSA-mh99-v99m-4gvg",
-      "source": 1124334,
-      "dependency": "brace-expansion",
-      "severity": "high",
-      "range": "<=5.0.7",
-      "expiresOn": "2026-08-15",
-      "nodes": [
-        "node_modules/@eslint/config-array/node_modules/brace-expansion",
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion",
-        "node_modules/eslint-config-next/node_modules/brace-expansion",
-        "node_modules/eslint/node_modules/brace-expansion"
-      ],
-      "affectedPackages": [
-        "@eslint-community/eslint-utils",
-        "@eslint/config-array",
-        "@eslint/eslintrc",
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser",
-        "@typescript-eslint/type-utils",
-        "@typescript-eslint/utils",
-        "brace-expansion",
-        "eslint",
-        "eslint-config-next",
-        "eslint-import-resolver-typescript",
-        "eslint-plugin-import",
-        "eslint-plugin-jsx-a11y",
-        "eslint-plugin-react",
-        "eslint-plugin-react-hooks",
-        "minimatch",
-        "typescript-eslint"
-      ]
-    }
-  ]
+  "exceptions": []
 }


### PR DESCRIPTION
## Summary
- pin `undici@7.29.0` through the root override to resolve Dependabot alerts 7–11 while Wrangler/Miniflare still pins 7.28.0
- refresh compatible `brace-expansion` transitive releases and retire the obsolete audit exception
- keep fail-closed dependency-audit coverage and documentation aligned

## Validation
- `npm audit --audit-level=low` — zero vulnerabilities
- `node scripts/ci/verify-dependency-audit.mjs` — no accepted exceptions
- `npm run check:generated-artifacts`
- adaptive PR static checks, typechecks, and Worker dry-run bundle passed under Node 24.16
- adaptive test selection: 1,643/1,644 files passed locally; the sole failure is the expected local-only assertion caused by the ignored `.codex/hooks.json`, which is absent in GitHub Actions
- pre-push commit-derived artifact gate passed