### PR TITLE
Complete Wrapped M V2 attribution pins

### DIFF
--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:db6fb857a49b301c95fef62f39ce8c6aafc04c404d63a05a289acb116a4fff0a",
+  "sourceChecksum": "sha256:ee3dcbb2f676fb8a000f624b1304ae169bc3f384db749d8b6a9fcf88aed42454",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:f2e1a6a0ba33e11f42f9fa7fb502fa174f0a2828abd4b25f68f8a8d788729e77",
+      "checksum": "sha256:11dcb9c1826014dc917d9da82db7251fda7dc0e28204c858a1e6094a157a2934",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
+++ b/shared/data/safety-score-v9/evaluation-build-manifest-v1.ts
@@ -470,7 +470,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
     },
     {
       "path": "worker/src/lib/safety-score-v9-supply-attribution-contract.ts",
-      "sha256": "d9b228286a10ac5da7719ba97b4cbe1897d2e207d346c87f9cf44e98cd883701"
+      "sha256": "02c95411c6d9a6cdb87c127d7bec919f05c16664459d71c851ab1513feae831e"
     },
     {
       "path": "worker/src/lib/safety-score-v9-supply-attribution.ts",
@@ -489,7 +489,7 @@ export const SAFETY_SCORE_V9_EVALUATION_BUILD_MANIFEST = {
       "sha256": "8143ea173162a28e0fb4c87ee2609927eb4122e2bc762e70049b13d84b4d8cd0"
     }
   ],
-  "digest": "d94579c30f469f1e5e55ee92fd31536ce7925ccab7469a39fae998b434be22d6"
+  "digest": "adb04f7268fc90a7343f1bd65b108af027b4c9c43e7f6ad933a83cdcb45e6ebc"
 } as const;
 
 export const SAFETY_SCORE_V9_EVALUATION_BUILD_DIGEST =

--- a/shared/data/stablecoins/coins/wm-m0.json
+++ b/shared/data/stablecoins/coins/wm-m0.json
@@ -288,7 +288,7 @@
   "deploymentModel": "native-multichain",
   "bridgeRouteRisk": {
     "tier": "issuer-native-lock-mint",
-    "summary": "wM is Ethereum-native (M0 WrappedM) and reaches Arbitrum, Base, and Solana through M0's own Wormhole-NTT Portal (hub lock/release, spoke mint/burn) and Plume through the Hyperlane-based M0 Portal Lite — all issuer-operated routes with the portal contracts verified on-chain 2026-07-20; Arbitrum's audited Wrapped M V2 migration was verified 2026-08-07.",
+    "summary": "wM is Ethereum-native (M0 WrappedM) and reaches Arbitrum, Base, and Solana through M0's own Wormhole-NTT Portal (hub lock/release, spoke mint/burn) and Plume through the Hyperlane-based M0 Portal Lite — all issuer-operated routes with the portal contracts verified on-chain 2026-07-20; the audited Wrapped M V2 migrations on Ethereum, Arbitrum, and Base were verified 2026-08-07.",
     "reviewedAt": "2026-08-07",
     "reviewer": "Codex bridge route review; Kimi P2 control cohort dc-2 (lead usdc-circle)",
     "confidence": "verified",
@@ -324,9 +324,9 @@
         "semantics": "native-mint",
         "scope": "canonical",
         "reviewDisposition": "reviewed",
-        "reviewNote": "Canonical home deployment: wM on Ethereum is M0's WrappedM (wraps $M 1:1 via M0's own wrapper under a Migratable upgrade admin; mint-authority review 2026-06-11).",
+        "reviewNote": "Canonical home deployment: wM on Ethereum is M0's WrappedM (wraps $M 1:1 via M0's own wrapper under a Migratable upgrade admin). The proxy migrated to M0's audited Wrapped M V2 implementation 0x6d9db63afccf515f393d5e65be69d38bb3b29d13 on 2026-07-31; the proxy runtime, underlying M, and M0 Minter Gateway controller 0xF7f9638cB444D65E5A40bf5fF98eBE4ff319F04e remained unchanged (verified 2026-08-07).",
         "mappingVersion": "bridge-route-facts-v1",
-        "observedAt": "2026-07-20",
+        "observedAt": "2026-08-07",
         "sources": [
           {
             "label": "wM Ethereum token",
@@ -335,6 +335,14 @@
           {
             "label": "M0 platform addresses (Portal deployments)",
             "url": "https://docs.m0.org/resources/addresses/m0-platform"
+          },
+          {
+            "label": "Ethereum Wrapped M V2 implementation (code verified 2026-08-07)",
+            "url": "https://eth.blockscout.com/address/0x6D9DB63aFCCF515f393D5e65Be69d38Bb3B29D13?tab=contract"
+          },
+          {
+            "label": "Ethereum Wrapped M V2 migration transaction",
+            "url": "https://etherscan.io/tx/0x00be17f60c63f9cb8a16d64e91ada2213e1c391c35cdfe91fb30db3076ed2c05"
           }
         ]
       },
@@ -421,9 +429,9 @@
         "semantics": "burn-mint",
         "scope": "peripheral",
         "reviewDisposition": "reviewed",
-        "reviewNote": "wM reaches base through M0's own Portal — a Wormhole-NTT-derived hub-and-spoke bridge (hub lock/release on Ethereum, spoke mint/burn); the base wM token is an M0 clone of the shared WrappedM implementation 0x813b926b1d096e117721bd1eb017fba122302da0 (eth_getCode 2026-07-20), and the M0 Spoke Portal 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd (M0 platform addresses doc; code verified 2026-07-20) holds the mint authority on this deployment.",
+        "reviewNote": "wM reaches base through M0's own Portal — a Wormhole-NTT-derived hub-and-spoke bridge (hub lock/release on Ethereum, spoke mint/burn). The proxy migrated to M0's audited Wrapped M V2 implementation 0xb1bb9f97af604385eb69212f34d986073ac6693c on 2026-07-30; the proxy runtime, underlying M, and M0 Spoke Portal controller 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd remained unchanged (verified 2026-08-07).",
         "mappingVersion": "bridge-route-facts-v1",
-        "observedAt": "2026-07-20",
+        "observedAt": "2026-08-07",
         "sourceChain": "ethereum",
         "controllerChain": "base",
         "controllerAddress": "0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd",
@@ -439,6 +447,14 @@
           {
             "label": "M0 Spoke Portal on base (code verified 2026-07-20)",
             "url": "https://basescan.org/address/0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd"
+          },
+          {
+            "label": "Base Wrapped M V2 implementation (code verified 2026-08-07)",
+            "url": "https://base.blockscout.com/address/0xB1bb9f97AF604385eb69212f34D986073Ac6693C?tab=contract"
+          },
+          {
+            "label": "Base Wrapped M V2 migration transaction",
+            "url": "https://basescan.org/tx/0x129b736fa00b0d89df19de3d8163fadd034d837215f49856ac68ccec76d92abc"
           }
         ]
       },

