### PR TITLE
fix(safety): hold mismatched cached publication

### DIFF
--- a/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
+++ b/worker/src/lib/__tests__/report-cards-v9-cache.test.ts
@@ -63,7 +63,22 @@ describe("canonical V9 report-card cache", () => {
     });
   });
 
-  it("requires matching publication and health rows", async () => {
+  it("holds the stored publication when health points at another generation", () => {
+    const publication = evaluatorPublication();
+    const health = {
+      ...makeReportCardsV9Response().publicationHealth,
+      acceptedPublicationGenerationId: "report-cards:v9:other",
+      acceptedAtSec: publication.publishedAtSec + 1,
+    };
+
+    expect(projectSafetyScoreV9PublicationToPublicSnapshot(publication, health).publicationHealth).toMatchObject({
+      status: "held",
+      acceptedPublicationGenerationId: publication.publicationGenerationId,
+      acceptedAtSec: publication.publishedAtSec,
+    });
+  });
+
+  it("requires a publication and health row", async () => {
     mockLoadPublication.mockResolvedValue(evaluatorPublication());
     mockLoadPublicationHealth.mockResolvedValue(null);
 

--- a/worker/src/lib/report-cards-v9-cache.ts
+++ b/worker/src/lib/report-cards-v9-cache.ts
@@ -26,15 +26,23 @@ export function projectSafetyScoreV9PublicationToPublicSnapshot(
   publicationHealth: V9PublicationHealth,
 ): ReportCardsV9CurrentResponse {
   const publication = SafetyScoreV9CurrentResponseSchema.parse(input);
-  if (
-    publicationHealth.acceptedPublicationGenerationId !==
-      publication.publicationGenerationId ||
-    publicationHealth.acceptedAtSec !== publication.publishedAtSec
-  ) {
-    throw new Error(
-      "Safety Score V9 publication health does not match the accepted publication",
-    );
-  }
+  const healthMatchesPublication =
+    publicationHealth.acceptedPublicationGenerationId ===
+      publication.publicationGenerationId &&
+    publicationHealth.acceptedAtSec === publication.publishedAtSec;
+  const effectiveHealth = healthMatchesPublication
+    ? publicationHealth
+    : {
+        ...publicationHealth,
+        status: "held" as const,
+        acceptedPublicationGenerationId: publication.publicationGenerationId,
+        acceptedAtSec: publication.publishedAtSec,
+        heldSinceSec: publication.publishedAtSec,
+        reasons: [{
+          code: "assessment-failed" as const,
+          detail: "Publication health did not match the stored snapshot; serving the last-known-good snapshot as held.",
+        }],
+      };
   return ReportCardsV9CurrentResponseSchema.parse({
     model: "v9",
     schemaVersion: REPORT_CARDS_V9_RESPONSE_SCHEMA_VERSION,
@@ -55,7 +63,7 @@ export function projectSafetyScoreV9PublicationToPublicSnapshot(
     },
     asOfSec: publication.asOfSec,
     updatedAt: publication.publishedAtSec,
-    publicationHealth,
+    publicationHealth: effectiveHealth,
     completeness: publication.completeness,
     source: {
       candidateId: publication.candidateId,


### PR DESCRIPTION
## Summary
- serve the authenticated stored Safety Score snapshot as explicitly held when publication health points at another generation
- preserve fail-closed semantics for missing publication/health rows
- add a regression test for the mismatch path

## Validation
- targeted report-card cache tests pass
- adaptive PR checks follow the protected gate

This addresses the remaining production 503 after the pre-9.19 compatibility fix.