### PR TITLE
fix(data): record reviewed Kerne timelock handover

### DIFF
--- a/public/datasets/stablecoin-cemetery.json
+++ b/public/datasets/stablecoin-cemetery.json
@@ -7,7 +7,7 @@
   "jsonUrl": "https://pharos.watch/datasets/stablecoin-cemetery.json",
   "csvUrl": "https://pharos.watch/datasets/stablecoin-cemetery.csv",
   "sourceDataPath": "shared/lib/cemetery-merged.ts",
-  "sourceChecksum": "sha256:59a0a9e05dd753daa0e9a92b1dbfdaf78d21aeb9ac16d694c94c8fb548d39d39",
+  "sourceChecksum": "sha256:93953c0faa6e8b165722a609258773bf26d4ea071cc7d79db584da91aeee1ec4",
   "sourceData": [
     {
       "path": "shared/data/dead-stablecoins.json",
@@ -16,7 +16,7 @@
     },
     {
       "path": "shared/data/stablecoins/coins.generated.json",
-      "checksum": "sha256:fcf223c9a27b27901a52a8542fc3bee999c14afacd5136bae699fda445761687",
+      "checksum": "sha256:e9747c1707ff45c972a9f3d7f0bd681f94e1f16476d48d8e1e3bde51b5c198cf",
       "role": "Generated tracked-stablecoin aggregate used for frozen cemetery rows."
     }
   ],

--- a/shared/data/stablecoins/coins/kusd-kerne.json
+++ b/shared/data/stablecoins/coins/kusd-kerne.json
@@ -73,7 +73,7 @@
   "status": "pre-launch",
   "announcedDate": "2026-04",
   "launchPhase": "launching-soon",
-  "launchPhaseDetail": "kUSD v2 is live on Base (first PSM mint 2026-05-14), but Pharos treats it as pre-active until a usable runtime price path exists. The protocol is in a genesis, capacity-capped phase: supply is about 1,113 USD, DefiLlama stablecoin id 402 exposes supply with price=null, CoinGecko does not resolve a Kerne USD coin, and the v1 WETH/Hyperliquid hedge vault leg is disclosed-degraded and excluded from reserves so kUSD is currently 100% USDC-backed through three PSM reserves. Staking wrapper skUSD (ERC-4626, 0x96F5102C15b839757f811A98CEc3725Ac21DfA14) is deployed with a published live APY but near-zero third-party stake. The previous skUSD (0xdEd74F7E) is retired. Admin is a 2-of-3 Gnosis Safe; hourly signed proof of reserves is published at kerne.fi/verify.",
+  "launchPhaseDetail": "kUSD v2 is live on Base (first PSM mint 2026-05-14), but Pharos treats it as pre-active until a usable runtime price path exists. The protocol is in a genesis, capacity-capped phase: supply is about 1,113 USD, DefiLlama stablecoin id 402 exposes supply with price=null, CoinGecko does not resolve a Kerne USD coin, and the v1 WETH/Hyperliquid hedge vault leg is disclosed-degraded and excluded from reserves so kUSD is currently 100% USDC-backed through three PSM reserves. Staking wrapper skUSD (ERC-4626, 0x96F5102C15b839757f811A98CEc3725Ac21DfA14) is deployed with a published live APY but near-zero third-party stake. The previous skUSD (0xdEd74F7E) is retired. kUSD role administration and all three PSMs' administration and manager configuration are behind a 48-hour TimelockController; the 2-of-3 Safe is its sole proposer, executor, and canceller, while a fixed PauseGuardian preserves immediate Safe-triggered PSM pausing. skUSD remains directly administered by the Safe, but its non-upgradeable wrapper powers do not confer kUSD minting or PSM control. Hourly signed proof of reserves is published at kerne.fi/verify.",
   "featuredContent": [
     {
       "type": "article",
@@ -124,6 +124,13 @@
       "title": "Hexens publishes final external audit report",
       "description": "First external audit covering kUSD, skUSD, KUSDPSM, KerneVault, and esKERNE: 10 findings, 0 critical, 2 high; 8 fixed and 2 acknowledged, all 10 in KerneVault. The live KerneVault runs pre-audit bytecode with deposits closed pending a remediated redeploy.",
       "sourceUrl": "https://hexens.io/audit-reports/kerne-protocol-july-2026"
+    },
+    {
+      "date": "2026-08-06",
+      "type": "milestone",
+      "title": "kUSD and PSM administration completes 48-hour timelock transition",
+      "description": "A 13-call operation scheduled on 2026-08-03 and executed on 2026-08-06 after 65 hours 32 minutes completed the handover: the TimelockController holds kUSD and PSM default-admin roles plus PSM manager roles, while the Safe's direct downstream roles were removed. The 2-of-3 Safe remains the timelock's sole proposer, executor, and canceller. A fixed PauseGuardian can only forward an immediate pause to the three PSMs.",
+      "sourceUrl": "https://basescan.org/tx/0xed24d495789540dae543793a5d8c9d884d8abfc386c0e726084da9183933d9b8"
     }
   ]
 }

