### PR TITLE
fix(v9): bridge the 9.15 publication boundary

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
@@ -1,4 +1,6 @@
 import { stableJsonStringifyV1 } from "@shared/lib/stable-json";
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { makeWorkerSafetyScoreV9Publication } from "../../test-helpers/report-cards-v9";
 import {
@@ -19,6 +21,35 @@ describe("Safety Score V9 publication codec", () => {
     await expect(
       parseSafetyScoreV9Publication(stored),
     ).resolves.toEqual(publication);
+  });
+
+  it("reads the last V5 publication emitted before stressStateDigest retired", async () => {
+    const publication = makeWorkerSafetyScoreV9Publication();
+    const envelope = JSON.parse(
+      await serializeSafetyScoreV9Publication(publication),
+    ) as Record<string, unknown>;
+    const priorPayload = JSON.parse(
+      gunzipSync(Buffer.from(String(envelope.payload), "base64")).toString("utf8"),
+    ) as typeof publication;
+    const legacyPayload = stableJsonStringifyV1({
+      ...priorPayload,
+      cards: priorPayload.cards.map((card) => ({
+        ...card,
+        stressStateDigest: "a".repeat(64),
+      })),
+    });
+    const compressed = gzipSync(Buffer.from(legacyPayload));
+    const stored = stableJsonStringifyV1({
+      ...envelope,
+      payloadSha256: createHash("sha256").update(legacyPayload).digest("hex"),
+      uncompressedBytes: Buffer.byteLength(legacyPayload),
+      compressedBytes: compressed.byteLength,
+      payload: compressed.toString("base64"),
+    });
+
+    await expect(parseSafetyScoreV9Publication(stored)).resolves.toEqual(
+      publication,
+    );
   });
 
   it("rejects the retired pre-cutover legacy envelope shapes", async () => {

--- a/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-codec.test.ts
@@ -52,6 +52,21 @@ describe("Safety Score V9 publication codec", () => {
     );
   });
 
+  it("rejects a malformed retired stressStateDigest", async () => {
+    const publication = makeWorkerSafetyScoreV9Publication();
+    const stored = stableJsonStringifyV1({
+      ...publication,
+      cards: publication.cards.map((card) => ({
+        ...card,
+        stressStateDigest: "not-a-digest",
+      })),
+    });
+
+    await expect(parseSafetyScoreV9Publication(stored)).rejects.toThrow(
+      "Retired Safety Score v9 stress state digest is invalid",
+    );
+  });
+
   it("rejects the retired pre-cutover legacy envelope shapes", async () => {
     const publication = makeWorkerSafetyScoreV9Publication();
     const legacyCandidateWrapper = stableJsonStringifyV1({

--- a/worker/src/lib/__tests__/safety-score-v9-publication-runner.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-runner.test.ts
@@ -235,6 +235,18 @@ describe("Safety Score V9 publication runner", () => {
   });
 
   it("holds when publication assessment loading fails", async () => {
+    mocks.build.mockReturnValue({
+      candidate: makeWorkerSafetyScoreV9Publication({
+        baseInputGenerationId: fixedInput.baseInputGenerationId,
+        publishedAtSec: fixedInput.clockSec,
+      }),
+      compilerFactSchemaDigest: "1".repeat(64),
+      producerCapabilityDigest: "2".repeat(64),
+      quarantines: [
+        { assetId: "alpha", code: "fact-build-failed" },
+      ],
+      quarantineAffectedAssetIds: ["alpha"],
+    });
     mocks.loadPublication.mockRejectedValue(new Error("read failed"));
 
     const result = await runSafetyScoreV9Publication({
@@ -245,12 +257,17 @@ describe("Safety Score V9 publication runner", () => {
     expect(result).toMatchObject({
       status: "held",
       reasons: [expect.objectContaining({ code: "assessment-failed" })],
+      affectedAssetIds: ["alpha"],
     });
     expect(mocks.persist).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         publicationAttempt: expect.objectContaining({
           outcome: "held",
+          quarantines: [
+            { assetId: "alpha", code: "fact-build-failed" },
+          ],
+          affectedAssetIds: ["alpha"],
         }),
       }),
     );

--- a/worker/src/lib/safety-score-v9-publication-codec.ts
+++ b/worker/src/lib/safety-score-v9-publication-codec.ts
@@ -134,7 +134,43 @@ function parsePublicationPayload(
   if (stableJsonStringifyV1(parsed.value) !== raw) {
     throw new Error(`${label} JSON is not canonical`);
   }
-  return SafetyScoreV9CurrentResponseSchema.parse(parsed.value);
+  return SafetyScoreV9CurrentResponseSchema.parse(
+    withoutRetiredStressStateDigests(parsed.value),
+  );
+}
+
+/**
+ * Methodology 9.15 retired this unused card field without changing the V5
+ * envelope version. Keep the storage reader able to cross that one-field
+ * boundary so the first 9.15 candidate can compare with and replace the last
+ * 9.14 publication. Integrity checks still cover the original stored bytes;
+ * only the already-authenticated payload is normalized for the current schema.
+ */
+function withoutRetiredStressStateDigests(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const publication = value as Record<string, unknown>;
+  if (!Array.isArray(publication.cards)) return value;
+  let changed = false;
+  const cards = publication.cards.map((card) => {
+    if (card === null || typeof card !== "object" || Array.isArray(card)) {
+      return card;
+    }
+    const record = card as Record<string, unknown>;
+    if (!("stressStateDigest" in record)) return card;
+    const digest = record.stressStateDigest;
+    if (
+      digest !== null &&
+      (typeof digest !== "string" || !/^[a-f0-9]{64}$/.test(digest))
+    ) {
+      throw new Error("Retired Safety Score v9 stress state digest is invalid");
+    }
+    const { stressStateDigest: _retired, ...currentCard } = record;
+    changed = true;
+    return currentCard;
+  });
+  return changed ? { ...publication, cards } : value;
 }
 
 function compressedStorageCandidate(value: unknown): boolean {

--- a/worker/src/lib/safety-score-v9-publication-runner.ts
+++ b/worker/src/lib/safety-score-v9-publication-runner.ts
@@ -430,7 +430,7 @@ export async function runSafetyScoreV9Publication(
             ),
           },
         ],
-        affectedAssetIds: [],
+        affectedAssetIds: pipeline.quarantineAffectedAssetIds,
       };
     }
 


### PR DESCRIPTION
## Summary
- accept the authenticated pre-9.15 V5 card field at the publication storage boundary and strip it before current-schema validation
- preserve quarantine-affected IDs when publication assessment loading fails
- add regression coverage for the compressed legacy publication and fallback attempt metadata

## Production incident
The 9.15 deployment could not load the last 9.14 publication because its cards still contained the retired `stressStateDigest`. The publication gate then masked that schema error with an invalid empty affected-asset list. Exact remote-D1 replay now parses the accepted publication and assesses the current candidate as a publishable bounded partial.

## Verification
- `npm run check:pr -- --base=origin/main`
- exact production replay against the current V9 input, journals, supply attribution, and accepted publication