### PR TITLE
ci: isolate Pages release snapshot fallbacks

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -52,29 +52,43 @@ jobs:
           PUBLIC_DATASETS_API_URL: https://stablecoin-dashboard.pages.dev/_site-data
           PUBLIC_DATASETS_REQUIRE_API: "1"
         run: |
-          # Fail-open refresh: a fetch failure or a shrinking digest archive
-          # falls back to the committed snapshot instead of failing the deploy.
+          # Refresh each snapshot independently. A failed surface falls back to
+          # its committed data without discarding successful archive refreshes.
           committed_digest_count="$(node -e 'console.log(JSON.parse(require("node:fs").readFileSync("data/digests.json","utf8")).length)')"
-          refresh_ok=true
+          digest_refresh_ok=true
           npx tsx scripts/maintenance/sync-digests.ts --output data/digests.json \
-            && npx tsx scripts/maintenance/sync-depeg-events.ts --output data/depeg-events.json \
-            && npm run generate:public-datasets \
-            || refresh_ok=false
-          if [ "$refresh_ok" = "true" ]; then
+            || digest_refresh_ok=false
+          if [ "$digest_refresh_ok" = "true" ]; then
             refreshed_digest_count="$(node -e 'console.log(JSON.parse(require("node:fs").readFileSync("data/digests.json","utf8")).length)' 2>/dev/null || echo 0)"
             if [ "$refreshed_digest_count" -lt "$committed_digest_count" ]; then
               echo "::warning::digest archive shrank (${refreshed_digest_count} < ${committed_digest_count}); using committed snapshot"
-              refresh_ok=false
+              digest_refresh_ok=false
             fi
           fi
-          if [ "$refresh_ok" != "true" ]; then
-            echo "::warning::release data refresh failed; building from the committed snapshot"
-            git checkout -- data/digests.json data/depeg-events.json public/datasets
-            git clean -fd -- public/datasets
-            echo "- Data refresh: FAILED (fail-open), built from committed snapshot" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "- Data refresh: OK (${refreshed_digest_count} digest entries)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$digest_refresh_ok" != "true" ]; then
+            echo "::warning::digest refresh failed; using committed digest snapshot"
+            git checkout -- data/digests.json
           fi
+
+          depeg_refresh_ok=true
+          npx tsx scripts/maintenance/sync-depeg-events.ts --output data/depeg-events.json \
+            || depeg_refresh_ok=false
+          if [ "$depeg_refresh_ok" != "true" ]; then
+            echo "::warning::depeg-event refresh failed; using committed depeg snapshot"
+            git checkout -- data/depeg-events.json
+          fi
+
+          public_datasets_refresh_ok=true
+          npm run generate:public-datasets || public_datasets_refresh_ok=false
+          if [ "$public_datasets_refresh_ok" != "true" ]; then
+            echo "::warning::public-dataset refresh failed; using committed public datasets"
+            git checkout -- public/datasets
+            git clean -fd -- public/datasets
+          fi
+
+          echo "- Digest refresh: ${digest_refresh_ok} (${refreshed_digest_count:-$committed_digest_count} entries)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Depeg-event refresh: ${depeg_refresh_ok}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Public-dataset refresh: ${public_datasets_refresh_ok}" >> "$GITHUB_STEP_SUMMARY"
       - name: Build clean production export
         env:
           GENERATED_ARTIFACTS_SKIP: stablecoin-catalog,world-map,sitemap-dates,case-study-client-index,docs-metadata,cemetery-dataset,public-datasets,homepage-bootstrap,postman,openapi,report-card-registry-fingerprint,legacy-stablecoin-redirects,stablecoin-client-registry,api-reference,og-editorial,og-learn,og-case-studies

--- a/scripts/__tests__/ci-workflow-scope.test.ts
+++ b/scripts/__tests__/ci-workflow-scope.test.ts
@@ -8,6 +8,23 @@ function readRepoFile(path: string): string {
 }
 
 describe("CI workflow scope", () => {
+  it("keeps successful Pages release snapshots when another refresh fails open", () => {
+    const workflow = parseYaml(readRepoFile(".github/workflows/pages-release.yml")) as {
+      jobs: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+    };
+    const refreshStep = workflow.jobs["pages-release"].steps?.find(
+      (step) => step.name === "Refresh API-backed release data",
+    );
+    const run = refreshStep?.run ?? "";
+
+    expect(run).toContain("git checkout -- data/digests.json");
+    expect(run).toContain("git checkout -- data/depeg-events.json");
+    expect(run).toContain("git checkout -- public/datasets");
+    expect(run).not.toContain(
+      "git checkout -- data/digests.json data/depeg-events.json public/datasets",
+    );
+  });
+
   it("packages the Worker before production D1 mutation", () => {
     const workflow = readRepoFile(".github/workflows/deploy-cloudflare.yml");
     const packageStep = workflow.indexOf("npm run check:worker-package");

--- a/src/generated/docs-metadata.json
+++ b/src/generated/docs-metadata.json
@@ -8,7 +8,7 @@
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "data-flow-map": {
-    "dateModified": "2026-08-10T19:17:40+02:00",
+    "dateModified": "2026-08-10T19:53:26+02:00",
     "dateCreated": "2026-03-03T14:17:10+01:00"
   },
   "data-pipeline": {
@@ -16,7 +16,7 @@
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "worker-and-api-limits": {
-    "dateModified": "2026-08-10T19:17:40+02:00",
+    "dateModified": "2026-08-10T19:53:26+02:00",
     "dateCreated": "2026-03-01T13:33:58+01:00"
   },
   "classification": {
@@ -28,11 +28,11 @@
     "dateCreated": "2026-07-15T17:09:51+02:00"
   },
   "pricing-pipeline": {
-    "dateModified": "2026-08-10T19:17:40+02:00",
+    "dateModified": "2026-08-10T19:53:26+02:00",
     "dateCreated": "2026-03-14T09:59:04+01:00"
   },
   "depeg-detection": {
-    "dateModified": "2026-08-10T19:17:40+02:00",
+    "dateModified": "2026-08-10T19:53:26+02:00",
     "dateCreated": "2026-02-28T12:27:51+01:00"
   },
   "dews": {
@@ -40,7 +40,7 @@
     "dateCreated": "2026-03-01T16:18:28+01:00"
   },
   "dex-liquidity": {
-    "dateModified": "2026-08-10T19:17:40+02:00",
+    "dateModified": "2026-08-10T19:53:26+02:00",
     "dateCreated": "2026-02-19T17:42:02+01:00"
   },
   "stability-index": {


### PR DESCRIPTION
## Summary\n- preserve successful digest refreshes when depeg/public-dataset refreshes fail\n- preserve successful depeg refreshes when public-dataset generation fails\n- retain per-surface committed fallback behavior and add workflow regression coverage\n\n## Why\nThe D1 mitigation release reached production Worker activation, but Pages release attempts fetched the required archives successfully and then discarded them when a separate snapshot fetch failed. This keeps the fail-open contract per surface so archive continuity can pass without coupling unrelated fetches.\n\n## Validation\n- npm run check:pr -- --base=origin/main\n- npm run check:commit-derived-artifacts\n- workflow YAML parse