--- a/shared/data/stablecoins/domains/mint-authority/kusd-kerne.json
+++ b/shared/data/stablecoins/domains/mint-authority/kusd-kerne.json
@@ -4,7 +4,7 @@
     "mintPath": "user-collateralized-governed",
     "authorityPosture": "concentrated-admin",
     "confidence": "manual-review",
-    "summary": "Anyone can mint kUSD permissionlessly by depositing USDC 1:1 into the on-chain Peg Stability Module (10 bps fee, 10,000,000 USDC cap); the PSM holds the kUSD MINTER_ROLE. A 2-of-3 Gnosis Safe is DEFAULT_ADMIN and can grant or revoke that minter role and change PSM parameters, so durable supply authority is concentrated in that multisig.",
+    "summary": "Anyone can mint kUSD permissionlessly by depositing USDC 1:1 into the live Peg Stability Module (10 bps fee, 10,000,000 USDC cap), which holds the kUSD MINTER_ROLE. Since 2026-08-06, kUSD role administration and the three PSMs' administration and manager configuration sit behind an OpenZeppelin TimelockController with a 48-hour minimum delay. The 2-of-3 Safe is the timelock's sole proposer, executor, and canceller. A fixed PauseGuardian preserves immediate Safe-triggered PSM pausing but cannot mint, raise caps, unpause, or change configuration. The separate, non-upgradeable skUSD wrapper remains directly administered by the Safe, but its wrapper powers do not authorize kUSD minting or PSM changes.",
     "controls": [
       {
         "chain": "base",
@@ -26,52 +26,135 @@
             "url": "https://base-rpc.publicnode.com"
           }
         ],
