### PR TITLE
fix(safety): prevent publication health drift

### DIFF
--- a/worker/src/lib/__tests__/safety-score-v9-publication-store.test.ts
+++ b/worker/src/lib/__tests__/safety-score-v9-publication-store.test.ts
@@ -29,6 +29,52 @@ afterEach(() => {
 });
 
 describe("Safety Score V9 publication store", () => {
+  it("rejects a health advance when the publication row is already newer", async () => {
+    const { db } = database();
+    const newer = makeWorkerSafetyScoreV9Publication({ publishedAtSec: 200 });
+    const incoming = makeWorkerSafetyScoreV9Publication({ publishedAtSec: 150 });
+    const health = {
+      schemaVersion: 1 as const,
+      status: "current" as const,
+      acceptedPublicationGenerationId: newer.publicationGenerationId,
+      acceptedAtSec: newer.publishedAtSec,
+      attemptedAtSec: newer.publishedAtSec,
+      heldSinceSec: null,
+      reasons: [],
+    };
+    await persistSafetyScoreV9Publication(db, {
+      publication: newer,
+      publicationHealth: health,
+      publicationAttempt: {
+        schemaVersion: 1,
+        attemptedAtSec: 200,
+        outcome: "published-clean",
+        publicationGenerationId: newer.publicationGenerationId,
+        quarantines: [],
+        affectedAssetIds: [],
+      },
+      publicationClockSec: 200,
+    });
+    await expect(persistSafetyScoreV9Publication(db, {
+      publication: incoming,
+      publicationHealth: {
+        ...health,
+        acceptedPublicationGenerationId: incoming.publicationGenerationId,
+        acceptedAtSec: incoming.publishedAtSec,
+        attemptedAtSec: incoming.publishedAtSec,
+      },
+      publicationAttempt: {
+        schemaVersion: 1,
+        attemptedAtSec: 150,
+        outcome: "published-clean",
+        publicationGenerationId: incoming.publicationGenerationId,
+        quarantines: [],
+        affectedAssetIds: [],
+      },
+      publicationClockSec: 150,
+    })).rejects.toThrow(/Stale or conflicting Safety Score v9 publication/);
+  });
+
   it("publishes canonical ratings and advances held health without replacing them", async () => {
     const { sqlite, db } = database();
     const publication = makeWorkerSafetyScoreV9Publication({

--- a/worker/src/lib/safety-score-v9-publication-store.ts
+++ b/worker/src/lib/safety-score-v9-publication-store.ts
@@ -400,6 +400,21 @@ export async function persistSafetyScoreV9Publication(
       "Stale or conflicting Safety Score v9 publication health update",
     );
   }
+  if (health.status === "current") {
+    const existingPublication = await loadSafetyScoreV9Publication(
+      db,
+      input.signal,
+    );
+    if (
+      existingPublication !== null &&
+      existingPublication.publicationGenerationId !== health.acceptedPublicationGenerationId &&
+      existingPublication.publishedAtSec >= input.publicationClockSec
+    ) {
+      throw new SafetyScoreV9PublicationConflictError(
+        "Stale or conflicting Safety Score v9 publication update",
+      );
+    }
+  }
 
   const cacheStatement = db.prepare(
     `INSERT INTO cache (key, value, updated_at) VALUES (?, ?, ?)


### PR DESCRIPTION
## Summary
- reject stale current-publication writes before health can advance independently
- preserve generation/timestamp consistency across cache rows
- add regression coverage for the conflict path

## Validation
- targeted publication-store and report-card cache tests pass

This closes the write-side race behind mismatched publication health.