### PR TITLE
Refresh Arbitrum wM V2 attribution identity

### DIFF
--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:86e78cc68f6c276582ca3ae31c007745bd0da607209f2dba27bb97485c6372d8",
+  "sourceChecksum": "sha256:db6fb857a49b301c95fef62f39ce8c6aafc04c404d63a05a289acb116a4fff0a",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:b5a54de2ef90af655bc1216338f5014e598dc93ba28f4792a4e9214fb8bfe095",
+      "checksum": "sha256:f2e1a6a0ba33e11f42f9fa7fb502fa174f0a2828abd4b25f68f8a8d788729e77",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -470,7 +470,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "worker/src/lib/safety-score-v9-supply-attribution-contract.ts",
-      "sha256": "fe38e7f76678a4eabc765f7eece1f6bd2bb2c4fc387db6ef045b106cf991f9e7"
+      "sha256": "d9b228286a10ac5da7719ba97b4cbe1897d2e207d346c87f9cf44e98cd883701"
     },
     {
       "path": "worker/src/lib/safety-score-v9-supply-attribution.ts",
@@ -489,7 +489,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "8143ea173162a28e0fb4c87ee2609927eb4122e2bc762e70049b13d84b4d8cd0"
     }
   ],
-  "digest": "6ad3ed7485efc04bd0d46d6ae60362a47cdc576a8b54e180944c28922414be23"
+  "digest": "d94579c30f469f1e5e55ee92fd31536ce7925ccab7469a39fae998b434be22d6"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/stablecoins/coins/wm-m0.json
+++ b/shared/data/stablecoins/coins/wm-m0.json
@@ -288,8 +288,8 @@
   "deploymentModel": "native-multichain",
   "bridgeRouteRisk": {
     "tier": "issuer-native-lock-mint",
-    "summary": "wM is Ethereum-native (M0 WrappedM) and reaches Arbitrum, Base, and Solana through M0's own Wormhole-NTT Portal (hub lock/release, spoke mint/burn) and Plume through the Hyperlane-based M0 Portal Lite — all issuer-operated routes with the portal contracts verified on-chain 2026-07-20.",
-    "reviewedAt": "2026-07-20",
+    "summary": "wM is Ethereum-native (M0 WrappedM) and reaches Arbitrum, Base, and Solana through M0's own Wormhole-NTT Portal (hub lock/release, spoke mint/burn) and Plume through the Hyperlane-based M0 Portal Lite — all issuer-operated routes with the portal contracts verified on-chain 2026-07-20; Arbitrum's audited Wrapped M V2 migration was verified 2026-08-07.",
+    "reviewedAt": "2026-08-07",
     "reviewer": "Codex bridge route review; Kimi P2 control cohort dc-2 (lead usdc-circle)",
     "confidence": "verified",
     "protocols": [
@@ -349,9 +349,9 @@
         "semantics": "burn-mint",
         "scope": "peripheral",
         "reviewDisposition": "reviewed",
-        "reviewNote": "wM reaches arbitrum through M0's own Portal — a Wormhole-NTT-derived hub-and-spoke bridge (hub lock/release on Ethereum, spoke mint/burn); the arbitrum wM token is an M0 clone of the shared WrappedM implementation 0x813b926b1d096e117721bd1eb017fba122302da0 (eth_getCode 2026-07-20), and the M0 Spoke Portal 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd (M0 platform addresses doc; code verified 2026-07-20) holds the mint authority on this deployment.",
+        "reviewNote": "wM reaches arbitrum through M0's own Portal — a Wormhole-NTT-derived hub-and-spoke bridge (hub lock/release on Ethereum, spoke mint/burn). The proxy migrated to M0's audited Wrapped M V2 implementation 0x3bb83030f5f784b3dc2c6af5d7e77f7c39d65804 on 2026-07-30; the proxy runtime, underlying M, and M0 Spoke Portal controller 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd remained unchanged (verified 2026-08-07).",
         "mappingVersion": "bridge-route-facts-v1",
-        "observedAt": "2026-07-20",
+        "observedAt": "2026-08-07",
         "sourceChain": "ethereum",
         "controllerChain": "arbitrum",
         "controllerAddress": "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
@@ -367,6 +367,14 @@
           {
             "label": "M0 Spoke Portal on arbitrum (code verified 2026-07-20)",
             "url": "https://arbiscan.io/address/0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+          },
+          {
+            "label": "Arbitrum Wrapped M V2 implementation (code verified 2026-08-07)",
+            "url": "https://arbitrum.blockscout.com/address/0x3BB83030F5f784B3dc2C6af5d7E77f7c39D65804?tab=contract"
+          },
+          {
+            "label": "Arbitrum Wrapped M V2 migration transaction",
+            "url": "https://arbiscan.io/tx/0x059a0c1d725a41b412947afcd3c127254e12822bd15cb81dcb39cb78211f57d8"
           }
         ]
       },

--- a/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
+++ b/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
@@ -8,4 +8,4 @@
  * requests do not serialize and hash the full catalog at runtime.
  */
 export const REPORT_CARDS_REGISTRY_FINGERPRINT =
-  "a06ba77ba96d26607744f1c40b61b52fe6d2b907dac3219815b4265c12c21652";
+  "9b44e365316b4e4d498522c7dd9f3b260dc351fb80f0fde66ce93f719fd4a095";

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -433,7 +433,7 @@
   "/stablecoin/wemix-dollar-wemix/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/weusd-picwe/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/witry-brix/": "2026-07-31T07:27:40+02:00",
-  "/stablecoin/wm-m0/": "2026-07-29T01:34:59+02:00",
+  "/stablecoin/wm-m0/": "2026-08-07T03:40:01+02:00",
   "/stablecoin/wmxn-ripio/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/wpen-ripio/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/wsrusd-reservoir/": "2026-07-31T07:27:40+02:00",

--- a/worker/src/lib/__tests__/fixtures/safety-score-v9-full-registry-input.ts
+++ b/worker/src/lib/__tests__/fixtures/safety-score-v9-full-registry-input.ts
@@ -3,7 +3,7 @@ import { ACTIVE_STABLECOINS } from "@shared/lib/stablecoins/registry";
 import { createReportCardsFixedInput } from "../../report-cards-fixed-input";
 
 // Keep reviewed registry evidence current at this deterministic V9 calibration snapshot.
-const CLOCK_SEC = 1_785_456_000;
+const CLOCK_SEC = 1_786_060_800;
 const DEX_UPDATED_AT_SEC = CLOCK_SEC - 100;
 
 function resourceRoute(assetId: string) {

--- a/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-fact-set.test.ts
@@ -2832,7 +2832,7 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
   });
 
   it("compiles exact wM route shares without bridge-materiality uncertainty", () => {
-    const clockSec = Date.parse("2026-07-24T09:00:00Z") / 1_000;
+    const clockSec = Date.parse("2026-08-07T09:00:00Z") / 1_000;
     const fixed = withWmReviewedDeploymentAttribution(
       exactFixedInput({
         assetId: "wm-m0",
@@ -3230,7 +3230,7 @@ describe("Safety Score v9 exact base fact-set adapter", { timeout: V9_EVALUATION
   it("restores the bridge-materiality cap when the wM packet is absent", () => {
     const fixed = exactFixedInput({
       assetId: "wm-m0",
-      clockSec: Date.parse("2026-07-24T09:00:00Z") / 1_000,
+      clockSec: Date.parse("2026-08-07T09:00:00Z") / 1_000,
       chainSupplyByChain: {},
       aggregateCirculating: { peggedUSD: 87_020_618.58982982 },
       omitLiveReserve: true,

--- a/worker/src/lib/__tests__/safety-score-v9-supply-attribution-generation.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-supply-attribution-generation.test.ts
@@ -45,7 +45,7 @@ import {
 } from "../safety-score-v9-supply-attribution-generation";
 import { createSafetyScoreV9FullRegistryInput } from "./fixtures/safety-score-v9-full-registry-input";
 
-const SOURCE_CLOCK_SEC = 1_785_456_000;
+const SOURCE_CLOCK_SEC = 1_786_060_800;
 const SOURCE_AGGREGATE_USD = 2_480_000_000;
 const TARGET_AGGREGATE_USD = 3_000_000_000;
 

--- a/worker/src/lib/__tests__/safety-score-v9-wm-supply-observer.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-wm-supply-observer.test.ts
@@ -70,6 +70,14 @@ function chainRpcs(): Map<string, ChainRpcConfig> {
   );
 }
 
+function evmImplementationAddress(chainId: string | undefined): string | null {
+  if (!chainId) return null;
+  const identity = expectedWmDeploymentIdentity(
+    `${chainId}:0x437cc33344a0b27a429f795ff6b469c72698b291`,
+  );
+  return identity?.runtime === "evm" ? identity.implementationAddress : null;
+}
+
 function evmCodeAtBlock(
   chainId: string | undefined,
   address: string,
@@ -144,9 +152,10 @@ function dependencies() {
       async (chainId: string | undefined, address: string) =>
         evmCodeAtBlock(chainId, address),
     ),
-    fetchEvmStorageAtBlock: vi.fn(async () =>
-      addressWord("0x813b926b1d096e117721bd1eb017fba122302da0"),
-    ),
+    fetchEvmStorageAtBlock: vi.fn(async (chainId: string | undefined) => {
+      const implementationAddress = evmImplementationAddress(chainId);
+      return implementationAddress ? addressWord(implementationAddress) : null;
+    }),
     fetchEvmMulticall3Aggregate3AtBlock: vi.fn(
       async (
         chainId: string | undefined,
@@ -372,6 +381,18 @@ describe("wM reviewed deployment observer", () => {
       expect.any(Number),
       expect.any(Object),
     );
+  });
+
+  it("rejects the retired Arbitrum implementation", async () => {
+    const outdated = dependencies();
+    outdated.fetchEvmStorageAtBlock.mockImplementation(async (chainId) => {
+      const implementationAddress = chainId === "arbitrum"
+        ? "0x813b926b1d096e117721bd1eb017fba122302da0"
+        : evmImplementationAddress(chainId);
+      return implementationAddress ? addressWord(implementationAddress) : null;
+    });
+
+    await expect(observe(outdated)).resolves.toBeNull();
   });
 
   it("reads Solana mint and controller from one finalized context and binds its block hash", async () => {

--- a/worker/src/lib/safety-score-v9-supply-attribution-contract.ts
+++ b/worker/src/lib/safety-score-v9-supply-attribution-contract.ts
@@ -111,7 +111,8 @@ export type CentrifugeDeploymentIdentity =
   | CentrifugeEvmDeploymentIdentity
   | CentrifugeSolanaDeploymentIdentity;
 
-const WM_IMPLEMENTATION = "0x813b926b1d096e117721bd1eb017fba122302da0";
+const WM_V1_IMPLEMENTATION = "0x813b926b1d096e117721bd1eb017fba122302da0";
+const WM_ARBITRUM_V2_IMPLEMENTATION = "0x3bb83030f5f784b3dc2c6af5d7e77f7c39d65804";
 const WM_UNDERLYING_M = "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b";
 const M0_PORTAL = "0xd925c84b55e4e44a53749ff5f2a5a13f63d128fd";
 
@@ -119,7 +120,7 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "ethereum:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "ef515e6adf8e4349bd060bbfe7472b8cb69b4ca89db7f94af138a0c82cfaa63a",
-    implementationAddress: WM_IMPLEMENTATION,
+    implementationAddress: WM_V1_IMPLEMENTATION,
     implementationCodeSha256: "5120fd4e1b25e5b1e0822a332d5c67d11093d7af243ba0cb6b0ebb2bcfd5fcc5",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: "0xf7f9638cb444d65e5a40bf5ff98ebe4ff319f04e",
@@ -128,8 +129,8 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "arbitrum:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "5c1fe46e765b84b11e490af16edddffaa6a162eac8bf26e7a0449cfaa42bceae",
-    implementationAddress: WM_IMPLEMENTATION,
-    implementationCodeSha256: "dae6453930cd04bafe4264f917790c05723583be42ee44324d5c4514456fda65",
+    implementationAddress: WM_ARBITRUM_V2_IMPLEMENTATION,
+    implementationCodeSha256: "92b85ef0789e99456c8326dcff26c19e179adab47a71c2ca13179274d26e278c",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: M0_PORTAL,
     controllerRead: "portal",
@@ -137,7 +138,7 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "base:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "961610d5a1d1ddab57ececfd095b6fd6a1a0c8d3026f9af70759196f1dffa9d2",
-    implementationAddress: WM_IMPLEMENTATION,
+    implementationAddress: WM_V1_IMPLEMENTATION,
     implementationCodeSha256: "cf480dfabed7c96872ef9aa2af6e9f78c2b0184210c8440a97cb129741d5af88",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: M0_PORTAL,
@@ -146,7 +147,7 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "plume:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "692615a84165d49ceb5c60125c65d21c1d379d3d1da7b03c984d6f9951094f58",
-    implementationAddress: WM_IMPLEMENTATION,
+    implementationAddress: WM_V1_IMPLEMENTATION,
     implementationCodeSha256: "8a3f761b3d5fde864819ce415092d2f8127ee002813ce83a341a053202eb16a0",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: "0x36f586a30502ae3afb555b8aa4dcc05d233c2ece",


### PR DESCRIPTION
Updates only the Arbitrum wM reviewed implementation identity after M0 migrated the unchanged proxy to audited Wrapped M V2. The proxy runtime, underlying M, and Portal controller pins remain fail-closed and unchanged.

Also refreshes the reviewed route evidence and required generated fingerprints/date/checksum projections.

Focused validation:
- 37 V9 attribution tests passed
- Worker typecheck passed
- Stablecoin data validation passed
- Full generated-artifact check passed
- Commit-derived pre-push gate passed