-        "evidence": "At Base block 49003308, kUSD hasRole(MINTER_ROLE, 0xaBDE1138) returned true while the same read returned false for 0x07eBb486 and 0xFf3025ec. The live PSM returned mintingEnabled=true, paused=false, supportedStables(USDC)=true, swapFees(USDC)=10, and stableCaps(USDC)=10000000000000 (10,000,000 USDC).",
-        "observedAt": "2026-07-23",
-        "observedBlock": 49003308
+        "evidence": "At Base block 49788701, kUSD hasRole(MINTER_ROLE, 0xaBDE1138) returned true while the same read returned false for 0x07eBb486 and 0xFf3025ec. The live PSM returned mintingEnabled=true, paused=false, supportedStables(USDC)=true, swapFees(USDC)=10, and stableCaps(USDC)=10000000000000 (10,000,000 USDC).",
+        "observedAt": "2026-08-10",
+        "observedBlock": 49788701
       },
       {
         "chain": "base",
         "address": "0x52d3e450ba6c299b1b07298f1e87dd74732d4877",
-        "label": "Kerne admin Gnosis Safe (2-of-3)",
+        "label": "Kerne control Safe (2-of-3; timelock proposer/executor/canceller)",
         "role": "minter-admin",
         "authorityType": "safe",
         "directMintAbility": "can-authorize",
         "threshold": 2,
         "signerCount": 3,
         "canRaiseCap": true,
-        "modulesOrGuardsStatus": "unknown",
+        "modulesOrGuardsStatus": "none-detected",
         "safe": {
+          "version": "1.4.1",
+          "owners": [
+            "0x14f04ce02f35b29af564a98544dd7e2393993946",
+            "0x0cec7021f4c20f3d5ebb55c1ac591c15efbb7895",
+            "0xf4a43c88b7370bd6e370c7af5fe663c6d223b3fb"
+          ],
           "threshold": 2,
-          "source": "manual"
+          "enabledModules": [],
+          "guard": null,
+          "fallbackHandler": "0xfd0732dc9e303f09fcef3a7388ad10a83459ec99",
+          "masterCopy": "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
+          "observedBlock": 49788701,
+          "observedAt": "2026-08-10",
+          "source": "onchain"
         },
         "sources": [
           {
             "label": "Kerne admin Safe on BaseScan",
             "url": "https://basescan.org/address/0x52d3e450ba6c299b1b07298f1e87dd74732d4877"
+          },
+          {
+            "label": "Safe Transaction Service state",
+            "url": "https://safe-transaction-base.safe.global/api/v1/safes/0x52d3E450bA6c299B1B07298F1E87DD74732D4877/"
+          },
+          {
+            "label": "Final timelock handover execution",
+            "url": "https://basescan.org/tx/0xed24d495789540dae543793a5d8c9d884d8abfc386c0e726084da9183933d9b8"
           }
         ],
-        "evidence": "Per Kerne deployment records the DEFAULT_ADMIN_ROLE across governance-relevant contracts is a 2-of-3 Gnosis Safe (0x52d3E450), which can grant or revoke the PSM minter role and adjust PSM parameters. Owner set, modules, and guard were not independently re-read on-chain in this submission."
+        "evidence": "At Base block 49788701, on-chain reads returned Safe version 1.4.1, the three listed owners, threshold 2, and no enabled modules; the Safe Transaction Service reported no guard and the standard fallback handler. The Safe no longer held DEFAULT_ADMIN_ROLE or MANAGER_ROLE on kUSD or any PSM, but it remained the TimelockController's proposer, executor, and canceller. All authority-expanding seat changes require a timelock self-call; a holder can still renounce its own timelock seat immediately, which can reduce liveness but cannot expand authority. The Safe remained DEFAULT_ADMIN_ROLE on skUSD, whose verified non-upgradeable wrapper code limits admin to vesting-period and role management rather than kUSD minting or PSM configuration.",
+        "observedAt": "2026-08-10",
+        "observedBlock": 49788701
+      },
+      {
+        "chain": "base",
+        "address": "0x36a14976980b7dd33136f6613545eb0a2c0a0d72",
+        "label": "Kerne TimelockController (48-hour kUSD and PSM administration)",
+        "role": "timelock",
+        "authorityType": "timelock",
+        "directMintAbility": "can-authorize",
+        "timelockDelaySec": 172800,
+        "canRaiseCap": true,
+        "modulesOrGuardsStatus": "not-applicable",
+        "capDescription": "The PSM MANAGER_ROLE controls caps and configuration. The timelock holds that role on all three PSMs, so a Safe-originated cap increase or configuration change must be scheduled and wait at least 48 hours. kUSD minter-role changes likewise pass through the timelock's DEFAULT_ADMIN_ROLE.",
+        "sources": [
+          {
+            "label": "TimelockController verified contract",
+            "url": "https://basescan.org/address/0x36a14976980b7dd33136f6613545eb0a2c0a0d72#code"
+          },
+          {
+            "label": "Final timelock handover execution",
+            "url": "https://basescan.org/tx/0xed24d495789540dae543793a5d8c9d884d8abfc386c0e726084da9183933d9b8"
+          }
+        ],
+        "evidence": "At Base block 49788701, getMinDelay() returned 172800. The timelock held DEFAULT_ADMIN_ROLE on kUSD and all three PSMs plus MANAGER_ROLE on the PSMs; the Safe held none of those downstream roles. The timelock held its own DEFAULT_ADMIN_ROLE while the Safe held its proposer, executor, and canceller seats. Verified constructor arguments name only the Safe as proposer and executor and use the zero-address external admin; the complete 32-log history through the observation block contains no later timelock role change.",
+        "observedAt": "2026-08-10",
+        "observedBlock": 49788701
+      },
+      {
+        "chain": "base",
+        "address": "0xc47adaf51907bb1871d07e18ea21dc75ae93cc8e",
+        "label": "Kerne PauseGuardian (immediate Safe-triggered PSM pause)",
+        "role": "other",
+        "authorityType": "contract",
+        "directMintAbility": "parameter-only",
+        "canRaiseCap": false,
+        "modulesOrGuardsStatus": "not-applicable",
+        "capDescription": "Although it holds MANAGER_ROLE on the PSMs, the guardian's immutable code can only forward pause() to the three fixed PSM addresses when called by the Safe. It cannot mint, raise a cap, change configuration, or unpause.",
+        "sources": [
+          {
+            "label": "PauseGuardian verified contract",
+            "url": "https://basescan.org/address/0xc47adaf51907bb1871d07e18ea21dc75ae93cc8e#code"
+          },
+          {
+            "label": "Final timelock handover execution",
+            "url": "https://basescan.org/tx/0xed24d495789540dae543793a5d8c9d884d8abfc386c0e726084da9183933d9b8"
+          }
+        ],
+        "evidence": "At Base block 49788701, the guardian held MANAGER_ROLE on the live, retired, and original PSMs. Independently verified source fixes the Safe and three PSM addresses as constructor immutables, rejects every other caller and module, and exposes only pause(address), which forwards the pause() selector. This is an immediate emergency-stop carve-out, not a cap or mint-authority bypass.",
+        "observedAt": "2026-08-10",
+        "observedBlock": 49788701
       }
     ],
     "review": {
       "sources": [
         {
-          "label": "Kerne live stats API",
-          "url": "https://kerne.fi/api/stats"
+          "label": "Timelock operation scheduled on 2026-08-03",
+          "url": "https://basescan.org/tx/0x2c6d001391e219ff375edabe90e590168200a3a2cb20c8abfec3d1dcfd302070"
         },
         {
-          "label": "Kerne security overview",
-          "url": "https://kerne.fi/security"
+          "label": "Timelock operation executed on 2026-08-06",
+          "url": "https://basescan.org/tx/0xed24d495789540dae543793a5d8c9d884d8abfc386c0e726084da9183933d9b8"
+        },
+        {
+          "label": "TimelockController verified contract",
+          "url": "https://basescan.org/address/0x36a14976980b7dd33136f6613545eb0a2c0a0d72#code"
+        },
+        {
+          "label": "PauseGuardian verified contract",
+          "url": "https://basescan.org/address/0xc47adaf51907bb1871d07e18ea21dc75ae93cc8e#code"
+        },
+        {
+          "label": "Kerne admin Safe on BaseScan",
+          "url": "https://basescan.org/address/0x52d3e450ba6c299b1b07298f1e87dd74732d4877"
+        },
+        {
+          "label": "skUSD verified contract",
+          "url": "https://basescan.org/address/0x96f5102c15b839757f811a98cec3725ac21dfa14#code"
         }
       ],
-      "evidence": "Pharos independently read the live contracts at Base block 49003308: 0xaBDE1138 held kUSD MINTER_ROLE with minting enabled, while 0x07eBb486 and 0xFf3025ec did not hold the role and retained their USDC redemption reserves. The 2-of-3 Gnosis Safe 0x52d3E450 remains described as DEFAULT_ADMIN with authority to grant or revoke the minter role and change PSM parameters; its owner set, modules, and guard were not re-read in this review.",
+      "evidence": "Pharos independently reconstructed the handover and re-read the live state at Base block 49788701. Four separate Safe transactions granted the TimelockController DEFAULT_ADMIN_ROLE on kUSD and the three PSMs on 2026-08-03. A 13-call operation was then scheduled at block 49505169 and executed at block 49623130 after 65 hours 32 minutes: it granted the timelock and code-limited PauseGuardian MANAGER_ROLE on every PSM, then removed the Safe's manager and default-admin seats. Current reads confirmed the timelock's 172800-second minimum delay, self-admin role, and the Safe's sole proposer/executor/canceller topology; they also confirmed the live PSM is the only kUSD MINTER_ROLE holder and remains enabled, unpaused, and capped at 10,000,000 USDC. skUSD remains directly administered by the Safe, but verified wrapper code provides no kUSD mint or PSM-control path, so it is recorded as a separate wrapper authority rather than a timelock bypass.",
       "reviewer": "Pharos on-chain review",
-      "reviewedAt": "2026-07-23",
-      "unresolvedQuestions": [
-        "Confirm the Safe owner set, modules, and guard on-chain at a fixed Base block.",
-        "Confirm whether the live KUSDPSM cap can be raised only after a timelock."
-      ]
+      "reviewedAt": "2026-08-10"
     }
   }
 }

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -1,6 +1,6 @@
 {
   "api-reference": {
-    "dateModified": "2026-08-10T13:54:03+02:00",
+    "dateModified": "2026-08-10T14:34:43+02:00",
     "dateCreated": "2026-02-23T15:28:17+01:00"
   },
   "architecture": {
@@ -12,7 +12,7 @@
     "dateCreated": "2026-03-03T14:17:10+01:00"
   },
   "data-pipeline": {
-    "dateModified": "2026-08-10T13:55:51+02:00",
+    "dateModified": "2026-08-10T14:34:43+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "worker-and-api-limits": {
@@ -52,7 +52,7 @@
     "dateCreated": "2026-02-25T19:21:45+01:00"
   },
   "redemption-backstops": {
-    "dateModified": "2026-08-10T13:55:51+02:00",
+    "dateModified": "2026-08-10T14:34:43+02:00",
     "dateCreated": "2026-03-12T23:06:41+01:00"
   },
   "chain-health": {

--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -229,7 +229,7 @@
   "/stablecoin/krw-imbank/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/krw1-bdacs/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/krwq-iq/": "2026-08-10T01:56:14+02:00",
-  "/stablecoin/kusd-kerne/": "2026-08-10T01:56:14+02:00",
+  "/stablecoin/kusd-kerne/": "2026-08-10T15:08:25+02:00",
   "/stablecoin/lisusd-lista/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/luausd-lumi-finance/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/lusd-liquity/": "2026-08-10T01:56:14+02:00",


### PR DESCRIPTION
## Summary

- replace the stale kUSD Safe-as-admin description with an independent fixed-block review in the current `mint-authority` sidecar
- model the actual control split: the TimelockController holds kUSD/PSM administration and PSM manager authority behind 48 hours; the Safe is the sole proposer/executor/canceller; the immutable PauseGuardian can only forward an immediate pause
- record skUSD as a separate non-upgradeable wrapper authority rather than treating its Safe admin as a kUSD mint or PSM-control bypass
- add the completed 2026-08-06 handover milestone while keeping kUSD `pre-launch`, `launching-soon`, and `concentrated-admin`
- settle sitemap/docs history metadata and the cemetery catalog checksum

This internally reviewed correction supersedes the project-submitted data shape in #797.

## Independent verification

- Base block `49788701` (2026-08-10 12:59:09 UTC): live PSM is the only kUSD minter; timelock holds kUSD/PSM default-admin and all PSM manager roles; Safe holds none of those downstream roles
- timelock delay is `172800`; its complete event history has no seat changes after deployment; Safe remains sole proposer/executor/canceller and timelock is self-administered
- Safe is 2-of-3, version 1.4.1, with no modules and no guard
- verified PauseGuardian code fixes the Safe and three PSMs as immutables and exposes only `pause(address)`
- verified skUSD code does not expose kUSD minting or PSM configuration
- DefiLlama id 402 still reports `price: null`; CoinGecko still returns no Kerne USD coin, so no activation is proposed

## Validation

- `npm run check:stablecoin-data`
- focused registry suite: 9 files / 156 tests
- `npm run check:generated-artifacts`
- `npm run check:pr -- --base=origin/main`: 51 files / 518 tests