--- a/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
+++ b/shared/data/stablecoins/report-card-registry-fingerprint.generated.ts
@@ -8,4 +8,4 @@
  * requests do not serialize and hash the full catalog at runtime.
  */
 export const REPORT_CARDS_REGISTRY_FINGERPRINT =
-  "9b44e365316b4e4d498522c7dd9f3b260dc351fb80f0fde66ce93f719fd4a095";
+  "42218f287d841768e2c1ddb38254028f37ab5aaf30e3598a1de22b472244f25c";

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -433,7 +433,7 @@
   "/stablecoin/wemix-dollar-wemix/": "2026-07-29T01:34:59+02:00",
   "/stablecoin/weusd-picwe/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/witry-brix/": "2026-07-31T07:27:40+02:00",
-  "/stablecoin/wm-m0/": "2026-08-07T03:40:01+02:00",
+  "/stablecoin/wm-m0/": "2026-08-07T04:41:19+02:00",
   "/stablecoin/wmxn-ripio/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/wpen-ripio/": "2026-07-31T07:27:40+02:00",
   "/stablecoin/wsrusd-reservoir/": "2026-07-31T07:27:40+02:00",

--- a/worker/src/lib/__tests__/safety-score-v9-wm-supply-observer.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-wm-supply-observer.test.ts
@@ -331,7 +331,7 @@ describe("wM reviewed deployment observer", () => {
   it("rejects a runtime-code or controller identity change", async () => {
     const wrongCode = dependencies();
     wrongCode.fetchEvmCodeAtBlock.mockImplementation(async (chainId, address) =>
-      chainId === "base" && address.toLowerCase() !== "0x813b926b1d096e117721bd1eb017fba122302da0"
+      chainId === "base" && address.toLowerCase() !== evmImplementationAddress("base")
         ? "0x6000"
         : evmCodeAtBlock(chainId, address),
     );
@@ -366,10 +366,12 @@ describe("wM reviewed deployment observer", () => {
   });
 
   it("rejects implementation bytecode drift at the pinned block", async () => {
+    const baseImplementation = evmImplementationAddress("base");
+    if (!baseImplementation) throw new Error("Missing Base implementation identity");
     const drifted = dependencies();
     drifted.fetchEvmCodeAtBlock.mockImplementation(async (chainId, address) =>
       chainId === "base" &&
-      address.toLowerCase() === "0x813b926b1d096e117721bd1eb017fba122302da0"
+      address.toLowerCase() === baseImplementation
         ? "0x6000"
         : evmCodeAtBlock(chainId, address),
     );
@@ -377,22 +379,38 @@ describe("wM reviewed deployment observer", () => {
     await expect(observe(drifted)).resolves.toBeNull();
     expect(drifted.fetchEvmCodeAtBlock).toHaveBeenCalledWith(
       "base",
-      "0x813b926b1d096e117721bd1eb017fba122302da0",
+      baseImplementation,
       expect.any(Number),
       expect.any(Object),
     );
   });
 
-  it("rejects the retired Arbitrum implementation", async () => {
-    const outdated = dependencies();
-    outdated.fetchEvmStorageAtBlock.mockImplementation(async (chainId) => {
-      const implementationAddress = chainId === "arbitrum"
-        ? "0x813b926b1d096e117721bd1eb017fba122302da0"
-        : evmImplementationAddress(chainId);
-      return implementationAddress ? addressWord(implementationAddress) : null;
-    });
+  it("rejects the retired V1 implementation on every migrated chain", async () => {
+    for (const migratedChain of ["arbitrum", "base", "ethereum"]) {
+      const outdated = dependencies();
+      outdated.fetchEvmStorageAtBlock.mockImplementation(async (chainId) => {
+        const implementationAddress = chainId === migratedChain
+          ? "0x813b926b1d096e117721bd1eb017fba122302da0"
+          : evmImplementationAddress(chainId);
+        return implementationAddress ? addressWord(implementationAddress) : null;
+      });
 
-    await expect(observe(outdated)).resolves.toBeNull();
+      await expect(
+        observeWmReviewedDeploymentUnitPartitionAttempt(
+          {
+            aggregateSupplyUsd: AGGREGATE_SUPPLY_USD,
+            registryFingerprint: REGISTRY_FINGERPRINT,
+            scoringClockSec: CLOCK_SEC,
+            chainRpcs: chainRpcs(),
+          },
+          outdated,
+        ),
+      ).resolves.toEqual({
+        status: "rejected",
+        rejectionCode: "deployment-identity-mismatch",
+        failedRouteId: `${migratedChain}:0x437cc33344a0b27a429f795ff6b469c72698b291`,
+      });
+    }
   });
 
   it("reads Solana mint and controller from one finalized context and binds its block hash", async () => {

--- a/worker/src/lib/safety-score-v9-supply-attribution-contract.ts
+++ b/worker/src/lib/safety-score-v9-supply-attribution-contract.ts
@@ -113,6 +113,8 @@ export type CentrifugeDeploymentIdentity =
 
 const WM_V1_IMPLEMENTATION = "0x813b926b1d096e117721bd1eb017fba122302da0";
 const WM_ARBITRUM_V2_IMPLEMENTATION = "0x3bb83030f5f784b3dc2c6af5d7e77f7c39d65804";
+const WM_BASE_V2_IMPLEMENTATION = "0xb1bb9f97af604385eb69212f34d986073ac6693c";
+const WM_ETHEREUM_V2_IMPLEMENTATION = "0x6d9db63afccf515f393d5e65be69d38bb3b29d13";
 const WM_UNDERLYING_M = "0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b";
 const M0_PORTAL = "0xd925c84b55e4e44a53749ff5f2a5a13f63d128fd";
 
@@ -120,8 +122,8 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "ethereum:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "ef515e6adf8e4349bd060bbfe7472b8cb69b4ca89db7f94af138a0c82cfaa63a",
-    implementationAddress: WM_V1_IMPLEMENTATION,
-    implementationCodeSha256: "5120fd4e1b25e5b1e0822a332d5c67d11093d7af243ba0cb6b0ebb2bcfd5fcc5",
+    implementationAddress: WM_ETHEREUM_V2_IMPLEMENTATION,
+    implementationCodeSha256: "a70202e1437227a8f6229324cffdde3375eb31d2b2231a90e55ea01c58aeac8e",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: "0xf7f9638cb444d65e5a40bf5ff98ebe4ff319f04e",
     controllerRead: "minter-gateway",
@@ -138,8 +140,8 @@ const WM_DEPLOYMENT_IDENTITIES: Readonly<Record<string, WmDeploymentIdentity>> =
   "base:0x437cc33344a0b27a429f795ff6b469c72698b291": {
     runtime: "evm",
     runtimeCodeSha256: "961610d5a1d1ddab57ececfd095b6fd6a1a0c8d3026f9af70759196f1dffa9d2",
-    implementationAddress: WM_V1_IMPLEMENTATION,
-    implementationCodeSha256: "cf480dfabed7c96872ef9aa2af6e9f78c2b0184210c8440a97cb129741d5af88",
+    implementationAddress: WM_BASE_V2_IMPLEMENTATION,
+    implementationCodeSha256: "c8a546e7bad03f58acf5e982738bb07ebb24b9774b9a69515e41012fd51d61b1",
     underlyingTokenAddress: WM_UNDERLYING_M,
     controllerAddress: M0_PORTAL,
     controllerRead: "portal",


### PR DESCRIPTION
## Summary

- pin the audited Wrapped M V2 implementations now active behind the unchanged Base and Ethereum proxies
- retain fail-closed checks for proxy runtime, implementation address and bytecode, underlying M, and controller identity
- refresh reviewed route evidence, V9 fingerprints, generated datasets, and retired-V1 regression coverage

## Verification

- live five-route observer attempt: accepted and exactly reconciled
- `npm run check:pr -- --base=origin/main` (98 files, 1,069 passed, 1 skipped)
- `npm run check:generated-artifacts`
- independent Base and Ethereum bytecode, migration, controller, configuration, and backing audits