### PR TITLE
Fix commodity row publication across stale quotes

### DIFF
--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -1,6 +1,6 @@
 {
   "api-reference": {
-    "dateModified": "2026-08-06T16:55:26+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-02-23T15:28:17+01:00"
   },
   "architecture": {
@@ -8,11 +8,11 @@
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "data-flow-map": {
-    "dateModified": "2026-08-06T16:17:17+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-03-03T14:17:10+01:00"
   },
   "data-pipeline": {
-    "dateModified": "2026-08-06T16:17:17+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "worker-and-api-limits": {
@@ -40,7 +40,7 @@
     "dateCreated": "2026-03-01T16:18:28+01:00"
   },
   "dex-liquidity": {
-    "dateModified": "2026-08-06T16:55:26+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "stability-index": {
@@ -48,11 +48,11 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "report-cards": {
-    "dateModified": "2026-08-06T16:55:26+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {
-    "dateModified": "2026-08-06T16:55:26+02:00",
+    "dateModified": "2026-08-07T01:25:07+02:00",
     "dateCreated": "2026-03-12T23:06:41+01:00"
   },
   "chain-health": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -298,7 +298,7 @@
   "/stablecoin/satusd-river/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/savusd-avant/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/sbc-brale/": "2026-07-31T07:27:40+02:00",
-  "/stablecoin/sbold-k3-capital/": "2026-08-06T16:07:59+02:00",
+  "/stablecoin/sbold-k3-capital/": "2026-08-07T01:25:07+02:00",
   "/stablecoin/scrvusd-curve/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/scusd-rings/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/sdai-sky/": "2026-07-29T01:34:59+02:00",

--- a/worker/src/cron/sync-stablecoins/supplemental-assets/__tests__/gold.test.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets/__tests__/gold.test.ts
@@ -61,12 +61,14 @@ vi.mock("../../../reserve-adapters/helpers", () => ({
 
 import { fetchGoldTokens } from "../gold";
 
-function stubGoldUpstreams(protocolMcap: number | null): void {
-  const nowSec = Math.floor(Date.now() / 1000);
+function stubGoldUpstreams(
+  protocolMcap: number | null,
+  priceObservedAt: number = Math.floor(Date.now() / 1000),
+): void {
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
     if (String(url).includes("/prices/current/")) {
       return new Response(
-        JSON.stringify({ coins: { "coingecko:pleasing-gold": { price: PGOLD_PRICE, timestamp: nowSec } } }),
+        JSON.stringify({ coins: { "coingecko:pleasing-gold": { price: PGOLD_PRICE, timestamp: priceObservedAt } } }),
         { status: 200 },
       );
     }
@@ -148,5 +150,48 @@ describe("fetchGoldTokens curated aggregate supply", () => {
     expect(asset?.supplySource).toBe("defillama");
     expect(asset?.circulating?.peggedGOLD).toBe(78_852_290);
     expect(asset?.chainCirculating).toEqual({});
+  });
+
+  it("keeps positive upstream market cap when price evidence is stale", async () => {
+    const staleAt = Math.floor(Date.now() / 1000) - 9 * 86400;
+    selectCuratedAggregateContractsMock.mockReturnValue(null);
+    stubGoldUpstreams(null, staleAt);
+
+    const [asset] = await fetchGoldTokens({
+      "pleasing-gold": {
+        usd: PGOLD_PRICE,
+        usd_market_cap: 78_852_290,
+        last_updated_at: staleAt,
+      },
+    });
+
+    expect(asset).toMatchObject({
+      id: "pgold-pleasing",
+      price: null,
+      priceConfidence: null,
+      priceUpdatedAt: null,
+      priceObservedAt: null,
+      priceObservedAtMode: null,
+      priceSyncedAt: null,
+      supplySource: "coingecko-fallback",
+      circulating: { peggedGOLD: 78_852_290 },
+    });
+    expect(asset?.priceSource).toBeUndefined();
+  });
+
+  it("still drops a commodity row without trusted price or positive market cap", async () => {
+    const staleAt = Math.floor(Date.now() / 1000) - 9 * 86400;
+    selectCuratedAggregateContractsMock.mockReturnValue(null);
+    stubGoldUpstreams(null, staleAt);
+
+    const assets = await fetchGoldTokens({
+      "pleasing-gold": {
+        usd: PGOLD_PRICE,
+        usd_market_cap: 0,
+        last_updated_at: staleAt,
+      },
+    });
+
+    expect(assets).toEqual([]);
   });
 });

--- a/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
+++ b/worker/src/cron/sync-stablecoins/supplemental-assets/shared.ts
@@ -185,7 +185,7 @@ export function getSupplementalChainLabels(meta: StablecoinMeta): string[] {
 
 export function buildSupplementalAsset(input: {
   meta: StablecoinMeta;
-  priceResolution: SupplementalPriceResolution;
+  priceResolution: SupplementalPriceResolution | null;
   mcap: number;
   supplySource: string;
   chainCirculating?: PeggedAsset["chainCirculating"];
@@ -195,6 +195,7 @@ export function buildSupplementalAsset(input: {
 }): PeggedAsset {
   const nowSec = Math.floor(Date.now() / 1000);
   const pKey = pegTypeKey(input.meta);
+  const priceResolution = input.priceResolution;
   return {
     id: input.meta.id,
     name: input.meta.name,
@@ -202,13 +203,13 @@ export function buildSupplementalAsset(input: {
     geckoId: input.meta.geckoId,
     pegType: pKey,
     pegMechanism: input.meta.flags.backing,
-    price: input.priceResolution.price,
-    priceSource: input.priceResolution.source,
-    priceConfidence: "single-source",
-    priceUpdatedAt: input.priceResolution.observedAt ?? nowSec,
-    priceObservedAt: input.priceResolution.observedAt ?? nowSec,
-    priceObservedAtMode: input.priceResolution.observedAtMode ?? "local_fetch",
-    priceSyncedAt: nowSec,
+    price: priceResolution?.price ?? null,
+    priceSource: priceResolution?.source,
+    priceConfidence: priceResolution ? "single-source" : null,
+    priceUpdatedAt: priceResolution ? (priceResolution.observedAt ?? nowSec) : null,
+    priceObservedAt: priceResolution ? (priceResolution.observedAt ?? nowSec) : null,
+    priceObservedAtMode: priceResolution ? (priceResolution.observedAtMode ?? "local_fetch") : null,
+    priceSyncedAt: priceResolution ? nowSec : null,
     supplySource: input.supplySource,
     circulating: { [pKey]: input.mcap },
     circulatingPrevDay: input.circulatingPrevDay != null ? { [pKey]: input.circulatingPrevDay } : null,
@@ -270,7 +271,9 @@ export function buildPricedSupplementalAsset(
   },
 ): PeggedAsset | null {
   const priceResolution = resolveSupplementalPrice(priceData, cgData, meta.geckoId);
-  if (!priceResolution) return null;
+  // Price coverage is independent from row publication: positive upstream
+  // market cap stays publishable with null price, while empty rows fail closed.
+  if (!priceResolution && !(Number.isFinite(input.mcap) && input.mcap > 0)) return null;
 
   return buildSupplementalAsset({
     meta,


### PR DESCRIPTION
## Summary

- preserve a commodity row when upstream still supplies a positive market cap but every quote is stale
- publish the missing price explicitly as null, without fabricating par or changing supply policy
- continue to fail closed when neither a trusted price nor a positive market cap exists
- refresh repository-required commit-derived metadata

## Production evidence

A 61-minute read-only observation covered five quarter-hour samples. Safety Score V9, Telegram dispatch, and DEX discovery recovered without intervention. XNK remained the sole repeated exact-publication gap across clean core runs: CoinGecko retained positive market cap and circulating supply, while its quote timestamp was stale. The commodity helper was conflating price freshness with row admission.

## Validation

- `npx vitest run worker/src/cron/sync-stablecoins/supplemental-assets/__tests__/gold.test.ts`
- `npm run typecheck:worker`
- `npm run check:commit-derived-artifacts`
- `git diff --check`

Docs are unchanged because the existing pricing and data-pipeline docs already specify that missing price coverage is independent from lifecycle row publication.