### PR TITLE
Flag WUSD market-access risk

### DIFF
--- a/shared/data/stablecoins/coins/wusd-worldwide.json
+++ b/shared/data/stablecoins/coins/wusd-worldwide.json
@@ -70,5 +70,12 @@
       }
     }
   },
-  "launchDate": "2024-12-13"
+  "launchDate": "2024-12-13",
+  "notices": [
+    {
+      "type": "danger",
+      "title": "Material secondary-market access risk",
+      "message": "WUSD has recently lost major centralized-exchange trading venues. MEXC placed WUSD under its ST Warning on July 22, 2026 with an estimated delisting date of July 25, 2026, and Bitget delisted WUSD/USDT on July 31, 2026."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds a `danger` notice to Worldwide USD (WUSD) for a first, directly verifiable risk signal: recent loss of centralized-exchange trading venues.

## Evidence

- **MEXC:** WUSD was placed under MEXC's ST Warning on 2026-07-22 with an estimated delisting date of 2026-07-25.
  - https://www.mexc.com/announcements/article/mexc-announcement-on-st-warning-july-2026-17827791536606
- **Bitget:** WUSD/USDT was included in Bitget's spot-pair delisting scheduled for 2026-07-31.
  - https://www.bitget.com/support/articles/12560603890084

## Scope

This first commit only records the exchange-delisting risk in `shared/data/stablecoins/coins/wusd-worldwide.json`. Other WUSD risk signals are intentionally being reviewed and added separately so each claim is independently inspectable.