### PR TITLE
Night-run 3b: first-cron fixes for assurance index discovery and Anzen RPC

### DIFF
--- a/worker/src/cron/reserve-adapters/__tests__/anzen-usdz.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/anzen-usdz.test.ts
@@ -20,12 +20,21 @@ vi.mock("viem/utils", async (importOriginal) => {
   };
 });
 
+const rpc = vi.hoisted(() => ({
+  fetchEvmCallHexAtBlock: vi.fn(),
+  fetchEvmCodeAtBlock: vi.fn(),
+}));
+
 vi.mock("../../../lib/evm-rpc", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../lib/evm-rpc")>();
-  return { ...actual, fetchEvmRpcBatch: vi.fn() };
+  return { ...actual, ...rpc };
 });
 
-import { fetchEvmRpcBatch } from "../../../lib/evm-rpc";
+import {
+  fetchEvmCallHexAtBlock,
+  fetchEvmCodeAtBlock,
+  MULTICALL3_ADDRESS,
+} from "../../../lib/evm-rpc";
 import { fetchAnzenUsdzReserves } from "../anzen-usdz";
 import { getReserveAdapter } from "../index";
 import { validateAdapterOutput } from "../validate";
@@ -115,14 +124,14 @@ function aggregateFor(chain: string, overrides: Record<number, `0x${string}`> = 
 }
 
 function primeRpcMocks(overrides: Record<number, `0x${string}`> = {}, codeDrift = false): void {
-  vi.mocked(fetchEvmRpcBatch).mockImplementation(async (chain) => {
+  vi.mocked(fetchEvmCodeAtBlock).mockImplementation(async (chain, address) => {
+    if (chain === "ethereum" && address.toLowerCase() === SPCT) return "0x7000";
+    if (chain === "ethereum" && address.toLowerCase() === ORACLE) return "0x7001";
+    if (chain === "ethereum" && address.toLowerCase() === USDC) return "0x7002";
     const codeIndex = ["ethereum", "base", "arbitrum", "blast", "manta"].indexOf(chain ?? "");
-    const code = codeDrift && chain === "blast" ? "0xdead" : `0x600${codeIndex}`;
-    if (chain === "ethereum") {
-      return [code, "0x7000", "0x7001", "0x7002", aggregateFor(chain, overrides)];
-    }
-    return [code, aggregateFor(chain ?? "")];
+    return codeDrift && chain === "blast" ? "0xdead" : `0x600${codeIndex}` as `0x${string}`;
   });
+  vi.mocked(fetchEvmCallHexAtBlock).mockImplementation(async (chain) => aggregateFor(chain ?? "", overrides));
 }
 
 function makeCoin(): StablecoinMeta {
@@ -171,10 +180,26 @@ describe("fetchAnzenUsdzReserves", () => {
     });
     expect(result.metadata?.totalReserveUsd).toBeCloseTo(Number(pooled) / 1e18, 7);
     expect(result.metadata?.supplyUsd).toBeCloseTo(Number(liability) / 1e18, 7);
-    expect(vi.mocked(fetchEvmRpcBatch)).toHaveBeenCalledTimes(5);
-    expect(vi.mocked(fetchEvmRpcBatch).mock.calls.map(([chain]) => chain)).toEqual(
+    expect(vi.mocked(fetchEvmCodeAtBlock)).toHaveBeenCalledTimes(8);
+    expect(vi.mocked(fetchEvmCallHexAtBlock)).toHaveBeenCalledTimes(5);
+    expect(vi.mocked(fetchEvmCallHexAtBlock).mock.calls.map(([chain]) => chain)).toEqual(
       expect.arrayContaining(["ethereum", "base", "arbitrum", "blast", "manta"]),
     );
+    for (const [chain, to, _data, block, options] of vi.mocked(fetchEvmCallHexAtBlock).mock.calls) {
+      expect(to).toBe(MULTICALL3_ADDRESS);
+      expect(block).toBe("latest");
+      expect(options).toMatchObject({
+        maxRetries: 0,
+        timeoutMs: 4_000,
+        extraRpcUrls: expect.arrayContaining([expect.stringMatching(/^https:\/\//)]),
+      });
+      expect(chain).toBeTypeOf("string");
+    }
+    const ethereumStateRead = vi.mocked(fetchEvmCallHexAtBlock).mock.calls.find(([chain]) => chain === "ethereum");
+    expect(ethereumStateRead?.[4]?.extraRpcUrls).toEqual([
+      "https://ethereum-rpc.publicnode.com",
+      "https://eth.drpc.org",
+    ]);
     expect(validateAdapterOutput(result, { adapter: getReserveAdapter("anzen-usdz") ?? undefined }).valid).toBe(true);
   });
 
@@ -208,13 +233,10 @@ describe("fetchAnzenUsdzReserves", () => {
 
   it("does not call or use global SPCT totalSupply", async () => {
     await fetchAnzenUsdzReserves(makeCoin(), config, signal);
-    for (const calls of vi.mocked(fetchEvmRpcBatch).mock.calls) {
-      const batch = calls[1] as Array<{ method: string; params: unknown[] }>;
-      const chain = calls[0] as string;
+    for (const [chain, to, data] of vi.mocked(fetchEvmCallHexAtBlock).mock.calls) {
       if (chain === "ethereum") {
-        expect(JSON.stringify(batch).toLowerCase().includes(SPCT)).toBe(true);
-        expect(batch.filter((call) => call.method === "eth_call")).toHaveLength(1);
-        expect(JSON.stringify(batch.find((call) => call.method === "eth_call")?.params).toLowerCase()).toContain("0xca11bde05977b3631167028862be2a173976ca11");
+        expect(to).toBe(MULTICALL3_ADDRESS);
+        expect(data.toLowerCase()).toContain(SPCT.slice(2));
       }
     }
   });

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/europ-independent-assurance.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/europ-independent-assurance.html
@@ -1,0 +1,18 @@
+<!-- captured-at: 2026-08-14T04:23:35Z -->
+<!-- source: https://schuman.io/reserve-audits/ -->
+<!-- source-trimmed: Reports tab and unrelated white-paper link from the live page. -->
+<section>
+  <p><strong>Q2 2026</strong> – Attestation regarding the number of EURØP tokens as of <strong>30.06.26</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2026/07/SALVUS_Attestation_relative_au_nombre_de_jetons_EUROP_30_06_2026.pdf"><span>Download as .pdf</span></a>
+  <p><strong>Q1 2026</strong> – Attestation regarding the number of EURØP tokens as of <strong>31.03.26</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2026/04/SALVUS_Attestation_relative_au_nombre_de_jetons_EUROP_31_03_2026.pdf"><span>Download as .pdf</span></a>
+  <p><strong>Q4 2025</strong> – Attestation regarding the number of EURØP tokens as of <strong>30.12.25</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2026/01/2025.12.30-Schuman-_-Salvus-Attestation_Letter-Signed-All.pdf"><span>Download as .pdf</span></a>
+  <p><strong>Q3 2025</strong> – Attestation regarding the number of EURØP tokens as of <strong>30.09.25</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2025/10/Q3_2025_Attestation_regarding_the_number_of_EUROP_tokens_as_of_30.pdf"><span>Download as .pdf</span></a>
+  <p><strong>Q2 2025</strong> – Attestation regarding the number of EURØP tokens as of <strong>30.06.25</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2025/07/Attestation_regarding_the_number_of_EUROP_tokens_as_of_30_06_25.pdf"><span>Download as .pdf</span></a>
+  <p><strong>Q1 2025</strong> – Attestation regarding the number of EURØP tokens as of <strong>31.03.25</strong></p>
+  <a href="https://schuman.io/wp-content/uploads/2025/05/Attestation_regarding_the_number_of_EUROP_tokens_as_of_31_03_25.pdf"><span>Download as .pdf</span></a>
+</section>
+<a href="https://schuman.io/wp-content/uploads/EUROP-White-Paper.pdf">EURØP White Paper</a>

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/straitsx-independent-assurance-xsgd.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/straitsx-independent-assurance-xsgd.html
@@ -1,0 +1,12 @@
+<!-- captured-at: 2026-08-14T04:23:35Z -->
+<!-- source: https://www.straitsx.com/xsgd -->
+<!-- source-trimmed: Reserve attestation report entries and dated whitepaper from the live page. -->
+<a href="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a670b36900b66cceed35615_StraitsX%20XSGD%20Whitepaper%20-%20V1.1%20-%20Last%20Update%20July%202026.docx.pdf">XSGD Whitepaper</a>
+<button data-gated-asset="XSGD Attestation Report Jan 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/69a451fe6610d41c17d09dd1_XSGD_SCS_Reserve_Account_Report_(31_Jan_2026).pdf"></button>
+<button data-gated-asset="XSGD Attestation Report Mid-Jan 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/69aa419eaca0ff281442fa1b_XSGD_SCS_Reserve_Account_Report_(15_Jan_2026).pdf"></button>
+<button data-gated-asset="XSGD Attestation Report Mid-May 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a44bd41af37fdee0db3f723_XSGD_SCS_Reserve_Account_Report_(15_May_2026).docx.pdf"></button>
+<button data-gated-asset="XSGD Attestation Report May 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a44bcf4afadd295291e1be8_XSGD_SCS_Reserve_Account_Report_(31_May_2026).docx.pdf"></button>
+<button data-gated-asset="XSGD Attestation Report Mid-June 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a6c78ced4f8b16b35a78869_XSGD%20SCS%20Reserve%20Account%20Report%20(15%20June%202026).pdf"></button>
+<button data-gated-asset="XSGD Attestation Report June 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a6c78f17a4f92b635508f81_XSGD%20SCS%20Reserve%20Account%20Report%20(30%20June%202026).pdf"></button>
+<button data-gated-asset="XSGD Attestation Report Mid-Jan 2025" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6978ae315022b2b06d3f2420_xsgd-250115.pdf"></button>
+<button data-gated-asset="XSGD Attestation Report Jan 2025" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6879058b9e987938b0968ecb_xsgd-report-2025-Jan.pdf"></button>

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/straitsx-independent-assurance-xusd.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/straitsx-independent-assurance-xusd.html
@@ -1,0 +1,12 @@
+<!-- captured-at: 2026-08-14T04:23:35Z -->
+<!-- source: https://www.straitsx.com/xusd -->
+<!-- source-trimmed: Reserve attestation report entries and dated whitepaper from the live page. -->
+<a href="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a670b7981914ac484b85888_StraitsX%20XUSD%20Whitepaper%20-%20V1.1%20-%20Last%20Update%20July%202026.docx.pdf">XUSD Whitepaper</a>
+<button data-gated-asset="XUSD Attestation Report Jan 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/69a451ead6ca614dc6f097e3_XUSD_SCS_Reserve_Account_Report_(31_Jan_2026).pdf"></button>
+<button data-gated-asset="XUSD Attestation Report Mid-Jan 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/69aa41e594932dbde21af2be_XUSD_SCS_Reserve_Account_Report_(15_Jan_2026).pdf"></button>
+<button data-gated-asset="XUSD Attestation Report Mid-May 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a44bd29af4533c36e7bee5b_XUSD_SCS_Reserve_Account_Report_(15_May_2026).docx.pdf"></button>
+<button data-gated-asset="XUSD Attestation Report May 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a44bd73219d7e8e1139a331_XUSD_SCS_Reserve_Account_Report_(31_May_2026).docx.pdf"></button>
+<button data-gated-asset="XUSD Attestation Report Mid-June 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a6c782ec811ea831738450f_XUSD%20SCS%20Reserve%20Account%20Report%20(15%20June%202026).pdf"></button>
+<button data-gated-asset="XUSD Attestation Report June 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6a6c789f7ac035cdb7e226fc_XUSD%20SCS%20Reserve%20Account%20Report%20(30%20June%202026).pdf"></button>
+<button data-gated-asset="XUSD Attestation Report Mid-Jan 2025" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6978acaf1b32a813bacd65d6_xusd-250115.pdf"></button>
+<button data-gated-asset="XUSD Attestation Report Jan 2025" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/6878e8f3f161741b3be8f591_xusd-report-25-jan.pdf"></button>

--- a/worker/src/cron/reserve-adapters/__tests__/fixtures/usdgo-transparency.html
+++ b/worker/src/cron/reserve-adapters/__tests__/fixtures/usdgo-transparency.html
@@ -1,0 +1,14 @@
+<!-- captured-at: 2026-08-14T04:23:35Z -->
+<!-- source: https://www.anchorage.com/platform/usdgo-reserve-attestations -->
+<!-- source-trimmed: USDGO 2026 reserve-attestation accordion from the live page. -->
+<div class="reserve-attestation-left">
+  <h2>Reserve attestations</h2>
+  <p>USDGO reserve holdings are fully disclosed on a monthly basis.</p>
+</div>
+<div class="accordion-dates-grid">
+  <a href="https://learn.anchorage.com/02.28.26_USDGO-Stablecoin-Attestation-Report.pdf" class="accordion-date-link">Feb</a>
+  <a href="https://learn.anchorage.com/03.31.26_USDGO-Stablecoin-Attestation-Report.pdf" class="accordion-date-link">Mar</a>
+  <a href="https://learn.anchorage.com/04.30.26_USDGO_Stablecoin_Attestation_Report%20(FINAL)%20signed%205.27.26.pdf" class="accordion-date-link">Apr</a>
+  <a href="https://learn.anchorage.com/05.31.26_USDGO_Stablecoin_Attestation_Report_signed.pdf" class="accordion-date-link">May</a>
+  <a href="https://learn.anchorage.com/06.30.26_USDGO-Stablecoin-Attestation-Report.pdf" class="accordion-date-link">Jun</a>
+</div>

--- a/worker/src/cron/reserve-adapters/__tests__/http-html-fixture-coverage.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/http-html-fixture-coverage.test.ts
@@ -15,6 +15,8 @@ const CAPTURED_AT_RE = /<!--\s*captured-at:\s*(\d{4}-\d{2}-\d{2}T[\d:]+Z)\s*-->/
 // explaining why. They are frozen on purpose: the refresh script must not list
 // them, and they are exempt from the 90-day staleness bound.
 const ARCHIVED_RE = /<!--\s*archived:\s*(\S[^>]*?)\s*-->/;
+const SOURCE_TRIMMED_RE = /<!--\s*source-trimmed:\s*(\S[^>]*?)\s*-->/;
+const SOURCE_RE = /<!--\s*source:\s*(https:\/\/\S+?)\s*-->/;
 const MAX_FIXTURE_AGE_DAYS = 90;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -38,11 +40,8 @@ function inspectFixtureFreshness(file: string, content: string, now = new Date()
 const FIXTURE_EXEMPT_ADAPTERS: Record<string, string> = {
   "attestation-pdf-index": "Upstream is a gated PDF index; HTML page is not the parsed surface.",
   "audx-independent-assurance": "Compact index HTML for newer-report detection is covered inline; evidence is the exact official PDF bytes bound to a reviewed manifest SHA-256.",
-  "europ-independent-assurance": "Compact index HTML for newer-report detection is covered inline; evidence is the exact official PDF bytes bound to a reviewed manifest SHA-256.",
   "quantoz-transparency": "Adapter test uses inline HTML; upstream layout is stable and compact.",
   "ripple-transparency": "Adapter test uses inline HTML; upstream layout is stable and compact.",
-  "straitsx-independent-assurance": "Compact gated-asset index HTML for newer-report detection is covered inline; evidence is the exact official PDF bytes bound to a reviewed manifest SHA-256.",
-  "usdgo-transparency": "Reviewed PDF manifest, pinned on-chain reads, and issuer API cross-checks are covered with compact inline discovery and payload fixtures.",
 };
 
 function fixturePrefixCandidates(key: string): string[] {
@@ -99,12 +98,24 @@ describe("http-html adapter fixture coverage", () => {
 
   const archivedFixtureNames = htmlFixtureNames.filter((name) =>
     ARCHIVED_RE.test(readFileSync(resolve(FIXTURES_DIR, name), "utf8")));
-  const refreshableFixtureNames = htmlFixtureNames.filter((name) => !archivedFixtureNames.includes(name));
+  const manuallyTrimmedFixtureNames = htmlFixtureNames.filter((name) =>
+    SOURCE_TRIMMED_RE.test(readFileSync(resolve(FIXTURES_DIR, name), "utf8")));
+  const currentFixtureNames = htmlFixtureNames.filter((name) => !archivedFixtureNames.includes(name));
+  const refreshableFixtureNames = currentFixtureNames.filter((name) => !manuallyTrimmedFixtureNames.includes(name));
 
-  it.each(refreshableFixtureNames)("%s carries a valid captured-at header no older than 90 whole days", (fixtureName) => {
+  it.each(currentFixtureNames)("%s carries a valid captured-at header no older than 90 whole days", (fixtureName) => {
     const content = readFileSync(resolve(FIXTURES_DIR, fixtureName), "utf8");
     const result = inspectFixtureFreshness(fixtureName, content);
     expect(result.error, result.error).toBeUndefined();
+  });
+
+  it.each(manuallyTrimmedFixtureNames)("%s identifies its live source and why it is manually trimmed", (fixtureName) => {
+    const content = readFileSync(resolve(FIXTURES_DIR, fixtureName), "utf8");
+    expect(content.match(SOURCE_RE)?.[1], `${fixtureName}: missing HTTPS source header`).toMatch(/^https:\/\//);
+    expect(
+      content.match(SOURCE_TRIMMED_RE)?.[1]?.trim().length,
+      `${fixtureName}: source-trimmed reason must be specific`,
+    ).toBeGreaterThan(20);
   });
 
   it.each(archivedFixtureNames)("%s documents why it is archived instead of refreshed", (fixtureName) => {

--- a/worker/src/cron/reserve-adapters/__tests__/independent-assurance.test.ts
+++ b/worker/src/cron/reserve-adapters/__tests__/independent-assurance.test.ts
@@ -1,17 +1,26 @@
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, afterEach, vi } from "vitest";
 import {
+  getIndependentAssuranceManifest,
   IndependentAssuranceManifestSchema,
   reconcileIndependentAssuranceManifest,
   type IndependentAssuranceManifest,
+  type IndependentAssuranceProduct,
 } from "@shared/lib/independent-assurance";
 import { getReserveAdapter } from "../index";
+import { EUROP_INDEPENDENT_ASSURANCE_PROFILE } from "../europ-independent-assurance";
 import {
   verifyIndependentAssuranceReport,
   type IndependentAssuranceProfile,
 } from "../independent-assurance";
+import { straitsxIndependentAssuranceProfile } from "../straitsx-independent-assurance";
+import { USDGO_INDEPENDENT_ASSURANCE_PROFILE } from "../usdgo-transparency";
 import { validateAdapterOutput } from "../validate";
 
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 const PDF_BYTES = new TextEncoder().encode("%PDF-1.7\nfixture\n");
 const PDF_SHA256 = createHash("sha256").update(PDF_BYTES).digest("hex");
 
@@ -104,6 +113,49 @@ async function verify(manifestOverride: Partial<IndependentAssuranceManifest> = 
   });
 }
 
+function readIndexFixture(name: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-only fixture reads with literal names from this file.
+  return readFileSync(resolve(TEST_DIR, "fixtures", name), "utf8");
+}
+
+async function verifyRealIndexFixture(
+  product: IndependentAssuranceProduct,
+  profile: IndependentAssuranceProfile,
+  fixtureName: string,
+  htmlOverride?: string,
+): Promise<void> {
+  const reviewed = getIndependentAssuranceManifest(product);
+  const indexHost = new URL(reviewed.officialIndexUrl).hostname;
+  const reportHost = new URL(reviewed.reportUrl).hostname;
+  const html = htmlOverride ?? readIndexFixture(fixtureName);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === reviewed.officialIndexUrl) {
+        return new Response(html, { headers: { "content-type": "text/html" } });
+      }
+      if (url === reviewed.reportUrl) {
+        return new Response(PDF_BYTES, {
+          headers: {
+            "content-type": "application/pdf",
+            "content-length": String(PDF_BYTES.length),
+          },
+        });
+      }
+      throw new Error(`unexpected fixture request ${url}`);
+    }),
+  );
+  await verifyIndependentAssuranceReport({
+    manifest: reviewed,
+    indexUrl: reviewed.officialIndexUrl,
+    indexHost,
+    reportHosts: [reportHost],
+    profile,
+    signal: new AbortController().signal,
+  });
+}
+
 describe("independent-assurance manifest framework", () => {
   afterEach(() => vi.unstubAllGlobals());
 
@@ -160,6 +212,37 @@ describe("independent-assurance manifest framework", () => {
     );
 
     await expect(verify()).rejects.toThrow("reviewed report URL is missing or duplicated");
+  });
+
+  it.each([
+    ["EUROP", EUROP_INDEPENDENT_ASSURANCE_PROFILE, "europ-independent-assurance.html"],
+    ["XSGD", straitsxIndependentAssuranceProfile("XSGD"), "straitsx-independent-assurance-xsgd.html"],
+    ["XUSD", straitsxIndependentAssuranceProfile("XUSD"), "straitsx-independent-assurance-xusd.html"],
+    ["USDGO", USDGO_INDEPENDENT_ASSURANCE_PROFILE, "usdgo-transparency.html"],
+  ] as const)("accepts the trimmed real %s index shape before verifying PDF bytes", async (product, profile, fixture) => {
+    await expect(verifyRealIndexFixture(product, profile, fixture)).rejects.toThrow("PDF byte length");
+  });
+
+  it("ignores a newer unrelated StraitsX whitepaper but fails closed on a newer XSGD report", async () => {
+    const fixture = "straitsx-independent-assurance-xsgd.html";
+    await expect(
+      verifyRealIndexFixture("XSGD", straitsxIndependentAssuranceProfile("XSGD"), fixture),
+    ).rejects.toThrow("PDF byte length");
+
+    const withNewReport = readIndexFixture(fixture) +
+      '<button data-gated-asset="XSGD Attestation Report July 2026" data-gated-url="https://cdn.prod.website-files.com/6119d1f2b05f8e65b1739721/XSGD_SCS_Reserve_Account_Report_(31_July_2026).pdf"></button>';
+    await expect(
+      verifyRealIndexFixture("XSGD", straitsxIndependentAssuranceProfile("XSGD"), fixture, withNewReport),
+    ).rejects.toThrow("newer unreviewed report");
+  });
+
+  it("still fails closed when the USDGO family has two reports for the reviewed latest date", async () => {
+    const fixture = "usdgo-transparency.html";
+    const ambiguous = readIndexFixture(fixture) +
+      '<a href="https://learn.anchorage.com/06.30.26_USDGO-Stablecoin-Attestation-Report-revised.pdf">Jun revised</a>';
+    await expect(
+      verifyRealIndexFixture("USDGO", USDGO_INDEPENDENT_ASSURANCE_PROFILE, fixture, ambiguous),
+    ).rejects.toThrow("reviewed report URL is missing or duplicated");
   });
 
   it("keeps stale verified reports out of score-grade state", () => {

--- a/worker/src/cron/reserve-adapters/anzen-usdz.ts
+++ b/worker/src/cron/reserve-adapters/anzen-usdz.ts
@@ -7,10 +7,11 @@ import { fetchJsonWithRetry } from "./request";
 import {
   decodeMulticall3Aggregate3Result,
   encodeMulticall3Aggregate3CallData,
-  fetchEvmRpcBatch,
+  fetchEvmCallHexAtBlock,
+  fetchEvmCodeAtBlock,
   MULTICALL3_ADDRESS,
-  type EvmRpcBatchCall,
 } from "../../lib/evm-rpc";
+import { getPublicFallbackRpcUrls } from "../../lib/public-rpc-registry";
 import {
   buildRedemptionSnapshotMetadata,
   decimalNumberFromBigInt,
@@ -64,12 +65,16 @@ const LAYERZERO_SHARED_DECIMALS = 8;
 
 // USDz.redeem() pays USDC out of the USDz contract after pulling it from the
 // SPCT pool. These identities and route controls are read in the same
-// Ethereum batch as pooledSPCT and the reserve/liability facts.
+// Ethereum Multicall3 request as pooledSPCT and the reserve/liability facts.
 const USDC_CONTRACT = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const USDC_DECIMALS = 6;
 const SPCT_PRICE_ORACLE_CONTRACT = "0x900fff3bbf47ded50fd4940d055e1324f38b0d4f";
 const ANZEN_REDEEM_DOC_URL = "https://docs.anzen.finance/usdz-101/overview";
 const SPCT_RUNTIME_CODE_HASH = "0xe72ed6f9f3222f61a7901b61e2a44bd7869bf79ac4146c777a97226137baeeaf";
+const ANZEN_ETHEREUM_FALLBACK_RPC_URL = "https://eth.drpc.org";
+const RPC_ATTEMPT_BUDGET_MS = 20_000;
+const RPC_DEADLINE_HEADROOM_MS = 2_000;
+const RPC_REQUEST_TIMEOUT_MS = 4_000;
 
 const TOTAL_SUPPLY_SELECTOR = "0x18160ddd";
 const SYMBOL_SELECTOR = "0x95d89b41";
@@ -141,6 +146,12 @@ function encodeAddressCall(selector: string, address: string): string {
 
 function wordCall(label: string, contract: string, data: string, allowFailure = false) {
   return { label, contract, data, allowFailure } as const;
+}
+
+function getAdapterRpcUrls(chain: SupportedSupplyChain): string[] {
+  const registered = getPublicFallbackRpcUrls(chain);
+  if (chain !== "ethereum") return registered;
+  return Array.from(new Set([registered[0], ANZEN_ETHEREUM_FALLBACK_RPC_URL].filter((url): url is string => Boolean(url))));
 }
 
 function buildStateCalls(chain: SupportedSupplyChain, usdz: string) {
@@ -278,49 +289,54 @@ async function readChain(
   chain: SupportedSupplyChain,
   contract: { address: string; decimals: number },
   signal: AbortSignal,
+  deadlineMs: number,
   ctx?: AdapterContext,
 ): Promise<ChainObservation> {
   const stateCalls = buildStateCalls(chain, contract.address);
-  const rpcCalls: EvmRpcBatchCall[] = [
-    { method: "eth_getCode", params: [contract.address, "latest"] },
-  ];
-  if (chain === "ethereum") {
-    rpcCalls.push(
-      { method: "eth_getCode", params: [SPCT_POOL_CONTRACT, "latest"] },
-      { method: "eth_getCode", params: [SPCT_PRICE_ORACLE_CONTRACT, "latest"] },
-      { method: "eth_getCode", params: [USDC_CONTRACT, "latest"] },
-    );
-  }
-  rpcCalls.push({
-    method: "eth_call",
-    params: [
-      {
-        to: MULTICALL3_ADDRESS,
-        data: encodeMulticall3Aggregate3CallData(stateCalls.map((call) => ({
+  const rpcOptions = {
+    signal,
+    timeoutMs: RPC_REQUEST_TIMEOUT_MS,
+    deadlineMs,
+    maxRetries: 0,
+    chainRpcs: ctx?.chainRpcs,
+    extraRpcUrls: getAdapterRpcUrls(chain),
+  };
+  const [code, supportingCodes, aggregate] = await runAdapterIo(
+    ctx,
+    `${ADAPTER_KEY}:rpc:${chain}`,
+    async () => {
+      const deploymentCode = await fetchEvmCodeAtBlock(chain, contract.address, "latest", rpcOptions);
+      const ethereumSupportingCodes: Array<`0x${string}` | null> = [];
+      if (chain === "ethereum") {
+        for (const address of [SPCT_POOL_CONTRACT, SPCT_PRICE_ORACLE_CONTRACT, USDC_CONTRACT]) {
+          ethereumSupportingCodes.push(await fetchEvmCodeAtBlock(chain, address, "latest", rpcOptions));
+        }
+      }
+      const state = await fetchEvmCallHexAtBlock(
+        chain,
+        MULTICALL3_ADDRESS,
+        encodeMulticall3Aggregate3CallData(stateCalls.map((call) => ({
           label: call.label,
           target: call.contract,
           callData: call.data,
           allowFailure: call.allowFailure,
         }))),
-      },
-      "latest",
-    ],
-  });
-  const responses = await runAdapterIo(ctx, `${ADAPTER_KEY}:rpc:${chain}`, () => fetchEvmRpcBatch(
-    chain,
-    rpcCalls,
-    { signal, timeoutMs: 12_000, maxRetries: 0 },
-  ), { signal });
-  if (!responses || responses.length !== rpcCalls.length) throw new Error(`${ADAPTER_KEY} ${chain} RPC batch failed`);
+        "latest",
+        rpcOptions,
+      );
+      return [deploymentCode, ethereumSupportingCodes, state] as const;
+    },
+    { signal },
+  );
   if (chain === "ethereum") {
-    for (const [index, expected] of [SPCT_RUNTIME_CODE_HASH].entries()) {
-      const code = responses[index + 1];
-      if (typeof code !== "string" || keccak256(code as `0x${string}`).toLowerCase() !== expected) {
-        throw new Error(`${ADAPTER_KEY} Ethereum supporting contract code hash drifted`);
-      }
+    if (supportingCodes.some((supportingCode) => typeof supportingCode !== "string")) {
+      throw new Error(`${ADAPTER_KEY} Ethereum supporting contract code is unavailable`);
+    }
+    if (keccak256(supportingCodes[0] as `0x${string}`).toLowerCase() !== SPCT_RUNTIME_CODE_HASH) {
+      throw new Error(`${ADAPTER_KEY} Ethereum supporting contract code hash drifted`);
     }
   }
-  return decodeChainObservation(chain, contract, responses[0], responses[responses.length - 1], stateCalls);
+  return decodeChainObservation(chain, contract, code, aggregate, stateCalls);
 }
 
 async function fetchLayerZeroMetadata(signal: AbortSignal, ctx?: AdapterContext): Promise<LayerZeroMetadata> {
@@ -399,11 +415,12 @@ export async function fetchAnzenUsdzReserves(
 ): Promise<AdapterResult> {
   assertContractInventory(coin);
   const contracts = Object.fromEntries(SUPPLY_CHAINS.map((chain) => [chain, getRequiredContract(coin, chain)])) as Record<SupportedSupplyChain, { address: string; decimals: number }>;
+  const rpcDeadlineMs = Date.now() + RPC_ATTEMPT_BUDGET_MS - RPC_DEADLINE_HEADROOM_MS;
   const observations = await Promise.all([
-    ...SUPPLY_CHAINS.map((chain) => readChain(chain, contracts[chain], signal, ctx)),
     fetchLayerZeroMetadata(signal, ctx),
+    ...SUPPLY_CHAINS.map((chain) => readChain(chain, contracts[chain], signal, rpcDeadlineMs, ctx)),
   ]);
-  const chainObservations = observations.slice(0, SUPPLY_CHAINS.length) as ChainObservation[];
+  const chainObservations = observations.slice(1) as ChainObservation[];
   const ethereum = chainObservations.find((observation) => observation.chain === "ethereum");
   if (!ethereum) throw new Error(`${ADAPTER_KEY} Ethereum observation missing`);
   const redemption = observeAnzenRedemption(ethereum.values);

--- a/worker/src/cron/reserve-adapters/europ-independent-assurance.ts
+++ b/worker/src/cron/reserve-adapters/europ-independent-assurance.ts
@@ -7,7 +7,40 @@ import {
   type IndependentAssuranceProfile,
 } from "./independent-assurance";
 
-const PROFILE: IndependentAssuranceProfile = {
+function formatDate(year: number, month: number, day: number): string | null {
+  if (
+    year < 2000 ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > new Date(Date.UTC(year, month, 0)).getUTCDate()
+  ) {
+    return null;
+  }
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function europReportDate(href: string): string | null {
+  const fileName = decodeURIComponent(new URL(href).pathname.split("/").pop() ?? "");
+  const yearFirst = fileName.match(/((?:19|20)\d{2})[._-](\d{1,2})[._-](\d{1,2})/);
+  const dayFirst = fileName.match(/(\d{1,2})[._-](\d{1,2})[._-]((?:19|20)?\d{2})/);
+  const quarter = fileName.match(/Q([1-4])[_-]((?:19|20)\d{2})/i);
+  if (yearFirst) {
+    return formatDate(Number(yearFirst[1]), Number(yearFirst[2]), Number(yearFirst[3]));
+  }
+  if (dayFirst) {
+    const year = dayFirst[3].length === 2 ? 2000 + Number(dayFirst[3]) : Number(dayFirst[3]);
+    return formatDate(year, Number(dayFirst[2]), Number(dayFirst[1]));
+  }
+  if (quarter) {
+    const month = Number(quarter[1]) * 3;
+    const day = new Date(Date.UTC(Number(quarter[2]), month, 0)).getUTCDate();
+    return formatDate(Number(quarter[2]), month, day);
+  }
+  return null;
+}
+
+export const EUROP_INDEPENDENT_ASSURANCE_PROFILE: IndependentAssuranceProfile = {
   adapterName: "europ-independent-assurance",
   product: "EUROP",
   profile: "europ-v1",
@@ -40,8 +73,11 @@ const PROFILE: IndependentAssuranceProfile = {
       relativePpm: 1,
     },
   },
-  isReportCandidate: (href, text) =>
-    !/whitepaper/i.test(`${href} ${text}`) && /europ|reserve|attestation|audit/i.test(`${href} ${text}`),
+  isReportCandidate: (href) => {
+    const decoded = decodeURIComponent(href);
+    return /(?:SALVUS.*Attestation.*(?:EUROP|Letter)|Attestation.*(?:number|nombre).*EUROP)/i.test(decoded);
+  },
+  reportDateFromCandidate: europReportDate,
 };
 
 export async function fetchEuropIndependentAssuranceReserves(
@@ -52,5 +88,12 @@ export async function fetchEuropIndependentAssuranceReserves(
 ): Promise<AdapterResult> {
   const params = parseLiveReserveAdapterParams("europ-independent-assurance", config.params) as
     LiveReserveAdapterParamsByKey["europ-independent-assurance"];
-  return fetchIndependentAssuranceReserves(coin, config, signal, PROFILE, params, ctx);
+  return fetchIndependentAssuranceReserves(
+    coin,
+    config,
+    signal,
+    EUROP_INDEPENDENT_ASSURANCE_PROFILE,
+    params,
+    ctx,
+  );
 }

--- a/worker/src/cron/reserve-adapters/independent-assurance.ts
+++ b/worker/src/cron/reserve-adapters/independent-assurance.ts
@@ -35,6 +35,7 @@ export interface IndependentAssuranceProfile {
   classifications: Readonly<Record<string, AssuranceSliceClassification>>;
   reconciliation?: IndependentAssuranceReconciliationOptions;
   isReportCandidate: (href: string, text: string) => boolean;
+  reportDateFromCandidate?: (href: string, text: string) => string | null;
 }
 
 interface ReportCandidate {
@@ -238,7 +239,9 @@ export async function verifyIndependentAssuranceReport(args: {
   const manifestUrl = normalizeUrl(args.manifest.reportUrl, args.indexUrl);
   const exact = candidates.filter((candidate) => candidate.url === manifestUrl);
   const datedCandidates = candidates.map((candidate) => {
-    const date = parseDiscoveryDate(`${candidate.url} ${candidate.text}`);
+    const date = args.profile.reportDateFromCandidate
+      ? args.profile.reportDateFromCandidate(candidate.url, candidate.text)
+      : parseDiscoveryDate(`${candidate.url} ${candidate.text}`);
     return { ...candidate, date };
   });
   const ambiguousDate = datedCandidates.some((candidate) => candidate.date == null);

--- a/worker/src/cron/reserve-adapters/straitsx-independent-assurance.ts
+++ b/worker/src/cron/reserve-adapters/straitsx-independent-assurance.ts
@@ -7,7 +7,79 @@ import {
   type IndependentAssuranceProfile,
 } from "./independent-assurance";
 
-const STRAITSX_PROFILE_BASE: Omit<IndependentAssuranceProfile, "product" | "requiredAssetCodes"> = {
+const MONTHS: Readonly<Record<string, number>> = {
+  jan: 1,
+  january: 1,
+  feb: 2,
+  february: 2,
+  mar: 3,
+  march: 3,
+  apr: 4,
+  april: 4,
+  may: 5,
+  jun: 6,
+  june: 6,
+  jul: 7,
+  july: 7,
+  aug: 8,
+  august: 8,
+  sep: 9,
+  september: 9,
+  oct: 10,
+  october: 10,
+  nov: 11,
+  november: 11,
+  dec: 12,
+  december: 12,
+};
+
+function formatDate(year: number, month: number, day: number): string | null {
+  if (
+    year < 2000 ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > new Date(Date.UTC(year, month, 0)).getUTCDate()
+  ) {
+    return null;
+  }
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function straitsxReportDate(href: string, text: string): string | null {
+  const fileName = decodeURIComponent(new URL(href).pathname.split("/").pop() ?? "");
+  const fullDate = fileName.match(
+    /(\d{1,2})[ _-](Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)[ _-]((?:19|20)\d{2})/i,
+  );
+  if (fullDate) {
+    return formatDate(Number(fullDate[3]), MONTHS[fullDate[2].toLowerCase()], Number(fullDate[1]));
+  }
+
+  const compactDate = fileName.match(/(?:xsgd|xusd)-(\d{2})(\d{2})(\d{2})(?:\D|$)/i);
+  if (compactDate) {
+    return formatDate(2000 + Number(compactDate[1]), Number(compactDate[2]), Number(compactDate[3]));
+  }
+
+  const monthOnly = fileName.match(/(?:xsgd|xusd)-report-(\d{2}|(?:19|20)\d{2})-([a-z]+)/i);
+  if (monthOnly) {
+    const month = MONTHS[monthOnly[2].toLowerCase()];
+    const year = monthOnly[1].length === 2 ? 2000 + Number(monthOnly[1]) : Number(monthOnly[1]);
+    if (month) return formatDate(year, month, new Date(Date.UTC(year, month, 0)).getUTCDate());
+  }
+
+  const labelDate = text.match(
+    /\b(Mid-)?(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+((?:19|20)\d{2})\b/i,
+  );
+  if (!labelDate) return null;
+  const month = MONTHS[labelDate[2].toLowerCase()];
+  const year = Number(labelDate[3]);
+  return formatDate(year, month, labelDate[1] ? 15 : new Date(Date.UTC(year, month, 0)).getUTCDate());
+}
+
+const STRAITSX_PROFILE_BASE: Omit<
+  IndependentAssuranceProfile,
+  "product" | "requiredAssetCodes" | "isReportCandidate" | "reportDateFromCandidate"
+> = {
   adapterName: "straitsx-independent-assurance",
   profile: "straitsx-v1",
   classifications: {
@@ -36,15 +108,19 @@ const STRAITSX_PROFILE_BASE: Omit<IndependentAssuranceProfile, "product" | "requ
       liquidityHorizon: "unknown",
     },
   },
-  isReportCandidate: (href, text) =>
-    !/whitepaper/i.test(`${href} ${text}`) && /xsgd|xusd/i.test(`${href} ${text}`) && /report|attestation|reserve/i.test(`${href} ${text}`),
 };
 
-function profileForProduct(product: "XSGD" | "XUSD"): IndependentAssuranceProfile {
+export function straitsxIndependentAssuranceProfile(product: "XSGD" | "XUSD"): IndependentAssuranceProfile {
   return {
     ...STRAITSX_PROFILE_BASE,
     product,
     requiredAssetCodes: product === "XSGD" ? ["cash", "short-dated-government-or-repo"] : ["cash"],
+    isReportCandidate: (href, text) => {
+      const decoded = decodeURIComponent(`${href} ${text}`);
+      return !/whitepaper/i.test(decoded) && decoded.toUpperCase().includes(product) &&
+        /(?:SCS[ _]Reserve[ _]Account[ _]Report|Attestation Report)/i.test(decoded);
+    },
+    reportDateFromCandidate: straitsxReportDate,
   };
 }
 
@@ -56,5 +132,12 @@ export async function fetchStraitsxIndependentAssuranceReserves(
 ): Promise<AdapterResult> {
   const params = parseLiveReserveAdapterParams("straitsx-independent-assurance", config.params) as
     LiveReserveAdapterParamsByKey["straitsx-independent-assurance"];
-  return fetchIndependentAssuranceReserves(coin, config, signal, profileForProduct(params.product), params, ctx);
+  return fetchIndependentAssuranceReserves(
+    coin,
+    config,
+    signal,
+    straitsxIndependentAssuranceProfile(params.product),
+    params,
+    ctx,
+  );
 }

--- a/worker/src/cron/reserve-adapters/usdgo-transparency.ts
+++ b/worker/src/cron/reserve-adapters/usdgo-transparency.ts
@@ -24,7 +24,7 @@ const CROSS_CHECK_TOLERANCE_PCT = 1;
 const BUIDL_BALANCE_OF_SELECTOR = "0x70a08231";
 const BUIDL_DECIMALS_SELECTOR = "0x313ce567";
 
-const PROFILE: IndependentAssuranceProfile = {
+export const USDGO_INDEPENDENT_ASSURANCE_PROFILE: IndependentAssuranceProfile = {
   adapterName: ADAPTER_KEY,
   product: "USDGO",
   profile: "usdgo-v1",
@@ -64,7 +64,9 @@ const PROFILE: IndependentAssuranceProfile = {
       liquidityHorizon: "one-day",
     },
   },
-  isReportCandidate: (href, text) => /usdgo|attestation|reserve.?report/i.test(`${href} ${text}`),
+  isReportCandidate: (href) =>
+    /USDGO[-_ ]Stablecoin[-_ ]Attestation[-_ ]Report/i.test(decodeURIComponent(href)),
+  reportDateFromCandidate: usdgoReportDate,
 };
 
 interface UsdgoIssuerCrossCheckPayload {
@@ -80,6 +82,19 @@ interface BuidlObservation {
   balanceRaw: bigint;
   decimals: number;
   codeHash: string;
+}
+
+function usdgoReportDate(href: string): string | null {
+  const fileName = decodeURIComponent(new URL(href).pathname.split("/").pop() ?? "");
+  const match = fileName.match(/^(\d{2})[.](\d{2})[.](\d{2})_USDGO[-_]Stablecoin[-_]Attestation[-_]Report/i);
+  if (!match) return null;
+  const month = Number(match[1]);
+  const day = Number(match[2]);
+  const year = 2000 + Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > new Date(Date.UTC(year, month, 0)).getUTCDate()) {
+    return null;
+  }
+  return `${year}-${match[1]}-${match[2]}`;
 }
 
 function encodeAddressCall(selector: string, address: string): string {
@@ -298,7 +313,14 @@ export async function fetchUsdgoTransparencyReserves(
   const reportTimestamp = Date.parse(manifest.reportAsOf);
   if (!Number.isFinite(reportTimestamp)) throw new Error(`${ADAPTER_KEY}: reviewed report timestamp is invalid`);
 
-  const assurancePromise = fetchIndependentAssuranceReserves(coin, config, signal, PROFILE, params, ctx);
+  const assurancePromise = fetchIndependentAssuranceReserves(
+    coin,
+    config,
+    signal,
+    USDGO_INDEPENDENT_ASSURANCE_PROFILE,
+    params,
+    ctx,
+  );
   const buidlPromise = readBuidlObservation(params, signal, ctx);
   const crossCheckPromise = readIssuerCrossCheck(params.issuerCrossCheckUrl, signal, ctx).catch((error: unknown) => ({
     error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

Both batch-3 first-production-cron failures root-caused and fixed:

- **Assurance index discovery** (EUROP, XSGD, XUSD, USDGO failed "ambiguous report date"): real publisher pages carry legacy two-digit years, compact/month-only formats, duplicate labels, and underscore-delimited period dates the generic scan misread. Discovery is now publisher-family-specific with fixtures captured from the live pages; genuinely newer or same-date-ambiguous same-family reports still fail closed. All four live pages resolve to their reviewed manifest PDFs.
- **anzen-usdz** ("ethereum RPC batch failed"): the adapter passed no RPC endpoints to the batch helper (null in Worker runtime; local curl bypassed the path) and used fragile array batching. Now standard single-envelope reads with explicit primary + verified fallback endpoints inside the 2-op limiter and attempt budget; every reconciliation/fail-closed check unchanged.

AUDX and USDRIF from batch 3 already sync live + scoring-eligible in production; this completes the remaining five.

## Validation
- `npm run check:pr -- --base=origin/main`: exit 0
- Live verification: all four index pages resolve; both RPC endpoints return 200 on the exact reworked request shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)