### PR TITLE
chore(generated): settle kUSD production timestamp

### DIFF
--- a/src/generated/sitemap-dates.json
+++ b/src/generated/sitemap-dates.json
@@ -229,7 +229,7 @@
   "/stablecoin/krw-imbank/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/krw1-bdacs/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/krwq-iq/": "2026-08-10T01:56:14+02:00",
-  "/stablecoin/kusd-kerne/": "2026-08-10T15:08:25+02:00",
+  "/stablecoin/kusd-kerne/": "2026-08-10T15:17:45+02:00",
   "/stablecoin/lisusd-lista/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/luausd-lumi-finance/": "2026-08-10T01:56:14+02:00",
   "/stablecoin/lusd-liquity/": "2026-08-10T01:56:14+02:00",


### PR DESCRIPTION
## Summary

- regenerate the kUSD sitemap timestamp from production commit `5eca224823e717d9603d21b895f6439441b78a85` after the #825 protected squash
- make `origin/main` pass the commit-derived artifact contract; no source metadata or runtime behavior changes

## Validation

- `npm run check:commit-derived-artifacts`
- `npm run check:pr -- --base=origin/main`: 49 files / 516 tests

This generated-only follow-up is required because the source-touching squash is the final Git-history timestamp source.